### PR TITLE
Add default redirect from '/' to '/swap'

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -27,6 +27,7 @@ export const App = () => (
                 <I18nInitializer />
                 <AppLayout>
                   <Routes>
+                    <Route element={<Navigate replace to="swap" />} index />
                     <Route element={<Swap />} path="swap" />
                     <Route element={<Earn />} path="earn" />
                     <Route element={<Borrow />} path="borrow" />


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds a redirect so users entering `/:lang/` are redirected to `/:lang/swap`, which is the default page

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/b38d0c52-6256-4ada-b861-06152a4764f2

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #6

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
