### PR TITLE
Add fee details to swap forms

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,8 +160,8 @@ importers:
   web:
     dependencies:
       '@hemilabs/react-hooks':
-        specifier: 1.2.0
-        version: 1.2.0(@hemilabs/wallet-watch-asset@1.0.2)(@tanstack/react-query@5.90.19(react@19.2.3))(react@19.2.3)(viem-erc20@2.1.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.19)(@tanstack/react-query@5.90.19(react@19.2.3))(@types/react@19.2.9)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))
+        specifier: 1.3.0
+        version: 1.3.0(@hemilabs/wallet-watch-asset@1.0.2)(@tanstack/react-query@5.90.19(react@19.2.3))(react@19.2.3)(viem-erc20@2.1.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.19)(@tanstack/react-query@5.90.19(react@19.2.3))(@types/react@19.2.9)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))
       '@hemilabs/wallet-watch-asset':
         specifier: 1.0.2
         version: 1.0.2
@@ -905,8 +905,8 @@ packages:
   '@graphprotocol/graph-ts@0.38.2':
     resolution: {integrity: sha512-87KIFSFs2+Te+mnmb7Y+M57oqzlLy20cIyPIRbn9qJfpZFSZHTKtBLT6KQmcsK0YkoWis9Ur3c3M2c9mmaaEHQ==}
 
-  '@hemilabs/react-hooks@1.2.0':
-    resolution: {integrity: sha512-4NQ7yYAWdCy/B7zD51rMqEBg5pd8x4Km3BuOKrYyR7ps84d/btuiPAtNQHgdzMtBRejksoXSZFObmwvl2IEKHw==}
+  '@hemilabs/react-hooks@1.3.0':
+    resolution: {integrity: sha512-jsVdUZzOuTeEV8zvqariboi6/EF2FvFzfPgLaZV4LMyY5Ati4+viHQkHjVvzEAn/rSzlK4NSixRDXMptp3iBcQ==}
     peerDependencies:
       '@hemilabs/wallet-watch-asset': ^1
       '@tanstack/react-query': ^5
@@ -8461,7 +8461,7 @@ snapshots:
     dependencies:
       assemblyscript: 0.27.31
 
-  '@hemilabs/react-hooks@1.2.0(@hemilabs/wallet-watch-asset@1.0.2)(@tanstack/react-query@5.90.19(react@19.2.3))(react@19.2.3)(viem-erc20@2.1.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.19)(@tanstack/react-query@5.90.19(react@19.2.3))(@types/react@19.2.9)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))':
+  '@hemilabs/react-hooks@1.3.0(@hemilabs/wallet-watch-asset@1.0.2)(@tanstack/react-query@5.90.19(react@19.2.3))(react@19.2.3)(viem-erc20@2.1.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.19)(@tanstack/react-query@5.90.19(react@19.2.3))(@types/react@19.2.9)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))':
     dependencies:
       '@hemilabs/wallet-watch-asset': 1.0.2
       '@tanstack/react-query': 5.90.19(react@19.2.3)

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@hemilabs/react-hooks": "1.2.0",
+    "@hemilabs/react-hooks": "1.3.0",
     "@hemilabs/wallet-watch-asset": "1.0.2",
     "@rainbow-me/rainbowkit": "2.2.10",
     "@tanstack/react-query": "5.90.19",

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -5,7 +5,9 @@ import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
 import { TokenDropdown } from "components/tokenDropdown";
 import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
 import { useDeposit } from "hooks/useDeposit";
+import { useEstimateDepositGas } from "hooks/useEstimateDepositGas";
 import { useMainnet } from "hooks/useMainnet";
+import { useMintFee } from "hooks/useMintFee";
 import { usePreviewDeposit } from "hooks/usePreviewDeposit";
 import { type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
@@ -14,6 +16,7 @@ import { formatAmount } from "utils/token";
 
 import { Form } from "./form";
 import { SubmitButton } from "./submitButton";
+import { SwapFees } from "./swapFees";
 import { getSwapErrors } from "./validation";
 
 type Props = {
@@ -61,6 +64,14 @@ export function Deposit({
       amountIn: amountBigInt,
       tokenIn: fromToken.address,
     });
+
+  const protocolFee = useMintFee();
+
+  const operationGasEstimation = useEstimateDepositGas({
+    amountIn: amountBigInt,
+    minPeggedTokenOut: depositPreview,
+    token: fromToken,
+  });
 
   const depositMutation = useDeposit({
     amountIn: amountBigInt,
@@ -121,6 +132,16 @@ export function Deposit({
         />
       </Form>
       <ApproveSection active={approve10x} onToggle={onToggleApprove10x} />
+      <SwapFees
+        amountBigInt={amountBigInt}
+        approveAmount={approveAmount}
+        fromInputValue={fromInputValue}
+        fromToken={fromToken}
+        operationGasEstimation={operationGasEstimation}
+        outputValue={outputValue}
+        protocolFee={protocolFee}
+        toToken={toToken}
+      />
     </>
   );
 }

--- a/web/src/components/swapForm/redeem.tsx
+++ b/web/src/components/swapForm/redeem.tsx
@@ -4,16 +4,20 @@ import { ApproveSection } from "components/approveSection";
 import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
 import { TokenDropdown } from "components/tokenDropdown";
 import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
+import { useEstimateRedeemGas } from "hooks/useEstimateRedeemGas";
 import { useMainnet } from "hooks/useMainnet";
 import { usePreviewRedeem } from "hooks/usePreviewRedeem";
 import { useRedeem } from "hooks/useRedeem";
+import { useRedeemFee } from "hooks/useRedeemFee";
 import { type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import type { Token } from "types";
 import { formatAmount } from "utils/token";
+import { useAccount } from "wagmi";
 
 import { Form } from "./form";
 import { SubmitButton } from "./submitButton";
+import { SwapFees } from "./swapFees";
 import { getSwapErrors } from "./validation";
 
 type Props = {
@@ -45,6 +49,7 @@ export function Redeem({
   toToken,
   whitelistedTokens,
 }: Props) {
+  const { address } = useAccount();
   const ethereumChain = useMainnet();
   const { t } = useTranslation();
 
@@ -60,6 +65,17 @@ export function Redeem({
     peggedTokenIn: amountBigInt,
     tokenOut: toToken.address,
   });
+
+  const operationGasEstimation = useEstimateRedeemGas({
+    enabled: amountBigInt > 0n && !!redeemPreview && !!address,
+    minAmountOut: redeemPreview ?? 0n,
+    peggedToken: fromToken,
+    peggedTokenIn: amountBigInt,
+    receiver: address!,
+    tokenOut: toToken.address,
+  });
+
+  const protocolFee = useRedeemFee();
 
   const redeemMutation = useRedeem({
     approveAmount,
@@ -126,6 +142,16 @@ export function Redeem({
         />
       </Form>
       <ApproveSection active={approve10x} onToggle={onToggleApprove10x} />
+      <SwapFees
+        amountBigInt={amountBigInt}
+        approveAmount={approveAmount}
+        fromInputValue={fromInputValue}
+        fromToken={fromToken}
+        operationGasEstimation={operationGasEstimation}
+        outputValue={outputValue}
+        protocolFee={protocolFee}
+        toToken={toToken}
+      />
     </>
   );
 }

--- a/web/src/components/swapForm/swapFees.tsx
+++ b/web/src/components/swapForm/swapFees.tsx
@@ -1,0 +1,120 @@
+import { useEstimateApproveErc20Fees } from "@hemilabs/react-hooks/useEstimateApproveErc20Fees";
+import { useNeedsApproval } from "@hemilabs/react-hooks/useNeedsApproval";
+import { getGatewayAddress } from "@vetro/gateway";
+import { FeeDetails } from "components/feeDetails";
+import { FeesContainer } from "components/feesContainer";
+import { useMainnet } from "hooks/useMainnet";
+import { useTranslation } from "react-i18next";
+import type { Token } from "types";
+import { formatAmount } from "utils/token";
+
+type Props = {
+  amountBigInt: bigint;
+  approveAmount: bigint | undefined;
+  fromInputValue: string;
+  fromToken: Token;
+  operationGasEstimation: {
+    fees: bigint | undefined;
+    isEnabled: boolean;
+    isError: boolean;
+  };
+  outputValue: string;
+  protocolFee: { data: bigint | undefined; isError: boolean };
+  toToken: Token;
+};
+
+// only add up fees when all are available
+const sumFees = function (fees: (bigint | undefined)[]) {
+  if (fees.every((fee): fee is bigint => fee !== undefined)) {
+    return fees.reduce((sum, fee) => sum + fee, 0n);
+  }
+  return undefined;
+};
+
+export const SwapFees = function ({
+  amountBigInt,
+  approveAmount,
+  fromInputValue,
+  fromToken,
+  operationGasEstimation,
+  outputValue,
+  protocolFee,
+  toToken,
+}: Props) {
+  const { t } = useTranslation();
+  const ethereumChain = useMainnet();
+  const gatewayAddress = getGatewayAddress(ethereumChain.id);
+
+  const { data: needsApproval } = useNeedsApproval({
+    amount: amountBigInt,
+    spender: gatewayAddress,
+    token: fromToken,
+  });
+
+  const { fees: approvalFee, isError: isApprovalFeeError } =
+    useEstimateApproveErc20Fees({
+      amount: approveAmount ?? amountBigInt,
+      enabled: needsApproval,
+      spender: gatewayAddress,
+      token: fromToken,
+    });
+
+  const {
+    fees: operationFee,
+    isEnabled: isOperationGasEstimationEnabled,
+    isError: isOperationFeeError,
+  } = operationGasEstimation;
+
+  const { data: protocolFeeData, isError: isProtocolFeeError } = protocolFee;
+
+  const networkFeeWei = needsApproval
+    ? sumFees([approvalFee, operationFee])
+    : operationFee;
+
+  const hasNetworkFeeError = needsApproval
+    ? isApprovalFeeError || isOperationFeeError
+    : isOperationFeeError;
+
+  const totalFeesWei = sumFees([networkFeeWei, protocolFeeData]);
+
+  const networkFeeDisplay = formatAmount({
+    amount: networkFeeWei,
+    decimals: ethereumChain.nativeCurrency.decimals,
+    isError: hasNetworkFeeError,
+    symbol: ethereumChain.nativeCurrency.symbol,
+  });
+
+  const protocolFeeDisplay = formatAmount({
+    amount: protocolFeeData,
+    decimals: ethereumChain.nativeCurrency.decimals,
+    isError: isProtocolFeeError,
+    symbol: ethereumChain.nativeCurrency.symbol,
+  });
+
+  const totalFeesDisplay = formatAmount({
+    amount: totalFeesWei,
+    decimals: ethereumChain.nativeCurrency.decimals,
+    isError: hasNetworkFeeError || isProtocolFeeError,
+    symbol: ethereumChain.nativeCurrency.symbol,
+  });
+
+  const label = `${fromInputValue} ${fromToken.symbol} = ${outputValue} ${toToken.symbol}`;
+
+  return (
+    <div className="w-full max-w-md border-t border-gray-200">
+      <FeesContainer
+        label={label}
+        totalFees={isOperationGasEstimationEnabled ? totalFeesDisplay : "-"}
+      >
+        <FeeDetails
+          label={t("pages.swap.fees.network-fee")}
+          value={isOperationGasEstimationEnabled ? networkFeeDisplay : "-"}
+        />
+        <FeeDetails
+          label={t("pages.swap.fees.fixed-protocol-fee")}
+          value={protocolFeeDisplay}
+        />
+      </FeesContainer>
+    </div>
+  );
+};

--- a/web/src/hooks/useEstimateDepositGas.ts
+++ b/web/src/hooks/useEstimateDepositGas.ts
@@ -1,0 +1,70 @@
+import { useEstimateFees } from "@hemilabs/react-hooks/useEstimateFees";
+import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
+import { getGatewayAddress } from "@vetro/gateway";
+import { encodeDeposit } from "@vetro/gateway/actions";
+import type { Token } from "types";
+import { createErc20AllowanceStateOverride } from "utils/erc20StateOverride";
+import { zeroAddress } from "viem";
+import { useAccount, useEstimateGas } from "wagmi";
+
+import { useMainnet } from "./useMainnet";
+
+type Params = {
+  amountIn: bigint;
+  minPeggedTokenOut: bigint | undefined;
+  token: Token;
+};
+
+export const useEstimateDepositGas = function ({
+  amountIn,
+  minPeggedTokenOut,
+  token,
+}: Params) {
+  const { address } = useAccount();
+  const ethereumChain = useMainnet();
+  const { data: tokenBalance } = useTokenBalance(token);
+
+  const gatewayAddress = getGatewayAddress(ethereumChain.id);
+
+  const data = encodeDeposit({
+    amountIn,
+    minPeggedTokenOut: minPeggedTokenOut ?? 0n,
+    receiver: address ?? zeroAddress,
+    tokenIn: token.address,
+  });
+
+  const {
+    data: gasUnits,
+    isEnabled,
+    isError: isGasUnitsError,
+  } = useEstimateGas({
+    chainId: ethereumChain.id,
+    data,
+    query: {
+      enabled:
+        address !== undefined &&
+        amountIn > 0n &&
+        minPeggedTokenOut !== undefined &&
+        minPeggedTokenOut > 0n &&
+        tokenBalance !== undefined &&
+        tokenBalance >= amountIn,
+    },
+    stateOverride: createErc20AllowanceStateOverride({
+      owner: address,
+      spender: gatewayAddress,
+      token,
+    }),
+    to: gatewayAddress,
+  });
+
+  const feeEstimation = useEstimateFees({
+    chainId: ethereumChain.id,
+    gasUnits,
+    isGasUnitsError,
+  });
+
+  return {
+    ...feeEstimation,
+    isEnabled,
+  };
+};

--- a/web/src/hooks/useEstimateRedeemGas.ts
+++ b/web/src/hooks/useEstimateRedeemGas.ts
@@ -1,0 +1,74 @@
+import { useEstimateFees } from "@hemilabs/react-hooks/useEstimateFees";
+import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
+import { getGatewayAddress } from "@vetro/gateway";
+import { encodeRedeem } from "@vetro/gateway/actions";
+import type { Token } from "types";
+import { createErc20AllowanceStateOverride } from "utils/erc20StateOverride";
+import { zeroAddress, type Address } from "viem";
+import { useEstimateGas } from "wagmi";
+
+import { useMainnet } from "./useMainnet";
+
+type Params = {
+  enabled?: boolean;
+  minAmountOut: bigint;
+  peggedToken: Token;
+  peggedTokenIn: bigint;
+  receiver: Address;
+  tokenOut: Address;
+};
+
+export const useEstimateRedeemGas = function ({
+  enabled = true,
+  minAmountOut,
+  peggedToken,
+  peggedTokenIn,
+  receiver,
+  tokenOut,
+}: Params) {
+  const ethereumChain = useMainnet();
+  const { data: tokenBalance } = useTokenBalance(peggedToken);
+
+  const gatewayAddress = getGatewayAddress(ethereumChain.id);
+
+  const data = encodeRedeem({
+    minAmountOut,
+    peggedTokenIn,
+    receiver: receiver ?? zeroAddress,
+    tokenOut,
+  });
+
+  const {
+    data: gasUnits,
+    isEnabled,
+    isError: isGasUnitsError,
+  } = useEstimateGas({
+    chainId: ethereumChain.id,
+    data,
+    query: {
+      enabled:
+        enabled &&
+        peggedTokenIn > 0n &&
+        minAmountOut > 0n &&
+        tokenBalance !== undefined &&
+        tokenBalance >= peggedTokenIn,
+    },
+    stateOverride: createErc20AllowanceStateOverride({
+      owner: receiver,
+      spender: gatewayAddress,
+      token: peggedToken,
+    }),
+    to: gatewayAddress,
+  });
+
+  const feeEstimation = useEstimateFees({
+    chainId: ethereumChain.id,
+    gasUnits,
+    isGasUnitsError,
+  });
+
+  return {
+    ...feeEstimation,
+    isEnabled,
+  };
+};

--- a/web/src/hooks/useEstimateRedeemGas.ts
+++ b/web/src/hooks/useEstimateRedeemGas.ts
@@ -14,7 +14,7 @@ type Params = {
   minAmountOut: bigint;
   peggedToken: Token;
   peggedTokenIn: bigint;
-  receiver: Address;
+  receiver: Address | undefined;
   tokenOut: Address;
 };
 

--- a/web/src/hooks/useWhitelistedTokens.ts
+++ b/web/src/hooks/useWhitelistedTokens.ts
@@ -7,6 +7,9 @@ const whitelistedTokens: Token[] = [
     address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     chainId: mainnet.id,
     decimals: 6,
+    extensions: {
+      allowanceSlot: 10n,
+    },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/usdc.svg",
     name: "USD Coin",
     symbol: "USDC",
@@ -15,6 +18,9 @@ const whitelistedTokens: Token[] = [
     address: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
     chainId: mainnet.id,
     decimals: 6,
+    extensions: {
+      allowanceSlot: 5n,
+    },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/usdt.svg",
     name: "Tether USD",
     symbol: "USDT",

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -4,6 +4,9 @@ export type Token = {
   address: Address;
   chainId: Chain["id"];
   decimals: number;
+  extensions?: {
+    allowanceSlot?: bigint;
+  };
   logoURI: string;
   name: string;
   symbol: string;

--- a/web/src/utils/erc20StateOverride.ts
+++ b/web/src/utils/erc20StateOverride.ts
@@ -7,11 +7,11 @@ import {
   toHex,
 } from "viem";
 
-// The operation requires the user has enough allowance to estimate it
-// but if the user needs to approve some amount (because it has no allowance), the estimation will revert!.
-// The revert error in the estimation is that the user has not enough allowance.
-// This override of the state here let's us update the internal state so the user does not have to
-// make an approval to perform the operation, and thus, the estimation can be calculated.
+// The operation requires the user to have enough allowance for gas estimation to succeed,
+// but if the user needs to approve some amount (because they currently have no allowance),
+// the estimation call will revert due to insufficient allowance.
+// This state override lets us update the internal storage view so the user does not have to
+// perform an approval transaction before the operation, and thus the gas estimation can be calculated.
 // Thanks, Claude!
 export function createErc20AllowanceStateOverride({
   owner,

--- a/web/src/utils/erc20StateOverride.ts
+++ b/web/src/utils/erc20StateOverride.ts
@@ -1,0 +1,52 @@
+import type { Token } from "types";
+import {
+  type Address,
+  encodeAbiParameters,
+  keccak256,
+  maxUint256,
+  toHex,
+} from "viem";
+
+// The operation requires the user has enough allowance to estimate it
+// but if the user needs to approve some amount (because it has no allowance), the estimation will revert!.
+// The revert error in the estimation is that the user has not enough allowance.
+// This override of the state here let's us update the internal state so the user does not have to
+// make an approval to perform the operation, and thus, the estimation can be calculated.
+// Thanks, Claude!
+export function createErc20AllowanceStateOverride({
+  owner,
+  spender,
+  token,
+}: {
+  owner: Address | undefined;
+  spender: Address;
+  token: Token;
+}) {
+  if (!owner) {
+    return [];
+  }
+  const ownerSlot = keccak256(
+    encodeAbiParameters(
+      [{ type: "address" }, { type: "uint256" }],
+      // 1n is the default allowance slot for ERC20 tokens using OpenZeppelin's implementation
+      [owner, token.extensions?.allowanceSlot ?? 1n],
+    ),
+  );
+  const slot = keccak256(
+    encodeAbiParameters(
+      [{ type: "address" }, { type: "bytes32" }],
+      [spender, ownerSlot],
+    ),
+  );
+  return [
+    {
+      address: token.address,
+      stateDiff: [
+        {
+          slot,
+          value: toHex(maxUint256, { size: 32 }),
+        },
+      ],
+    },
+  ];
+}

--- a/web/src/utils/token.ts
+++ b/web/src/utils/token.ts
@@ -20,6 +20,7 @@ type FormatAmountParams = {
   amount: bigint | undefined;
   decimals: number;
   isError: boolean;
+  symbol?: string;
 };
 
 /**
@@ -34,9 +35,11 @@ export function formatAmount({
   amount,
   decimals,
   isError,
+  symbol,
 }: FormatAmountParams) {
   if (amount !== undefined) {
-    return formatUnits(amount, decimals);
+    const formatted = formatUnits(amount, decimals);
+    return symbol ? `${formatted} ${symbol}` : formatted;
   }
 
   if (isError) {

--- a/web/test/utils/token.test.ts
+++ b/web/test/utils/token.test.ts
@@ -86,6 +86,50 @@ describe("utils/token", function () {
 
       expect(result).toBe("0.000000000000000001");
     });
+
+    it("appends symbol when amount is defined", function () {
+      const result = formatAmount({
+        amount: BigInt(1000000000000000000),
+        decimals,
+        isError: false,
+        symbol: "ETH",
+      });
+
+      expect(result).toBe("1 ETH");
+    });
+
+    it("appends symbol when amount is zero", function () {
+      const result = formatAmount({
+        amount: 0n,
+        decimals,
+        isError: false,
+        symbol: "ETH",
+      });
+
+      expect(result).toBe("0 ETH");
+    });
+
+    it('returns "..." without symbol when loading', function () {
+      const result = formatAmount({
+        amount: undefined,
+        decimals,
+        isError: false,
+        symbol: "ETH",
+      });
+
+      expect(result).toBe("...");
+    });
+
+    it('returns "-" without symbol when error', function () {
+      const result = formatAmount({
+        amount: undefined,
+        decimals,
+        isError: true,
+        symbol: "ETH",
+      });
+
+      expect(result).toBe("-");
+    });
   });
 
   describe("parseTokenUnits", function () {


### PR DESCRIPTION
### Description

This PR adds comprehensive fee details display to both deposit and redeem swap forms. Users can now see a breakdown of network fees (including approval costs when needed) and fixed protocol fees before executing transactions.

**Key changes:**
- Added `SwapFees` component to display fee breakdown with expandable details
- Created `useEstimateDepositGas` and `useEstimateRedeemGas` hooks to calculate network fees
- Added ERC20 state override utility to enable gas estimation without requiring actual approvals
- Enhanced `formatAmount` utility to optionally include token symbols
- Added `allowanceSlot` extension to token types for accurate state overrides
- Bumped `@hemilabs/react-hooks` to v1.3.0 for `useMintFee` and `useRedeemFee` support

**Commits:**
- 8f10af4 Bump @hemilabs/react-hook to 1.3.0
- d702283 Add optional symbol when formatting amounts
- f49ebf3 Add hooks to estimate deposit and redeem
- e5c3a01 Add swap fees

### Screenshots

<!-- Please add screenshots showing the fee details UI -->

https://github.com/user-attachments/assets/ee9782af-d147-4b89-927a-424c19df4c38

### Related issue(s)

Related to #6

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.