### PR TITLE
Add i18n-aware layout and navigation components

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -1,4 +1,4 @@
-import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { AppLayout } from "components/base/appLayout";
 import { SwitchLanguage } from "components/switchLanguage";
 import { I18nInitializer } from "i18n/config";
 import { Analytics } from "pages/analytics";
@@ -6,42 +6,35 @@ import { Borrow } from "pages/borrow";
 import { Bridge } from "pages/bridge";
 import { Earn } from "pages/earn";
 import { Faq } from "pages/faq";
-import { Home } from "pages/home";
 import { Swap } from "pages/swap";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 
 export const App = () => (
   <BrowserRouter>
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="text-center">
-        <div className="mb-4">
-          <ConnectButton />
-        </div>
-        <Routes>
-          {/* Redirect root to English */}
-          <Route path="/" element={<Navigate to="/en" replace />} />
+    <AppLayout>
+      <Routes>
+        {/* Redirect root to English */}
+        <Route path="/" element={<Navigate to="/en" replace />} />
 
-          {/* Language-prefixed routes */}
-          <Route
-            path="/:lang/*"
-            element={
-              <>
-                <I18nInitializer />
-                <Routes>
-                  <Route index element={<Home />} />
-                  <Route path="swap" element={<Swap />} />
-                  <Route path="earn" element={<Earn />} />
-                  <Route path="borrow" element={<Borrow />} />
-                  <Route path="bridge" element={<Bridge />} />
-                  <Route path="analytics" element={<Analytics />} />
-                  <Route path="faq" element={<Faq />} />
-                </Routes>
-                <SwitchLanguage />
-              </>
-            }
-          />
-        </Routes>
-      </div>
-    </div>
+        {/* Language-prefixed routes */}
+        <Route
+          path="/:lang/*"
+          element={
+            <>
+              <I18nInitializer />
+              <Routes>
+                <Route path="swap" element={<Swap />} />
+                <Route path="earn" element={<Earn />} />
+                <Route path="borrow" element={<Borrow />} />
+                <Route path="bridge" element={<Bridge />} />
+                <Route path="analytics" element={<Analytics />} />
+                <Route path="faq" element={<Faq />} />
+              </Routes>
+              <SwitchLanguage />
+            </>
+          }
+        />
+      </Routes>
+    </AppLayout>
   </BrowserRouter>
 );

--- a/web/src/components/base/appLayout.tsx
+++ b/web/src/components/base/appLayout.tsx
@@ -1,0 +1,7 @@
+import type { ReactNode } from "react";
+
+export const AppLayout = ({ children }: { children: ReactNode }) => (
+  <div className="font-geist flex min-h-screen flex-col bg-gray-50">
+    {children}
+  </div>
+);

--- a/web/src/components/base/button/index.tsx
+++ b/web/src/components/base/button/index.tsx
@@ -1,8 +1,8 @@
 import { type ComponentProps } from "react";
-import { Link } from "react-router";
 import { isRelativeUrl } from "utils/url";
 
 import { ExternalLink } from "../externalLink";
+import { I18nLink } from "../i18nLink";
 
 import "./button.css";
 
@@ -40,7 +40,7 @@ type ButtonProps = Omit<ComponentProps<"button">, "className"> &
   ButtonStyleProps;
 
 type ButtonLinkProps = Omit<ComponentProps<"a">, "href" | "ref" | "className"> &
-  Required<{ href: ComponentProps<typeof Link>["to"] }> &
+  Required<{ href: ComponentProps<typeof I18nLink>["to"] }> &
   ButtonStyleProps;
 
 export const Button = ({
@@ -83,5 +83,5 @@ export const ButtonLink = function ({
       />
     );
   }
-  return <Link className={className} {...props} to={props.href} />;
+  return <I18nLink className={className} {...props} to={props.href} />;
 };

--- a/web/src/components/base/i18nLink.tsx
+++ b/web/src/components/base/i18nLink.tsx
@@ -1,0 +1,11 @@
+import { type ComponentProps } from "react";
+import { NavLink, useParams } from "react-router";
+
+type I18nLinkProps = ComponentProps<typeof NavLink>;
+
+export const I18nLink = function ({ to, ...props }: I18nLinkProps) {
+  const { lang } = useParams();
+  const localizedTo = `/${lang}${to}`;
+
+  return <NavLink to={localizedTo} {...props} />;
+};

--- a/web/src/i18n/config.tsx
+++ b/web/src/i18n/config.tsx
@@ -1,30 +1,38 @@
 import i18n from "i18next";
 import { useLayoutEffect } from "react";
 import { initReactI18next } from "react-i18next";
-import { useParams } from "react-router";
+import { useNavigate, useParams } from "react-router";
 
 import { resources } from "./resources";
+
+const fallbackLng = "en";
+const supportedLngs = ["en", "es"];
 
 export const initializeI18n = () =>
   i18n.use(initReactI18next).init({
     debug: import.meta.env.DEV,
-    fallbackLng: "en",
+    fallbackLng,
     lng: "en", // Default language
     resources,
-    supportedLngs: ["en", "es"],
+    supportedLngs,
   });
 
 // Component to sync the route language parameter with i18n
 export const I18nInitializer = function () {
   const { lang } = useParams<{ lang: string }>();
+  const navigate = useNavigate();
 
   useLayoutEffect(
     function () {
+      if (lang && !supportedLngs.includes(lang)) {
+        navigate(`/${fallbackLng}`, { replace: true });
+        return;
+      }
       if (lang && i18n.language !== lang) {
         i18n.changeLanguage(lang);
       }
     },
-    [lang],
+    [lang, navigate],
   );
 
   return null;

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -18,9 +18,6 @@
     "faq": {
       "title": "Hello Faq"
     },
-    "home": {
-      "title": "Hello world"
-    },
     "swap": {
       "title": "Hello Swap"
     }

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -18,9 +18,6 @@
     "faq": {
       "title": "Hola FAQ"
     },
-    "home": {
-      "title": "Hola mundo"
-    },
     "swap": {
       "title": "Hola Intercambios"
     }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Geist:wght@400..600&family=Inter:opsz@14..32&display=swap");
 @import "tailwindcss";
 
 @theme {
@@ -13,6 +14,7 @@
   --color-blue-900: #1a2f95;
   --color-blue-950: #0f1957;
 
+  --font-geist: "Geist", sans-serif;
   --font-size-xsm: 0.8125rem; /* 13px */
   --font-size-mid: 0.9375rem; /* 15px */
 
@@ -42,4 +44,41 @@
 @utility text-mid {
   font-size: var(--font-size-mid);
   line-height: var(--line-height-mid);
+}
+
+/* using 4.16 to keep the proportion of REM > utility number */
+@utility text-4.16xl {
+  font-size: 2.5rem;
+  line-height: 44px;
+}
+
+/* Headers styling */
+h1,
+h2,
+h3,
+h4,
+h5 {
+  @apply font-semibold;
+}
+
+h1 {
+  @apply text-4.16xl;
+}
+
+h2 {
+  @apply text-4xl;
+}
+
+h3 {
+  /* override line height from tailwind */
+  @apply text-2xl leading-[28px];
+}
+
+h4 {
+  /* override line height from tailwind */
+  @apply text-base leading-[22px];
+}
+
+h5 {
+  @apply text-xsm;
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -46,8 +46,9 @@
   line-height: var(--line-height-mid);
 }
 
-/* using 4.16 to keep the proportion of REM > utility number */
-@utility text-4.16xl {
+/* I'm using "4.4" as proportional from values. 
+If text-4xl is 2.25 rem => 4, then here 2.5 rem => 4.4 */
+@utility text-4.4xl {
   font-size: 2.5rem;
   line-height: 44px;
 }
@@ -62,7 +63,7 @@ h5 {
 }
 
 h1 {
-  @apply text-4.16xl;
+  @apply text-4.4xl;
 }
 
 h2 {

--- a/web/src/pages/home.tsx
+++ b/web/src/pages/home.tsx
@@ -1,6 +1,0 @@
-import { useTranslation } from "react-i18next";
-
-export const Home = function () {
-  const { t } = useTranslation();
-  return <h1>{t("pages.home.title")}</h1>;
-};

--- a/web/stories/header.stories.tsx
+++ b/web/stories/header.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+const Header = function ({ level }: { level: 1 | 2 | 3 | 4 | 5 }) {
+  const Tag = `h${level}` as const;
+  return <Tag>Clear Money</Tag>;
+};
+
+const meta: Meta<typeof Header> = {
+  component: Header,
+  title: "Typography/Headers",
+};
+
+export default meta;
+type Story = StoryObj<typeof Header>;
+
+export const H1: Story = {
+  args: {
+    level: 1,
+  },
+};
+
+export const H2: Story = {
+  args: {
+    level: 2,
+  },
+};
+
+export const H3: Story = {
+  args: {
+    level: 3,
+  },
+};
+
+export const H4: Story = {
+  args: {
+    level: 4,
+  },
+};
+
+export const H5: Story = {
+  args: {
+    level: 5,
+  },
+};


### PR DESCRIPTION
### Description

This PR introduces foundational layout and navigation improvements for the application:

- Add `AppLayout` component with consistent styling (Geist font, gray-50 background)
- Implement `I18nLink` component that automatically prefixes routes with language parameter
- Add typography system with heading styles (h1-h5) and custom utility classes
- Update i18n configuration to handle invalid language redirects to English fallback
- Remove unused Home route and related translations
- Add Storybook stories for header typography components

**Commits:**
- f50c837 Add background color and update i18n redirect
- d8ba516 Add i18n-aware link component
- 158ebe2 Add heading styles
- 8b1efb6 Remove unused Home route

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Typography added to storybook

https://github.com/user-attachments/assets/882767d2-0c31-4da7-ad8d-8324d8b9054d

### Related issue(s)

Related to #6

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.