### PR TITLE
Add Figma MCP integration for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,5 +11,6 @@
         ]
       }
     ]
-  }
+  },
+  "enableAllProjectMcpServers": true
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "figma": {
+      "command": "npx",
+      "args": ["-y", "@figma/mcp-server-figma"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A pnpm-based monorepo for the Vetro project.
 
 This project uses pnpm 10.28.1, which is automatically managed via Corepack (built into Node.js 16.13+). Simply enable Corepack:
 
-```bash
+```sh
 corepack enable
 ```
 
@@ -22,11 +22,21 @@ This will ensure you use the correct pnpm version specified in `package.json`.
 
 From the root of the monorepo, run:
 
-```bash
+```sh
 pnpm install
 ```
 
 This will install all dependencies for the entire monorepo, including all workspace packages.
+
+### 3. Enable Figma MCP (Claude Users Only)
+
+If you're using Claude Code, enable the Figma MCP server to access design files:
+
+```sh
+/mcp
+```
+
+Then authenticate with your Figma account when prompted. The MCP configuration is already set up in `.mcp.json`.
 
 ## Workspace Structure
 


### PR DESCRIPTION
### Description

Adds Figma MCP (Model Context Protocol) server integration to enable Claude Code users to access and work with Figma design files directly from the development environment.

Changes included:
- Added `.mcp.json` configuration file with Figma MCP server setup
- Enabled project MCP servers in `.claude/settings.json`
- Updated README with instructions for enabling Figma MCP (Claude users only)

### Screenshots

N/A - Configuration changes only

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.