### PR TITLE
Add token dropdown component for swap page

### DIFF
--- a/web/src/components/base/chevronIcon.tsx
+++ b/web/src/components/base/chevronIcon.tsx
@@ -1,0 +1,17 @@
+type Props = {
+  direction?: "down" | "up";
+};
+
+export const ChevronIcon = ({ direction = "down" }: Props) => (
+  <svg
+    className={`inline-block size-4 shrink-0 ${direction === "up" ? "rotate-180" : ""}`}
+    fill="currentColor"
+    viewBox="0 0 20 20"
+  >
+    <path
+      clipRule="evenodd"
+      d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+      fillRule="evenodd"
+    />
+  </svg>
+);

--- a/web/src/components/base/dropdown/index.tsx
+++ b/web/src/components/base/dropdown/index.tsx
@@ -110,7 +110,9 @@ export function Dropdown<T>({
     switch (event.key) {
       case "ArrowDown":
         event.preventDefault();
-        setFocusedIndex((prev) => (prev < items.length - 1 ? prev + 1 : prev));
+        setFocusedIndex((prev) =>
+          prev === -1 ? 0 : prev < items.length - 1 ? prev + 1 : prev,
+        );
         break;
       case "ArrowUp":
         event.preventDefault();
@@ -155,15 +157,14 @@ export function Dropdown<T>({
           ref={listRef}
           role="listbox"
         >
-          {items.map(function (item) {
+          {items.map(function (item, index) {
             const isSelected = isItemEqual(item, value);
+            const isFocused = index === focusedIndex;
 
             return (
               <div
                 aria-selected={isSelected}
-                className={
-                  "text-xsm flex cursor-pointer items-center px-3 py-2 hover:rounded hover:bg-gray-50"
-                }
+                className={`text-xsm flex cursor-pointer items-center rounded px-3 py-2 ${isFocused ? "bg-gray-100" : "hover:bg-gray-50"}`}
                 key={getItemKey(item)}
                 onClick={() => handleItemClick(item)}
                 role="option"

--- a/web/src/components/base/dropdown/index.tsx
+++ b/web/src/components/base/dropdown/index.tsx
@@ -1,0 +1,180 @@
+import { useOnClickOutside } from "@hemilabs/react-hooks/useOnClickOutside";
+import { useWindowSize } from "@hemilabs/react-hooks/useWindowSize";
+import {
+  type KeyboardEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useTranslation } from "react-i18next";
+
+import { ChevronIcon } from "../chevronIcon";
+
+type DropdownProps<T> = {
+  getItemKey: (item: T) => string;
+  items: T[];
+  onChange: (item: T) => void;
+  renderItem: (item: T, isSelected: boolean) => ReactNode;
+  renderTrigger: (selectedItem: T, isOpen: boolean) => ReactNode;
+  value: T;
+};
+
+export function Dropdown<T>({
+  getItemKey,
+  items,
+  onChange,
+  renderItem,
+  renderTrigger,
+  value,
+}: DropdownProps<T>) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const { t } = useTranslation();
+  const { height: windowHeight, width: windowWidth } = useWindowSize();
+
+  const isItemEqual = (a: T, b: T) => getItemKey(a) === getItemKey(b);
+
+  const containerRef = useOnClickOutside<HTMLDivElement>(() =>
+    setIsOpen(false),
+  );
+
+  // Position dropdown based on viewport
+  useEffect(
+    function positionDropdownOnScreen() {
+      if (!isOpen || !triggerRef.current || !listRef.current) {
+        return;
+      }
+
+      const triggerRect = triggerRef.current.getBoundingClientRect();
+      const listRect = listRef.current.getBoundingClientRect();
+      const gap = 8;
+
+      // Vertical positioning
+      const spaceBelow = windowHeight - triggerRect.bottom;
+      const spaceAbove = triggerRect.top;
+
+      let top: number;
+      if (spaceBelow >= listRect.height || spaceBelow > spaceAbove) {
+        top = triggerRect.bottom + gap;
+      } else {
+        top = triggerRect.top - listRect.height - gap;
+      }
+
+      // Horizontal positioning
+      const spaceRight = windowWidth - triggerRect.left;
+      const spaceLeft = triggerRect.right;
+
+      let left: number;
+      if (spaceRight >= listRect.width || spaceRight > spaceLeft) {
+        // Align to left edge of trigger
+        left = triggerRect.left;
+      } else {
+        // Align to right edge of trigger
+        left = triggerRect.right - listRect.width;
+      }
+
+      // Ensure the menu doesn't go off-screen
+      left = Math.max(gap, Math.min(left, windowWidth - listRect.width - gap));
+      top = Math.max(gap, Math.min(top, windowHeight - listRect.height - gap));
+
+      listRef.current.style.top = `${top}px`;
+      listRef.current.style.left = `${left}px`;
+      listRef.current.style.width = `${triggerRect.width}px`;
+    },
+    [isOpen, windowHeight, windowWidth],
+  );
+
+  function handleTriggerClick() {
+    setIsOpen(!isOpen);
+    setFocusedIndex(-1);
+  }
+
+  function handleItemClick(item: T) {
+    onChange(item);
+    setIsOpen(false);
+    triggerRef.current?.focus();
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (!isOpen) {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        setIsOpen(true);
+      }
+      return;
+    }
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        setFocusedIndex((prev) => (prev < items.length - 1 ? prev + 1 : prev));
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        setFocusedIndex((prev) => (prev > 0 ? prev - 1 : 0));
+        break;
+      case "Enter":
+        event.preventDefault();
+        if (focusedIndex >= 0 && focusedIndex < items.length) {
+          handleItemClick(items[focusedIndex]);
+        }
+        break;
+      case "Escape":
+        event.preventDefault();
+        setIsOpen(false);
+        triggerRef.current?.focus();
+        break;
+    }
+  }
+
+  return (
+    <div className="relative inline-block" ref={containerRef}>
+      <div
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        onClick={handleTriggerClick}
+        onKeyDown={handleKeyDown}
+        ref={triggerRef}
+        role="button"
+        tabIndex={0}
+      >
+        <div className="flex cursor-pointer items-center gap-1.5 rounded-full bg-white/5 py-1.5 pr-3 pl-1.5 shadow-sm hover:bg-gray-50">
+          {renderTrigger(value, isOpen)}
+          <ChevronIcon direction={isOpen ? "up" : "down"} />
+        </div>
+      </div>
+
+      {isOpen && (
+        <div
+          aria-label={t("common.select-option")}
+          className="fixed z-10 min-w-3xs overflow-y-auto rounded-lg bg-white p-1 shadow-xl"
+          ref={listRef}
+          role="listbox"
+        >
+          {items.map(function (item) {
+            const isSelected = isItemEqual(item, value);
+
+            return (
+              <div
+                aria-selected={isSelected}
+                className={
+                  "text-xsm flex cursor-pointer items-center px-3 py-2 hover:rounded hover:bg-gray-50"
+                }
+                key={getItemKey(item)}
+                onClick={() => handleItemClick(item)}
+                role="option"
+              >
+                <div className="flex w-full items-center justify-between gap-2 font-medium text-gray-900">
+                  {renderItem(item, isSelected)}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/base/dropdown/index.tsx
+++ b/web/src/components/base/dropdown/index.tsx
@@ -7,7 +7,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { useTranslation } from "react-i18next";
 
 import { ChevronIcon } from "../chevronIcon";
 
@@ -17,6 +16,7 @@ type DropdownProps<T> = {
   onChange: (item: T) => void;
   renderItem: (item: T, isSelected: boolean) => ReactNode;
   renderTrigger: (selectedItem: T, isOpen: boolean) => ReactNode;
+  triggerId: string;
   value: T;
 };
 
@@ -26,13 +26,13 @@ export function Dropdown<T>({
   onChange,
   renderItem,
   renderTrigger,
+  triggerId,
   value,
 }: DropdownProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const triggerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
-  const { t } = useTranslation();
   const { height: windowHeight, width: windowWidth } = useWindowSize();
 
   const isItemEqual = (a: T, b: T) => getItemKey(a) === getItemKey(b);
@@ -135,6 +135,7 @@ export function Dropdown<T>({
       <div
         aria-expanded={isOpen}
         aria-haspopup="listbox"
+        id={triggerId}
         onClick={handleTriggerClick}
         onKeyDown={handleKeyDown}
         ref={triggerRef}
@@ -149,7 +150,7 @@ export function Dropdown<T>({
 
       {isOpen && (
         <div
-          aria-label={t("common.select-option")}
+          aria-labelledby={triggerId}
           className="fixed z-10 min-w-3xs overflow-y-auto rounded-lg bg-white p-1 shadow-xl"
           ref={listRef}
           role="listbox"

--- a/web/src/components/tokenDropdown/index.tsx
+++ b/web/src/components/tokenDropdown/index.tsx
@@ -11,7 +11,7 @@ type TokenDropdownProps = {
 
 const renderTrigger = (selectedToken: Token) => (
   <>
-    <TokenLogo logoURI={selectedToken.logoURI} symbol={selectedToken.symbol} />
+    <TokenLogo {...selectedToken} />
     <span className="text-sm font-semibold text-gray-900">
       {selectedToken.symbol}
     </span>
@@ -21,7 +21,7 @@ const renderTrigger = (selectedToken: Token) => (
 const renderItem = (token: Token) => (
   <>
     <div className="flex items-center gap-2">
-      <TokenLogo logoURI={token.logoURI} symbol={token.symbol} />
+      <TokenLogo {...token} />
       <span className="text-gray-500">{token.name}</span>
     </div>
     <span>{token.symbol}</span>

--- a/web/src/components/tokenDropdown/index.tsx
+++ b/web/src/components/tokenDropdown/index.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { type Token } from "types";
 
 import { Dropdown } from "../base/dropdown";
@@ -28,17 +29,21 @@ const renderItem = (token: Token) => (
   </>
 );
 
-export const TokenDropdown = ({
+export const TokenDropdown = function ({
   onChange,
   tokens,
   value,
-}: TokenDropdownProps) => (
-  <Dropdown
-    getItemKey={(token) => `${token.address}-${token.chainId}`}
-    items={tokens}
-    onChange={onChange}
-    renderItem={renderItem}
-    renderTrigger={renderTrigger}
-    value={value}
-  />
-);
+}: TokenDropdownProps) {
+  const { t } = useTranslation();
+  return (
+    <Dropdown
+      getItemKey={(token) => `${token.address}-${token.chainId}`}
+      items={tokens}
+      onChange={onChange}
+      renderItem={renderItem}
+      renderTrigger={renderTrigger}
+      triggerId={t("pages.swap.select-option")}
+      value={value}
+    />
+  );
+};

--- a/web/src/components/tokenDropdown/index.tsx
+++ b/web/src/components/tokenDropdown/index.tsx
@@ -1,0 +1,44 @@
+import { type Token } from "types";
+
+import { Dropdown } from "../base/dropdown";
+import { TokenLogo } from "../tokenLogo";
+
+type TokenDropdownProps = {
+  onChange: (token: Token) => void;
+  tokens: Token[];
+  value: Token;
+};
+
+const renderTrigger = (selectedToken: Token) => (
+  <>
+    <TokenLogo logoURI={selectedToken.logoURI} symbol={selectedToken.symbol} />
+    <span className="text-sm font-semibold text-gray-900">
+      {selectedToken.symbol}
+    </span>
+  </>
+);
+
+const renderItem = (token: Token) => (
+  <>
+    <div className="flex items-center gap-2">
+      <TokenLogo logoURI={token.logoURI} symbol={token.symbol} />
+      <span className="text-gray-500">{token.name}</span>
+    </div>
+    <span>{token.symbol}</span>
+  </>
+);
+
+export const TokenDropdown = ({
+  onChange,
+  tokens,
+  value,
+}: TokenDropdownProps) => (
+  <Dropdown
+    getItemKey={(token) => `${token.address}-${token.chainId}`}
+    items={tokens}
+    onChange={onChange}
+    renderItem={renderItem}
+    renderTrigger={renderTrigger}
+    value={value}
+  />
+);

--- a/web/src/components/tokenLogo/index.tsx
+++ b/web/src/components/tokenLogo/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Token } from "types";
 
 type Props = Pick<Token, "logoURI" | "symbol">;
@@ -6,9 +6,16 @@ type Props = Pick<Token, "logoURI" | "symbol">;
 export const TokenLogo = function ({ logoURI, symbol }: Props) {
   const [hasError, setHasError] = useState(false);
 
+  useEffect(
+    function resetOnUrlChange() {
+      setHasError(false);
+    },
+    [logoURI],
+  );
+
   if (!logoURI || hasError) {
     return (
-      <div className="flex size-5 items-center justify-center overflow-hidden rounded-full border border-solid border-white bg-neutral-50 text-[6px] font-semibold text-ellipsis whitespace-nowrap text-neutral-700">
+      <div className="flex size-5 items-center justify-center overflow-hidden rounded-full border border-solid border-white bg-neutral-50 text-[8px] font-semibold text-neutral-700">
         {symbol}
       </div>
     );

--- a/web/src/components/tokenLogo/index.tsx
+++ b/web/src/components/tokenLogo/index.tsx
@@ -1,0 +1,25 @@
+import { useState } from "react";
+import type { Token } from "types";
+
+type Props = Pick<Token, "logoURI" | "symbol">;
+
+export const TokenLogo = function ({ logoURI, symbol }: Props) {
+  const [hasError, setHasError] = useState(false);
+
+  if (!logoURI || hasError) {
+    return (
+      <div className="flex size-5 items-center justify-center overflow-hidden rounded-full border border-solid border-white bg-neutral-50 text-[6px] font-semibold text-ellipsis whitespace-nowrap text-neutral-700">
+        {symbol}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      alt={`${symbol} logo`}
+      className="size-5 rounded-full"
+      onError={() => setHasError(true)}
+      src={logoURI}
+    />
+  );
+};

--- a/web/src/hooks/useVusd.ts
+++ b/web/src/hooks/useVusd.ts
@@ -16,6 +16,8 @@ const initialVusd: Token = {
   address: "0x7A06C4AeF988e7925575C50261297a946aD204A8",
   chainId: hemi.id,
   decimals: 18,
+  logoURI: "https://hemilabs.github.io/token-list/l1Logos/vusd.svg",
+  name: "VUSD",
   symbol: "VUSD",
 };
 

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -1,7 +1,4 @@
 {
-  "common": {
-    "select-option": "Select option"
-  },
   "language": {
     "switchTo": "Switch to Spanish"
   },
@@ -28,6 +25,7 @@
       "title": "Hello Faq"
     },
     "swap": {
+      "select-option": "Select token to swap",
       "title": "Swap stablecoins for VUSD and back"
     }
   }

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -1,4 +1,7 @@
 {
+  "common": {
+    "select-option": "Select option"
+  },
   "language": {
     "switchTo": "Switch to Spanish"
   },

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -1,4 +1,7 @@
 {
+  "common": {
+    "select-option": "Seleccionar opción"
+  },
   "language": {
     "switchTo": "Cambiar a Inglés"
   },

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -1,7 +1,4 @@
 {
-  "common": {
-    "select-option": "Seleccionar opción"
-  },
   "language": {
     "switchTo": "Cambiar a Inglés"
   },
@@ -28,6 +25,7 @@
       "title": "Hola FAQ"
     },
     "swap": {
+      "select-option": "Select token to swap",
       "title": "Intercambie stablecoins por VUSD y viceversa"
     }
   }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -4,5 +4,7 @@ export type Token = {
   address: Address;
   chainId: Chain["id"];
   decimals: number;
+  logoURI: string;
+  name: string;
   symbol: string;
 };

--- a/web/stories/chevronIcon.stories.tsx
+++ b/web/stories/chevronIcon.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ChevronIcon } from "../src/components/base/chevronIcon";
+
+const meta: Meta<typeof ChevronIcon> = {
+  argTypes: {
+    direction: {
+      control: "select",
+      options: ["down", "up"],
+    },
+  },
+  component: ChevronIcon,
+  title: "Components/ChevronIcon",
+};
+
+export default meta;
+type Story = StoryObj<typeof ChevronIcon>;
+
+export const Default: Story = {
+  args: {
+    direction: "down",
+  },
+};

--- a/web/stories/tokenDropdown.stories.tsx
+++ b/web/stories/tokenDropdown.stories.tsx
@@ -19,8 +19,7 @@ const tokens: Token[] = [
     address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     chainId: 1,
     decimals: 6,
-    logoURI:
-      "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/usdc.svg",
     name: "USDCoin",
     symbol: "USDC",
   },
@@ -28,8 +27,7 @@ const tokens: Token[] = [
     address: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
     chainId: 1,
     decimals: 6,
-    logoURI:
-      "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/usdt.svg",
     name: "Tether USD",
     symbol: "USDT",
   },
@@ -40,6 +38,50 @@ export const Default: Story = {
     onChange: () => ({}),
     tokens,
     value: tokens[0],
+  },
+  render: function Render(args) {
+    const [selectedToken, setSelectedToken] = useState<Token>(args.value);
+
+    function handleTokenSelect(token: Token) {
+      setSelectedToken(token);
+    }
+
+    return (
+      <div className="w-[120px]">
+        <TokenDropdown
+          onChange={handleTokenSelect}
+          tokens={args.tokens}
+          value={selectedToken}
+        />
+      </div>
+    );
+  },
+};
+
+const tokensWithMissingLogo: Token[] = [
+  {
+    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    chainId: 1,
+    decimals: 6,
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/usdc.svg",
+    name: "USDCoin",
+    symbol: "USDC",
+  },
+  {
+    address: "0x1234567890123456789012345678901234567890",
+    chainId: 1,
+    decimals: 18,
+    logoURI: "https://some.invalid.url/test.png",
+    name: "Token Without Logo",
+    symbol: "TWL",
+  },
+];
+
+export const WithMissingLogoUri: Story = {
+  args: {
+    onChange: () => ({}),
+    tokens: tokensWithMissingLogo,
+    value: tokensWithMissingLogo[1],
   },
   render: function Render(args) {
     const [selectedToken, setSelectedToken] = useState<Token>(args.value);

--- a/web/stories/tokenDropdown.stories.tsx
+++ b/web/stories/tokenDropdown.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+import { TokenDropdown } from "../src/components/tokenDropdown";
+import type { Token } from "../src/types";
+
+const meta = {
+  args: {},
+  component: TokenDropdown,
+  title: "Components/TokenDropdown",
+} satisfies Meta<typeof TokenDropdown>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const tokens: Token[] = [
+  {
+    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    chainId: 1,
+    decimals: 6,
+    logoURI:
+      "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+    name: "USDCoin",
+    symbol: "USDC",
+  },
+  {
+    address: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+    chainId: 1,
+    decimals: 6,
+    logoURI:
+      "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+    name: "Tether USD",
+    symbol: "USDT",
+  },
+];
+
+export const Default: Story = {
+  args: {
+    onChange: () => ({}),
+    tokens,
+    value: tokens[0],
+  },
+  render: function Render(args) {
+    const [selectedToken, setSelectedToken] = useState<Token>(args.value);
+
+    function handleTokenSelect(token: Token) {
+      setSelectedToken(token);
+    }
+
+    return (
+      <div className="w-[120px]">
+        <TokenDropdown
+          onChange={handleTokenSelect}
+          tokens={args.tokens}
+          value={selectedToken}
+        />
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
### Description

Implements a reusable token dropdown component as part of the Swap page implementation. This PR adds:

- **Base dropdown component** with keyboard navigation, accessibility features, and smart viewport positioning
- **Token dropdown** that integrates the base dropdown with token-specific UI (logo + name)
- **Token logo component** for displaying token icons with fallback
- **Chevron icon** for dropdown indicators
- Extended the \`Token\` type with \`name\` and \`logoURI\` properties

The dropdown component features:
- Full keyboard navigation (Arrow keys, Enter, Escape, Tab)
- Click-outside-to-close behavior
- Automatic positioning based on available viewport space
- ARIA attributes for accessibility
- Storybook stories for both components

**Commits:**
- 461b4a1 Extend Token type with name and logoURI
- 78d3d55 Add token logo component
- bbe5880 Add chevron icon
- 21bfefc Add token dropdown component

### Screenshots

Storybook for the dropdown component

https://github.com/user-attachments/assets/ce91d065-6d90-4823-afd9-3444a1d0a510

### Related issue(s)

Related to #6

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.