### PR TITLE
Add requestRedeem and cancelRedeemRequest wallet actions

### DIFF
--- a/packages/gateway/src/abi/gatewayAbi.ts
+++ b/packages/gateway/src/abi/gatewayAbi.ts
@@ -69,6 +69,13 @@ export const gatewayAbi = [
     type: "function",
   },
   {
+    inputs: [],
+    name: "cancelRedeemRequest",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
     inputs: [
       { name: "tokenIn_", type: "address" },
       { name: "amountIn_", type: "uint256" },
@@ -89,6 +96,13 @@ export const gatewayAbi = [
     ],
     name: "redeem",
     outputs: [{ type: "uint256" }],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ name: "peggedTokenAmount_", type: "uint256" }],
+    name: "requestRedeem",
+    outputs: [],
     stateMutability: "nonpayable",
     type: "function",
   },

--- a/packages/gateway/src/actions/index.ts
+++ b/packages/gateway/src/actions/index.ts
@@ -10,5 +10,7 @@ export * from "./public/previewDeposit.js";
 export * from "./public/previewRedeem.js";
 
 // Export all wallet actions
+export * from "./wallet/cancelRedeemRequest.js";
 export * from "./wallet/deposit.js";
 export * from "./wallet/redeem.js";
+export * from "./wallet/requestRedeem.js";

--- a/packages/gateway/src/actions/wallet/cancelRedeemRequest.ts
+++ b/packages/gateway/src/actions/wallet/cancelRedeemRequest.ts
@@ -1,0 +1,112 @@
+import { EventEmitter } from "events";
+import { toPromiseEvent } from "to-promise-event";
+import {
+  type TransactionReceipt,
+  type WalletClient,
+  encodeFunctionData,
+} from "viem";
+import { waitForTransactionReceipt, writeContract } from "viem/actions";
+
+import { gatewayAbi } from "../../abi/gatewayAbi.js";
+import { getGatewayAddress } from "../../getGatewayAddress.js";
+import type { CancelRedeemRequestEvents } from "../../types.js";
+
+const canCancelRedeemRequest = function ({
+  client,
+}: {
+  client: WalletClient;
+}): {
+  canCancelRedeemRequest: boolean;
+  reason?: string;
+} {
+  if (!client) {
+    return {
+      canCancelRedeemRequest: false,
+      reason: "Client is not defined",
+    };
+  }
+  if (!client.chain) {
+    return {
+      canCancelRedeemRequest: false,
+      reason: "Chain is not defined on wallet client",
+    };
+  }
+  if (!client.account) {
+    return {
+      canCancelRedeemRequest: false,
+      reason: "Client must have an account",
+    };
+  }
+
+  return { canCancelRedeemRequest: true };
+};
+
+const runCancelRedeemRequest = (walletClient: WalletClient) =>
+  async function (emitter: EventEmitter<CancelRedeemRequestEvents>) {
+    try {
+      const { canCancelRedeemRequest: canCancelRedeemRequestFlag, reason } =
+        canCancelRedeemRequest({
+          client: walletClient,
+        });
+
+      if (!canCancelRedeemRequestFlag) {
+        emitter.emit("cancel-redeem-request-failed-validation", reason!);
+        return;
+      }
+
+      // already validated
+      const gatewayAddress = getGatewayAddress(walletClient.chain!.id);
+
+      emitter.emit("pre-cancel-redeem-request");
+
+      const cancelHash = await writeContract(walletClient, {
+        abi: gatewayAbi,
+        account: walletClient.account!,
+        address: gatewayAddress,
+        chain: walletClient.chain,
+        functionName: "cancelRedeemRequest",
+      }).catch(function (error: Error) {
+        emitter.emit("user-signing-cancel-redeem-request-error", error);
+      });
+
+      if (!cancelHash) {
+        return;
+      }
+
+      emitter.emit("user-signed-cancel-redeem-request", cancelHash);
+
+      const cancelReceipt = await waitForTransactionReceipt(walletClient, {
+        hash: cancelHash,
+      }).catch(function (error: Error) {
+        emitter.emit("cancel-redeem-request-failed", error);
+      });
+
+      if (!cancelReceipt) {
+        return;
+      }
+
+      const cancelEventMap: Record<
+        TransactionReceipt["status"],
+        keyof CancelRedeemRequestEvents
+      > = {
+        reverted: "cancel-redeem-request-transaction-reverted",
+        success: "cancel-redeem-request-transaction-succeeded",
+      };
+
+      emitter.emit(cancelEventMap[cancelReceipt.status], cancelReceipt);
+    } catch (error) {
+      emitter.emit("unexpected-error", error as Error);
+    } finally {
+      emitter.emit("cancel-redeem-request-settled");
+    }
+  };
+
+export const cancelRedeemRequest = (
+  ...args: Parameters<typeof runCancelRedeemRequest>
+) => toPromiseEvent<CancelRedeemRequestEvents>(runCancelRedeemRequest(...args));
+
+export const encodeCancelRedeemRequest = () =>
+  encodeFunctionData({
+    abi: gatewayAbi,
+    functionName: "cancelRedeemRequest",
+  });

--- a/packages/gateway/src/actions/wallet/requestRedeem.ts
+++ b/packages/gateway/src/actions/wallet/requestRedeem.ts
@@ -1,0 +1,146 @@
+import { EventEmitter } from "events";
+import { toPromiseEvent } from "to-promise-event";
+import {
+  type TransactionReceipt,
+  type WalletClient,
+  encodeFunctionData,
+} from "viem";
+import { waitForTransactionReceipt, writeContract } from "viem/actions";
+
+import { gatewayAbi } from "../../abi/gatewayAbi.js";
+import { getGatewayAddress } from "../../getGatewayAddress.js";
+import type { RequestRedeemEvents } from "../../types.js";
+
+export type RequestRedeemParams = {
+  peggedTokenAmount: bigint;
+};
+
+const canRequestRedeem = function ({
+  client,
+  peggedTokenAmount,
+}: {
+  client: WalletClient;
+  peggedTokenAmount: bigint;
+}): {
+  canRequestRedeem: boolean;
+  reason?: string;
+} {
+  if (!client) {
+    return {
+      canRequestRedeem: false,
+      reason: "Client is not defined",
+    };
+  }
+  if (!client.chain) {
+    return {
+      canRequestRedeem: false,
+      reason: "Chain is not defined on wallet client",
+    };
+  }
+  if (!client.account) {
+    return {
+      canRequestRedeem: false,
+      reason: "Client must have an account",
+    };
+  }
+
+  if (typeof peggedTokenAmount !== "bigint") {
+    return {
+      canRequestRedeem: false,
+      reason: "Amount must be a bigint",
+    };
+  }
+  if (peggedTokenAmount <= 0n) {
+    return {
+      canRequestRedeem: false,
+      reason: "Amount must be greater than 0",
+    };
+  }
+
+  return { canRequestRedeem: true };
+};
+
+const runRequestRedeem = (
+  walletClient: WalletClient,
+  { peggedTokenAmount }: RequestRedeemParams,
+) =>
+  async function (emitter: EventEmitter<RequestRedeemEvents>) {
+    try {
+      const { canRequestRedeem: canRequestRedeemFlag, reason } =
+        canRequestRedeem({
+          client: walletClient,
+          peggedTokenAmount,
+        });
+
+      if (!canRequestRedeemFlag) {
+        emitter.emit("request-redeem-failed-validation", reason!);
+        return;
+      }
+
+      // already validated
+      const gatewayAddress = getGatewayAddress(walletClient.chain!.id);
+
+      emitter.emit("pre-request-redeem");
+
+      const requestRedeemHash = await writeContract(walletClient, {
+        abi: gatewayAbi,
+        account: walletClient.account!,
+        address: gatewayAddress,
+        args: [peggedTokenAmount],
+        chain: walletClient.chain,
+        functionName: "requestRedeem",
+      }).catch(function (error: Error) {
+        emitter.emit("user-signing-request-redeem-error", error);
+      });
+
+      if (!requestRedeemHash) {
+        return;
+      }
+
+      emitter.emit("user-signed-request-redeem", requestRedeemHash);
+
+      const requestRedeemReceipt = await waitForTransactionReceipt(
+        walletClient,
+        {
+          hash: requestRedeemHash,
+        },
+      ).catch(function (error: Error) {
+        emitter.emit("request-redeem-failed", error);
+      });
+
+      if (!requestRedeemReceipt) {
+        return;
+      }
+
+      const requestRedeemEventMap: Record<
+        TransactionReceipt["status"],
+        keyof RequestRedeemEvents
+      > = {
+        reverted: "request-redeem-transaction-reverted",
+        success: "request-redeem-transaction-succeeded",
+      };
+
+      emitter.emit(
+        requestRedeemEventMap[requestRedeemReceipt.status],
+        requestRedeemReceipt,
+      );
+    } catch (error) {
+      emitter.emit("unexpected-error", error as Error);
+    } finally {
+      emitter.emit("request-redeem-settled");
+    }
+  };
+
+export const requestRedeem = (...args: Parameters<typeof runRequestRedeem>) =>
+  toPromiseEvent<RequestRedeemEvents>(runRequestRedeem(...args));
+
+export const encodeRequestRedeem = ({
+  peggedTokenAmount,
+}: {
+  peggedTokenAmount: bigint;
+}) =>
+  encodeFunctionData({
+    abi: gatewayAbi,
+    args: [peggedTokenAmount],
+    functionName: "requestRedeem",
+  });

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -10,8 +10,13 @@ import {
   previewDeposit,
   previewRedeem,
 } from "./actions/public/index.js";
+import { cancelRedeemRequest } from "./actions/wallet/cancelRedeemRequest.js";
 import { type DepositParams, deposit } from "./actions/wallet/deposit.js";
 import { type RedeemParams, redeem } from "./actions/wallet/redeem.js";
+import {
+  type RequestRedeemParams,
+  requestRedeem,
+} from "./actions/wallet/requestRedeem.js";
 
 // Export ABI
 export { gatewayAbi } from "./abi/gatewayAbi.js";
@@ -42,6 +47,8 @@ export const gatewayPublicActions = () => (client: Client) => ({
 });
 
 export const gatewayWalletActions = () => (client: WalletClient) => ({
+  cancelRedeemRequest: () => cancelRedeemRequest(client),
   deposit: (params: DepositParams) => deposit(client, params),
   redeem: (params: RedeemParams) => redeem(client, params),
+  requestRedeem: (params: RequestRedeemParams) => requestRedeem(client, params),
 });

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -36,6 +36,17 @@ export type MintEvents = ApprovalEvents &
     "user-signing-mint-error": [Error];
   };
 
+export type CancelRedeemRequestEvents = CommonEvents & {
+  "cancel-redeem-request-failed": [Error];
+  "cancel-redeem-request-failed-validation": [string];
+  "cancel-redeem-request-settled": [];
+  "cancel-redeem-request-transaction-reverted": [TransactionReceipt];
+  "cancel-redeem-request-transaction-succeeded": [TransactionReceipt];
+  "pre-cancel-redeem-request": [];
+  "user-signed-cancel-redeem-request": [Hash];
+  "user-signing-cancel-redeem-request-error": [Error];
+};
+
 export type RedeemEvents = ApprovalEvents &
   CommonEvents & {
     "pre-redeem": [];
@@ -47,6 +58,17 @@ export type RedeemEvents = ApprovalEvents &
     "user-signed-redeem": [Hash];
     "user-signing-redeem-error": [Error];
   };
+
+export type RequestRedeemEvents = CommonEvents & {
+  "pre-request-redeem": [];
+  "request-redeem-failed": [Error];
+  "request-redeem-failed-validation": [string];
+  "request-redeem-settled": [];
+  "request-redeem-transaction-reverted": [TransactionReceipt];
+  "request-redeem-transaction-succeeded": [TransactionReceipt];
+  "user-signed-request-redeem": [Hash];
+  "user-signing-request-redeem-error": [Error];
+};
 
 export type WithdrawEvents = ApprovalEvents &
   CommonEvents & {

--- a/packages/gateway/test/wallet/cancelRedeemRequest.test.ts
+++ b/packages/gateway/test/wallet/cancelRedeemRequest.test.ts
@@ -1,0 +1,216 @@
+import {
+  type TransactionReceipt,
+  type WalletClient,
+  zeroAddress,
+  zeroHash,
+} from "viem";
+import { waitForTransactionReceipt, writeContract } from "viem/actions";
+import { sepolia } from "viem/chains";
+import { describe, expect, it, vi } from "vitest";
+
+import { cancelRedeemRequest } from "../../src/actions/wallet/cancelRedeemRequest";
+
+vi.mock("viem/actions", () => ({
+  waitForTransactionReceipt: vi.fn(),
+  writeContract: vi.fn(),
+}));
+
+// @ts-expect-error - mock client
+const mockWalletClient = {
+  account: {
+    address: zeroAddress,
+  },
+  chain: sepolia,
+} as WalletClient;
+
+describe("cancelRedeemRequest", function () {
+  it("should emit 'cancel-redeem-request-failed-validation' if client is not defined", async function () {
+    const { emitter, promise } = cancelRedeemRequest(
+      // @ts-expect-error - Testing invalid input
+      undefined,
+    );
+
+    const onFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("cancel-redeem-request-failed-validation", onFailedValidation);
+    emitter.on("cancel-redeem-request-settled", onSettled);
+
+    await promise;
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Client is not defined",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'cancel-redeem-request-failed-validation' if client.chain is not defined", async function () {
+    const clientWithoutChain = {
+      account: mockWalletClient.account,
+    } as WalletClient;
+
+    const { emitter, promise } = cancelRedeemRequest(clientWithoutChain);
+
+    const onFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("cancel-redeem-request-failed-validation", onFailedValidation);
+    emitter.on("cancel-redeem-request-settled", onSettled);
+
+    await promise;
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Chain is not defined on wallet client",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'cancel-redeem-request-failed-validation' if client.account is not defined", async function () {
+    // @ts-expect-error - Testing invalid input
+    const clientWithoutAccount = {
+      chain: sepolia,
+    } as WalletClient;
+
+    const { emitter, promise } = cancelRedeemRequest(clientWithoutAccount);
+
+    const onFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("cancel-redeem-request-failed-validation", onFailedValidation);
+    emitter.on("cancel-redeem-request-settled", onSettled);
+
+    await promise;
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Client must have an account",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'user-signing-cancel-redeem-request-error' when signing fails", async function () {
+    vi.mocked(writeContract).mockRejectedValue(new Error("Signing error"));
+
+    const { emitter, promise } = cancelRedeemRequest(mockWalletClient);
+
+    const onPreCancel = vi.fn();
+    const onSigningError = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("pre-cancel-redeem-request", onPreCancel);
+    emitter.on("user-signing-cancel-redeem-request-error", onSigningError);
+    emitter.on("cancel-redeem-request-settled", onSettled);
+
+    await promise;
+
+    expect(onPreCancel).toHaveBeenCalledOnce();
+    expect(onSigningError).toHaveBeenCalledExactlyOnceWith(expect.any(Error));
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'cancel-redeem-request-failed' when receipt fails", async function () {
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockRejectedValue(
+      new Error("Receipt error"),
+    );
+
+    const { emitter, promise } = cancelRedeemRequest(mockWalletClient);
+
+    const onPreCancel = vi.fn();
+    const onUserSigned = vi.fn();
+    const onFailed = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("pre-cancel-redeem-request", onPreCancel);
+    emitter.on("user-signed-cancel-redeem-request", onUserSigned);
+    emitter.on("cancel-redeem-request-failed", onFailed);
+    emitter.on("cancel-redeem-request-settled", onSettled);
+
+    await promise;
+
+    expect(onPreCancel).toHaveBeenCalledOnce();
+    expect(onUserSigned).toHaveBeenCalledExactlyOnceWith(zeroHash);
+    expect(onFailed).toHaveBeenCalledExactlyOnceWith(expect.any(Error));
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'cancel-redeem-request-transaction-reverted' when transaction reverts", async function () {
+    const receipt = {
+      status: "reverted",
+    } as TransactionReceipt;
+
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt);
+
+    const { emitter, promise } = cancelRedeemRequest(mockWalletClient);
+
+    const onPreCancel = vi.fn();
+    const onUserSigned = vi.fn();
+    const onReverted = vi.fn();
+    const onSucceeded = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("pre-cancel-redeem-request", onPreCancel);
+    emitter.on("user-signed-cancel-redeem-request", onUserSigned);
+    emitter.on("cancel-redeem-request-transaction-reverted", onReverted);
+    emitter.on("cancel-redeem-request-transaction-succeeded", onSucceeded);
+    emitter.on("cancel-redeem-request-settled", onSettled);
+
+    await promise;
+
+    expect(onPreCancel).toHaveBeenCalledOnce();
+    expect(onUserSigned).toHaveBeenCalledExactlyOnceWith(zeroHash);
+    expect(onReverted).toHaveBeenCalledExactlyOnceWith(receipt);
+    expect(onSucceeded).not.toHaveBeenCalled();
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'cancel-redeem-request-transaction-succeeded' on success", async function () {
+    const receipt = {
+      status: "success",
+    } as TransactionReceipt;
+
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt);
+
+    const { emitter, promise } = cancelRedeemRequest(mockWalletClient);
+
+    const onPreCancel = vi.fn();
+    const onUserSigned = vi.fn();
+    const onSucceeded = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("pre-cancel-redeem-request", onPreCancel);
+    emitter.on("user-signed-cancel-redeem-request", onUserSigned);
+    emitter.on("cancel-redeem-request-transaction-succeeded", onSucceeded);
+    emitter.on("cancel-redeem-request-settled", onSettled);
+
+    await promise;
+
+    expect(onPreCancel).toHaveBeenCalledOnce();
+    expect(onUserSigned).toHaveBeenCalledExactlyOnceWith(zeroHash);
+    expect(onSucceeded).toHaveBeenCalledExactlyOnceWith(receipt);
+    expect(writeContract).toHaveBeenCalledOnce();
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'unexpected-error' when an unexpected error occurs", async function () {
+    vi.mocked(writeContract).mockImplementation(function () {
+      throw new Error("Unexpected");
+    });
+
+    const { emitter, promise } = cancelRedeemRequest(mockWalletClient);
+
+    const onUnexpectedError = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("unexpected-error", onUnexpectedError);
+    emitter.on("cancel-redeem-request-settled", onSettled);
+
+    await promise;
+
+    expect(onUnexpectedError).toHaveBeenCalledExactlyOnceWith(
+      expect.any(Error),
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/gateway/test/wallet/requestRedeem.test.ts
+++ b/packages/gateway/test/wallet/requestRedeem.test.ts
@@ -1,0 +1,303 @@
+import {
+  type TransactionReceipt,
+  type WalletClient,
+  zeroAddress,
+  zeroHash,
+} from "viem";
+import { waitForTransactionReceipt, writeContract } from "viem/actions";
+import { sepolia } from "viem/chains";
+import { describe, expect, it, vi } from "vitest";
+
+import { requestRedeem } from "../../src/actions/wallet/requestRedeem";
+
+vi.mock("viem/actions", () => ({
+  waitForTransactionReceipt: vi.fn(),
+  writeContract: vi.fn(),
+}));
+
+// @ts-expect-error - mock client
+const mockWalletClient = {
+  account: {
+    address: zeroAddress,
+  },
+  chain: sepolia,
+} as WalletClient;
+
+const validParameters = {
+  peggedTokenAmount: BigInt(1000),
+};
+
+describe("requestRedeem", function () {
+  it("should emit 'request-redeem-failed-validation' if client is not defined", async function () {
+    const { emitter, promise } = requestRedeem(
+      // @ts-expect-error - Testing invalid input
+      undefined,
+      validParameters,
+    );
+
+    const onFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("request-redeem-failed-validation", onFailedValidation);
+    emitter.on("request-redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Client is not defined",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'request-redeem-failed-validation' if client.chain is not defined", async function () {
+    const clientWithoutChain = {
+      account: mockWalletClient.account,
+    } as WalletClient;
+
+    const { emitter, promise } = requestRedeem(
+      clientWithoutChain,
+      validParameters,
+    );
+
+    const onFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("request-redeem-failed-validation", onFailedValidation);
+    emitter.on("request-redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Chain is not defined on wallet client",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'request-redeem-failed-validation' if client.account is not defined", async function () {
+    // @ts-expect-error - Testing invalid input
+    const clientWithoutAccount = {
+      chain: sepolia,
+    } as WalletClient;
+
+    const { emitter, promise } = requestRedeem(
+      clientWithoutAccount,
+      validParameters,
+    );
+
+    const onFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("request-redeem-failed-validation", onFailedValidation);
+    emitter.on("request-redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Client must have an account",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'request-redeem-failed-validation' if peggedTokenAmount is not a bigint", async function () {
+    const parameters = { peggedTokenAmount: 1000 };
+
+    const { emitter, promise } = requestRedeem(
+      mockWalletClient,
+      // @ts-expect-error - Testing invalid input
+      parameters,
+    );
+
+    const onFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("request-redeem-failed-validation", onFailedValidation);
+    emitter.on("request-redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Amount must be a bigint",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'request-redeem-failed-validation' if peggedTokenAmount is zero", async function () {
+    const parameters = { peggedTokenAmount: BigInt(0) };
+
+    const { emitter, promise } = requestRedeem(mockWalletClient, parameters);
+
+    const onFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("request-redeem-failed-validation", onFailedValidation);
+    emitter.on("request-redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Amount must be greater than 0",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'request-redeem-failed-validation' if peggedTokenAmount is negative", async function () {
+    const parameters = { peggedTokenAmount: BigInt(-1) };
+
+    const { emitter, promise } = requestRedeem(mockWalletClient, parameters);
+
+    const onFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("request-redeem-failed-validation", onFailedValidation);
+    emitter.on("request-redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Amount must be greater than 0",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'user-signing-request-redeem-error' when signing fails", async function () {
+    vi.mocked(writeContract).mockRejectedValue(new Error("Signing error"));
+
+    const { emitter, promise } = requestRedeem(
+      mockWalletClient,
+      validParameters,
+    );
+
+    const onPreRequestRedeem = vi.fn();
+    const onSigningError = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("pre-request-redeem", onPreRequestRedeem);
+    emitter.on("user-signing-request-redeem-error", onSigningError);
+    emitter.on("request-redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onPreRequestRedeem).toHaveBeenCalledOnce();
+    expect(onSigningError).toHaveBeenCalledExactlyOnceWith(expect.any(Error));
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'request-redeem-failed' when receipt fails", async function () {
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockRejectedValue(
+      new Error("Receipt error"),
+    );
+
+    const { emitter, promise } = requestRedeem(
+      mockWalletClient,
+      validParameters,
+    );
+
+    const onPreRequestRedeem = vi.fn();
+    const onUserSigned = vi.fn();
+    const onFailed = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("pre-request-redeem", onPreRequestRedeem);
+    emitter.on("user-signed-request-redeem", onUserSigned);
+    emitter.on("request-redeem-failed", onFailed);
+    emitter.on("request-redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onPreRequestRedeem).toHaveBeenCalledOnce();
+    expect(onUserSigned).toHaveBeenCalledExactlyOnceWith(zeroHash);
+    expect(onFailed).toHaveBeenCalledExactlyOnceWith(expect.any(Error));
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'request-redeem-transaction-reverted' when transaction reverts", async function () {
+    const receipt = {
+      status: "reverted",
+    } as TransactionReceipt;
+
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt);
+
+    const { emitter, promise } = requestRedeem(
+      mockWalletClient,
+      validParameters,
+    );
+
+    const onPreRequestRedeem = vi.fn();
+    const onUserSigned = vi.fn();
+    const onReverted = vi.fn();
+    const onSucceeded = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("pre-request-redeem", onPreRequestRedeem);
+    emitter.on("user-signed-request-redeem", onUserSigned);
+    emitter.on("request-redeem-transaction-reverted", onReverted);
+    emitter.on("request-redeem-transaction-succeeded", onSucceeded);
+    emitter.on("request-redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onPreRequestRedeem).toHaveBeenCalledOnce();
+    expect(onUserSigned).toHaveBeenCalledExactlyOnceWith(zeroHash);
+    expect(onReverted).toHaveBeenCalledExactlyOnceWith(receipt);
+    expect(onSucceeded).not.toHaveBeenCalled();
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'request-redeem-transaction-succeeded' on success", async function () {
+    const receipt = {
+      status: "success",
+    } as TransactionReceipt;
+
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt);
+
+    const { emitter, promise } = requestRedeem(
+      mockWalletClient,
+      validParameters,
+    );
+
+    const onPreRequestRedeem = vi.fn();
+    const onUserSigned = vi.fn();
+    const onSucceeded = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("pre-request-redeem", onPreRequestRedeem);
+    emitter.on("user-signed-request-redeem", onUserSigned);
+    emitter.on("request-redeem-transaction-succeeded", onSucceeded);
+    emitter.on("request-redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onPreRequestRedeem).toHaveBeenCalledOnce();
+    expect(onUserSigned).toHaveBeenCalledExactlyOnceWith(zeroHash);
+    expect(onSucceeded).toHaveBeenCalledExactlyOnceWith(receipt);
+    expect(writeContract).toHaveBeenCalledOnce();
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'unexpected-error' when an unexpected error occurs", async function () {
+    vi.mocked(writeContract).mockImplementation(function () {
+      throw new Error("Unexpected");
+    });
+
+    const { emitter, promise } = requestRedeem(
+      mockWalletClient,
+      validParameters,
+    );
+
+    const onUnexpectedError = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("unexpected-error", onUnexpectedError);
+    emitter.on("request-redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onUnexpectedError).toHaveBeenCalledExactlyOnceWith(
+      expect.any(Error),
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
### Description

Add `requestRedeem` and `cancelRedeemRequest` wallet actions to the gateway package. These new actions follow the same event-driven pattern as existing wallet actions (`deposit`, `redeem`) and include:

- ABI entries for `requestRedeem` and `cancelRedeemRequest` contract functions
- Event types (`RequestRedeemEvents`, `CancelRedeemRequestEvents`)
- Encode helpers (`encodeRequestRedeem`, `encodeCancelRedeemRequest`)
- Exports via `gatewayWalletActions`

**Commits:**
d780ed1 Add requestRedeem and cancelRedeem wallet actions

### Screenshots

N/A - no UI changes.

### Related issue(s)

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.