### PR TITLE
Add striped divider component to Earn page

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -18,6 +18,7 @@
   --font-size-xsm: 0.8125rem; /* 13px */
   --font-size-mid: 0.9375rem; /* 15px */
 
+  --height-22: 5.5rem; /* 88px */
   --height-50: 12.5rem; /* 200px */
 
   --line-height-xsm: 1.25rem; /* 20px */
@@ -36,6 +37,10 @@
   --shadow-xl:
     0 0 0 1px rgba(0, 0, 0, 0.04), 0 5px 16px -2px rgba(0, 0, 0, 0.06),
     0 15px 35px -5px rgba(0, 0, 0, 0.2);
+}
+
+@utility h-22 {
+  height: var(--height-22);
 }
 
 @utility h-50 {

--- a/web/src/pages/earn/components/stripedDivider/index.tsx
+++ b/web/src/pages/earn/components/stripedDivider/index.tsx
@@ -1,0 +1,14 @@
+export const StripedDivider = () => (
+  <div
+    className="h-[88px] w-full"
+    style={{
+      background: `repeating-linear-gradient(
+        120deg,
+        #f3f4f6,
+        #f3f4f6 4px,
+        #e5e7eb 4px,
+        #e5e7eb 6px
+      )`,
+    }}
+  />
+);

--- a/web/src/pages/earn/components/stripedDivider/index.tsx
+++ b/web/src/pages/earn/components/stripedDivider/index.tsx
@@ -1,7 +1,7 @@
 export const StripedDivider = () => (
   <div
     aria-hidden="true"
-    className="h-[88px] w-full"
+    className="h-22 w-full"
     style={{
       background: `repeating-linear-gradient(
         120deg,

--- a/web/src/pages/earn/components/stripedDivider/index.tsx
+++ b/web/src/pages/earn/components/stripedDivider/index.tsx
@@ -1,5 +1,6 @@
 export const StripedDivider = () => (
   <div
+    aria-hidden="true"
     className="h-[88px] w-full"
     style={{
       background: `repeating-linear-gradient(

--- a/web/src/pages/earn/index.tsx
+++ b/web/src/pages/earn/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import { EarnStats } from "./components/earnStats";
 import { PoolInfoBar } from "./components/poolInfoBar";
+import { StripedDivider } from "./components/stripedDivider";
 
 export function Earn() {
   const { t } = useTranslation();
@@ -10,10 +11,13 @@ export function Earn() {
   return (
     <>
       <PageTitle value={t("pages.earn.title")} />
-      <div className="flex flex-col border-t border-b border-gray-200 bg-gray-100 *:-mt-px md:flex-row md:items-center md:justify-center md:gap-14 md:px-14 md:*:w-[267px]">
+      <div className="flex flex-col border-y border-gray-200 bg-gray-100 *:-mt-px md:flex-row md:items-center md:justify-center md:gap-14 md:px-14 md:*:w-[267px]">
         <EarnStats />
       </div>
       <PoolInfoBar />
+      <div className="border-b border-gray-200 bg-gray-100 p-2">
+        <StripedDivider />
+      </div>
     </>
   );
 }

--- a/web/stories/stripedDivider.stories.tsx
+++ b/web/stories/stripedDivider.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { StripedDivider } from "../src/pages/earn/components/stripedDivider";
+
+const meta: Meta<typeof StripedDivider> = {
+  component: StripedDivider,
+  title: "Earn/StripedDivider",
+};
+
+export default meta;
+type Story = StoryObj<typeof StripedDivider>;
+
+export const Default: Story = {};


### PR DESCRIPTION
### Description

This PR adds the decorative background pattern rendered below the PoolInfoBar. It also includes Storybook story at Earn/StripedDivider.

### Screenshots

https://github.com/user-attachments/assets/522631a8-7292-4d4a-8e9d-8537c446d708

### Related issue(s)

Related to #23

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
