### PR TITLE
Tell copilot to follow CLAUDE.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot instructions
+
+Follow the guidelines declared in [CLAUDE.md](../CLAUDE.md)


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

When using Claude on the terminal outside of VS code, it uses `CLAUDE.md`. But when using any model through Copilot in VS Code, it follows `.github/copilot-instructions`. In order to have Copilot follow the same standards as Claude, I'm adding this instruction so they match

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

It now reads them!

<img width="434" height="212" alt="image" src="https://github.com/user-attachments/assets/7a60a95a-b00a-439d-beb1-9fc31825172b" />

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
