### PR TITLE
Add real gas estimation to stake forms

### DIFF
--- a/web/.env
+++ b/web/.env
@@ -1,1 +1,1 @@
-VITE_PORTAL_API_URL="http://localhost:3006"
+VITE_PORTAL_API_URL="https://portal-api.hemi.xyz"

--- a/web/.env
+++ b/web/.env
@@ -1,0 +1,1 @@
+VITE_PORTAL_API_URL="http://localhost:3006"

--- a/web/src/components/feeDetails.tsx
+++ b/web/src/components/feeDetails.tsx
@@ -1,11 +1,28 @@
+import Skeleton from "react-loading-skeleton";
+
 type Props = {
+  isError?: boolean;
   label: string;
-  value: string;
+  value?: string;
 };
 
-export const FeeDetails = ({ label, value }: Props) => (
-  <div className="text-xsm flex cursor-default items-center justify-between border-t border-gray-200 px-2 py-3">
-    <span className="text-gray-500">{label}</span>
-    <span className="font-semibold text-gray-900">{value}</span>
-  </div>
-);
+export function FeeDetails({ isError, label, value }: Props) {
+  function renderValue() {
+    if (value !== undefined) {
+      return value;
+    }
+
+    if (isError) {
+      return "-";
+    }
+
+    return <Skeleton width={50} />;
+  }
+
+  return (
+    <div className="text-xsm flex cursor-default items-center justify-between border-t border-gray-200 px-2 py-3">
+      <span className="text-gray-500">{label}</span>
+      <span className="font-semibold text-gray-900">{renderValue()}</span>
+    </div>
+  );
+}

--- a/web/src/components/feeDetails.tsx
+++ b/web/src/components/feeDetails.tsx
@@ -7,22 +7,13 @@ type Props = {
 };
 
 export function FeeDetails({ isError, label, value }: Props) {
-  function renderValue() {
-    if (value !== undefined) {
-      return value;
-    }
-
-    if (isError) {
-      return "-";
-    }
-
-    return <Skeleton width={50} />;
-  }
+  const renderedValue =
+    value !== undefined ? value : isError ? "-" : <Skeleton width={50} />;
 
   return (
     <div className="text-xsm flex cursor-default items-center justify-between border-t border-gray-200 px-2 py-3">
       <span className="text-gray-500">{label}</span>
-      <span className="font-semibold text-gray-900">{renderValue()}</span>
+      <span className="font-semibold text-gray-900">{renderedValue}</span>
     </div>
   );
 }

--- a/web/src/components/feesContainer.tsx
+++ b/web/src/components/feesContainer.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useState } from "react";
 import Skeleton from "react-loading-skeleton";
 
+import { ButtonIcon } from "./base/button";
 import { ChevronIcon } from "./base/chevronIcon";
 import feesSvg from "./icons/fees.svg";
 
@@ -14,26 +15,24 @@ type Props = {
 export function FeesContainer({ children, isError, label, totalFees }: Props) {
   const [isOpen, setIsOpen] = useState(false);
 
-  function renderTotalFees() {
-    if (totalFees !== undefined) {
-      return totalFees;
-    }
-
-    if (isError) {
-      return "-";
-    }
-
-    return <Skeleton width={50} />;
-  }
+  const renderedTotalFees =
+    totalFees !== undefined ? (
+      totalFees
+    ) : isError ? (
+      "-"
+    ) : (
+      <Skeleton width={50} />
+    );
 
   return (
     <div className={`w-full border-b border-gray-200`}>
-      <button
+      <div
         aria-controls="fees-list"
         aria-expanded={isOpen}
         className="text-xsm flex h-11 w-full cursor-pointer items-center justify-between px-2 py-3"
         onClick={() => setIsOpen(!isOpen)}
-        type="button"
+        role="button"
+        tabIndex={0}
       >
         <span className="font-semibold text-gray-900">{label}</span>
         <div className="flex items-center gap-2">
@@ -41,19 +40,22 @@ export function FeesContainer({ children, isError, label, totalFees }: Props) {
             <>
               <img alt="Fees icon" height="16" src={feesSvg} width="16" />
               <span className="font-semibold text-gray-500">
-                {renderTotalFees()}
+                {renderedTotalFees}
               </span>
             </>
           )}
-          <ChevronIcon direction={isOpen ? "up" : "down"} />
+          <ButtonIcon variant="tertiary">
+            <ChevronIcon direction={isOpen ? "up" : "down"} />
+          </ButtonIcon>
         </div>
-      </button>
+      </div>
 
-      {isOpen && (
-        <div aria-hidden={!isOpen} id="fees-list">
-          {children}
-        </div>
-      )}
+      <div
+        className={`grid transition-[grid-template-rows] duration-200 ease-out ${isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"}`}
+        id="fees-list"
+      >
+        <div className="overflow-hidden">{children}</div>
+      </div>
     </div>
   );
 }

--- a/web/src/components/feesContainer.tsx
+++ b/web/src/components/feesContainer.tsx
@@ -1,16 +1,30 @@
 import { type ReactNode, useState } from "react";
+import Skeleton from "react-loading-skeleton";
 
 import { ChevronIcon } from "./base/chevronIcon";
 import feesSvg from "./icons/fees.svg";
 
 type Props = {
   children: ReactNode;
+  isError?: boolean;
   label: string;
-  totalFees: string;
+  totalFees?: string;
 };
 
-export const FeesContainer = function ({ children, label, totalFees }: Props) {
+export function FeesContainer({ children, isError, label, totalFees }: Props) {
   const [isOpen, setIsOpen] = useState(false);
+
+  function renderTotalFees() {
+    if (totalFees !== undefined) {
+      return totalFees;
+    }
+
+    if (isError) {
+      return "-";
+    }
+
+    return <Skeleton width={50} />;
+  }
 
   return (
     <div className={`w-full border-b border-gray-200`}>
@@ -26,7 +40,9 @@ export const FeesContainer = function ({ children, label, totalFees }: Props) {
           {!isOpen && (
             <>
               <img alt="Fees icon" height="16" src={feesSvg} width="16" />
-              <span className="font-semibold text-gray-500">{totalFees}</span>
+              <span className="font-semibold text-gray-500">
+                {renderTotalFees()}
+              </span>
             </>
           )}
           <ChevronIcon direction={isOpen ? "up" : "down"} />
@@ -40,4 +56,4 @@ export const FeesContainer = function ({ children, label, totalFees }: Props) {
       )}
     </div>
   );
-};
+}

--- a/web/src/hooks/useEthPrice.ts
+++ b/web/src/hooks/useEthPrice.ts
@@ -9,13 +9,22 @@ type PricesResponse = {
   time: string;
 };
 
+function parseEthPrice(data: PricesResponse) {
+  const ethPriceRaw = data?.prices?.ETH;
+  const ethPrice =
+    typeof ethPriceRaw === "string" ? parseFloat(ethPriceRaw) : NaN;
+
+  if (!Number.isFinite(ethPrice)) {
+    throw new Error("Invalid ETH price received from API");
+  }
+
+  return ethPrice;
+}
+
 export const useEthPrice = () =>
   useQuery({
     enabled: apiUrl !== undefined && isValidUrl(apiUrl),
-    queryFn: () =>
-      fetch(`${apiUrl}/prices`).then((data: PricesResponse) =>
-        parseFloat(data.prices.ETH),
-      ),
+    queryFn: () => fetch(`${apiUrl}/prices`).then(parseEthPrice),
     queryKey: ["eth-price"],
     refetchInterval: 60 * 1000, // 1 minute
     retry: 2,

--- a/web/src/hooks/useEthPrice.ts
+++ b/web/src/hooks/useEthPrice.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import fetch from "fetch-plus-plus";
+import { isValidUrl } from "utils/url";
+
+const apiUrl = import.meta.env.VITE_PORTAL_API_URL;
+
+type PricesResponse = {
+  prices: Record<string, string>;
+  time: string;
+};
+
+export const useEthPrice = () =>
+  useQuery({
+    enabled: apiUrl !== undefined && isValidUrl(apiUrl),
+    queryFn: () =>
+      fetch(`${apiUrl}/prices`).then((data: PricesResponse) =>
+        parseFloat(data.prices.ETH),
+      ),
+    queryKey: ["eth-price"],
+    refetchInterval: 60 * 1000, // 1 minute
+    retry: 2,
+    staleTime: 30 * 1000, // 30 seconds
+  });

--- a/web/src/hooks/useNetworkFee.ts
+++ b/web/src/hooks/useNetworkFee.ts
@@ -8,6 +8,24 @@ type Props = {
   isError: boolean;
 };
 
+function formatFeeInUsd(feeInUsd: number) {
+  if (feeInUsd > 0 && feeInUsd < 0.01) {
+    return "<$0.01";
+  }
+  return `$${feeInUsd.toFixed(2)}`;
+}
+
+function calculateFee(fees: bigint, ethPrice: number, decimals: number) {
+  const gasInEth = parseFloat(formatUnits(fees, decimals));
+  const feeInUsd = gasInEth * ethPrice;
+
+  if (!Number.isFinite(gasInEth) || !Number.isFinite(feeInUsd)) {
+    return undefined;
+  }
+
+  return formatFeeInUsd(feeInUsd);
+}
+
 export function useNetworkFee({ fees, isError: isGasError }: Props) {
   const {
     data: ethPrice,
@@ -17,15 +35,15 @@ export function useNetworkFee({ fees, isError: isGasError }: Props) {
   const { nativeCurrency } = useMainnet();
 
   const isError = isGasError || isPriceError;
+  const canCalculate =
+    fees !== undefined && ethPrice !== undefined && Number.isFinite(ethPrice);
 
-  if (fees !== undefined && ethPrice !== undefined) {
-    const gasInEth = parseFloat(formatUnits(fees, nativeCurrency.decimals));
-    const feeInUsd = gasInEth * ethPrice;
-
-    const formattedFee =
-      feeInUsd > 0 && feeInUsd < 0.01 ? "<$0.01" : `$${feeInUsd.toFixed(2)}`;
-
-    return { data: formattedFee, isError: false, isLoading: false };
+  if (canCalculate) {
+    const formattedFee = calculateFee(fees, ethPrice, nativeCurrency.decimals);
+    if (formattedFee !== undefined) {
+      return { data: formattedFee, isError: false, isLoading: false };
+    }
+    return { data: undefined, isError: true, isLoading: false };
   }
 
   if (isError) {

--- a/web/src/hooks/useNetworkFee.ts
+++ b/web/src/hooks/useNetworkFee.ts
@@ -5,6 +5,7 @@ import { useMainnet } from "./useMainnet";
 
 type Props = {
   fees: bigint | undefined;
+  isEnabled?: boolean;
   isError: boolean;
 };
 
@@ -26,7 +27,11 @@ function calculateFee(fees: bigint, ethPrice: number, decimals: number) {
   return formatFeeInUsd(feeInUsd);
 }
 
-export function useNetworkFee({ fees, isError: isGasError }: Props) {
+export function useNetworkFee({
+  fees,
+  isEnabled = true,
+  isError: isGasError,
+}: Props) {
   const {
     data: ethPrice,
     isError: isPriceError,
@@ -41,13 +46,13 @@ export function useNetworkFee({ fees, isError: isGasError }: Props) {
   if (canCalculate) {
     const formattedFee = calculateFee(fees, ethPrice, nativeCurrency.decimals);
     if (formattedFee !== undefined) {
-      return { data: formattedFee, isError: false, isLoading: false };
+      return { data: formattedFee, isError: false };
     }
-    return { data: undefined, isError: true, isLoading: false };
+    return { data: undefined, isError: true };
   }
 
-  if (isError) {
-    return { data: undefined, isError: true, isLoading: false };
+  if (isError || !isEnabled) {
+    return { data: undefined, isError: true };
   }
 
   return {

--- a/web/src/hooks/useNetworkFee.ts
+++ b/web/src/hooks/useNetworkFee.ts
@@ -1,0 +1,40 @@
+import { formatUnits } from "viem";
+
+import { useEthPrice } from "./useEthPrice";
+import { useMainnet } from "./useMainnet";
+
+type Props = {
+  fees: bigint | undefined;
+  isError: boolean;
+};
+
+export function useNetworkFee({ fees, isError: isGasError }: Props) {
+  const {
+    data: ethPrice,
+    isError: isPriceError,
+    isLoading: isPriceLoading,
+  } = useEthPrice();
+  const { nativeCurrency } = useMainnet();
+
+  const isError = isGasError || isPriceError;
+
+  if (fees !== undefined && ethPrice !== undefined) {
+    const gasInEth = parseFloat(formatUnits(fees, nativeCurrency.decimals));
+    const feeInUsd = gasInEth * ethPrice;
+
+    const formattedFee =
+      feeInUsd > 0 && feeInUsd < 0.01 ? "<$0.01" : `$${feeInUsd.toFixed(2)}`;
+
+    return { data: formattedFee, isError: false, isLoading: false };
+  }
+
+  if (isError) {
+    return { data: undefined, isError: true, isLoading: false };
+  }
+
+  return {
+    data: undefined,
+    isError: false,
+    isLoading: isPriceLoading || fees === undefined,
+  };
+}

--- a/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
@@ -9,6 +9,7 @@ import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
 import { useMainnet } from "hooks/useMainnet";
 import { useStakeDeposit } from "hooks/useStakeDeposit";
 import { useVusd } from "hooks/useVusd";
+import { useDepositFees } from "pages/earn/hooks/useDepositFees";
 import type { FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { formatAmount } from "utils/token";
@@ -49,7 +50,7 @@ export function StakeDepositForm({
   onClose,
   onInputChange,
 }: Props) {
-  const { isConnected } = useAccount();
+  const { address: account, isConnected } = useAccount();
   const chain = useMainnet();
   const { openConnectModal } = useConnectModal();
   const { t } = useTranslation();
@@ -67,6 +68,13 @@ export function StakeDepositForm({
 
   const depositMutation = useStakeDeposit({
     assets: amountBigInt,
+  });
+
+  const { data: networkFee, isError: isFeeError } = useDepositFees({
+    account,
+    amount: amountBigInt,
+    isConnected,
+    token: vusd,
   });
 
   const inputError = getStakeErrors({
@@ -96,9 +104,6 @@ export function StakeDepositForm({
       });
     }
   }
-
-  // TODO: implement real gas estimation
-  const networkFee = "$0.40";
 
   return (
     <form className="flex flex-col" onSubmit={handleSubmit}>
@@ -131,6 +136,7 @@ export function StakeDepositForm({
 
       <div className="px-6">
         <FeesContainer
+          isError={isFeeError}
           label={t("pages.earn.stake.fees-label", {
             amount: inputValue,
             token: vusd.symbol,
@@ -138,6 +144,7 @@ export function StakeDepositForm({
           totalFees={networkFee}
         >
           <FeeDetails
+            isError={isFeeError}
             label={t("pages.swap.fees.network-fee")}
             value={networkFee}
           />

--- a/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
@@ -9,6 +9,7 @@ import { useMainnet } from "hooks/useMainnet";
 import { useStakedBalance } from "hooks/useStakedBalance";
 import { useStakeWithdraw } from "hooks/useStakeWithdraw";
 import { useVusd } from "hooks/useVusd";
+import { useWithdrawFees } from "pages/earn/hooks/useWithdrawFees";
 import type { FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { formatAmount } from "utils/token";
@@ -50,7 +51,7 @@ export function StakeWithdrawForm({
   onClose,
   onInputChange,
 }: Props) {
-  const { isConnected } = useAccount();
+  const { address: account, isConnected } = useAccount();
   const chain = useMainnet();
   const { openConnectModal } = useConnectModal();
   const { t } = useTranslation();
@@ -66,6 +67,12 @@ export function StakeWithdrawForm({
 
   const withdrawMutation = useStakeWithdraw({
     assets: amountBigInt,
+  });
+
+  const { data: networkFee, isError: isFeeError } = useWithdrawFees({
+    account,
+    amount: amountBigInt,
+    isConnected,
   });
 
   const inputError = getWithdrawErrors({
@@ -95,9 +102,6 @@ export function StakeWithdrawForm({
       });
     }
   }
-
-  // TODO: implement real gas estimation
-  const networkFee = "$0.40";
 
   return (
     <form className="flex flex-1 flex-col" onSubmit={handleSubmit}>
@@ -133,6 +137,7 @@ export function StakeWithdrawForm({
 
       <div className="px-6">
         <FeesContainer
+          isError={isFeeError}
           label={t("pages.earn.stake.withdrawing-fees-label", {
             amount: inputValue,
             token: vusd.symbol,
@@ -140,6 +145,7 @@ export function StakeWithdrawForm({
           totalFees={networkFee}
         >
           <FeeDetails
+            isError={isFeeError}
             label={t("pages.swap.fees.network-fee")}
             value={networkFee}
           />

--- a/web/src/pages/earn/hooks/useDepositFees.ts
+++ b/web/src/pages/earn/hooks/useDepositFees.ts
@@ -1,0 +1,88 @@
+import { useEstimateApproveErc20Fees } from "@hemilabs/react-hooks/useEstimateApproveErc20Fees";
+import { useEstimateFees } from "@hemilabs/react-hooks/useEstimateFees";
+import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
+import { getStakingVaultAddress, stakingVaultAbi } from "@vetro/earn";
+import { useMainnet } from "hooks/useMainnet";
+import { useNetworkFee } from "hooks/useNetworkFee";
+import type { Token } from "types";
+import { createErc20AllowanceStateOverride } from "utils/erc20StateOverride";
+import { type Address, encodeFunctionData, zeroAddress } from "viem";
+import { useEstimateGas } from "wagmi";
+
+type Params = {
+  account: Address | undefined;
+  amount: bigint;
+  isConnected: boolean;
+  token: Token | undefined;
+};
+
+function sumFees(
+  approvalFees: bigint | undefined,
+  depositFees: bigint | undefined,
+) {
+  if (approvalFees !== undefined && depositFees !== undefined) {
+    return approvalFees + depositFees;
+  }
+  return depositFees;
+}
+
+export function useDepositFees({
+  account,
+  amount,
+  isConnected,
+  token,
+}: Params) {
+  const chain = useMainnet();
+  const stakingVaultAddress = getStakingVaultAddress(chain.id);
+  const tokenAddress = token?.address ?? zeroAddress;
+
+  const { data: tokenBalance } = useTokenBalance({
+    address: tokenAddress,
+    chainId: chain.id,
+  });
+
+  const hasEnoughBalance = tokenBalance !== undefined && tokenBalance >= amount;
+  const canEstimate =
+    amount > 0n && isConnected && token !== undefined && hasEnoughBalance;
+
+  const stateOverride = token
+    ? createErc20AllowanceStateOverride({
+        owner: account,
+        spender: stakingVaultAddress,
+        token,
+      })
+    : [];
+
+  // Estimate gas for approve
+  const { fees: approvalFees, isError: isApprovalError } =
+    useEstimateApproveErc20Fees({
+      amount,
+      enabled: amount > 0n && token !== undefined,
+      spender: stakingVaultAddress,
+      token: { address: tokenAddress, chainId: chain.id },
+    });
+
+  // Estimate gas for deposit
+  const { data: depositGasUnits, isError: isDepositGasError } = useEstimateGas({
+    chainId: chain.id,
+    data: encodeFunctionData({
+      abi: stakingVaultAbi,
+      args: [amount, account ?? zeroAddress],
+      functionName: "deposit",
+    }),
+    query: { enabled: canEstimate },
+    stateOverride,
+    to: stakingVaultAddress,
+  });
+
+  const { fees: depositFees, isError: isDepositFeeError } = useEstimateFees({
+    chainId: chain.id,
+    gasUnits: depositGasUnits,
+    isGasUnitsError: isDepositGasError,
+  });
+
+  return useNetworkFee({
+    fees: sumFees(approvalFees, depositFees),
+    isError: isApprovalError || isDepositFeeError,
+  });
+}

--- a/web/src/pages/earn/hooks/useDepositFees.ts
+++ b/web/src/pages/earn/hooks/useDepositFees.ts
@@ -57,7 +57,7 @@ export function useDepositFees({
   const { fees: approvalFees, isError: isApprovalError } =
     useEstimateApproveErc20Fees({
       amount,
-      enabled: amount > 0n && token !== undefined,
+      enabled: canEstimate,
       spender: stakingVaultAddress,
       token: { address: tokenAddress, chainId: chain.id },
     });

--- a/web/src/pages/earn/hooks/useDepositFees.ts
+++ b/web/src/pages/earn/hooks/useDepositFees.ts
@@ -83,6 +83,7 @@ export function useDepositFees({
 
   return useNetworkFee({
     fees: sumFees(approvalFees, depositFees),
+    isEnabled: canEstimate,
     isError: isApprovalError || isDepositFeeError,
   });
 }

--- a/web/src/pages/earn/hooks/useWithdrawFees.ts
+++ b/web/src/pages/earn/hooks/useWithdrawFees.ts
@@ -17,6 +17,11 @@ export function useWithdrawFees({ account, amount, isConnected }: Params) {
   const stakingVaultAddress = getStakingVaultAddress(chain.id);
   const { data: stakedBalance } = useStakedBalance();
 
+  const hasEnoughBalance =
+    stakedBalance !== undefined && stakedBalance >= amount;
+  const canEstimate =
+    amount > 0n && isConnected && account !== undefined && hasEnoughBalance;
+
   // Estimate gas for requestWithdraw
   const { data: withdrawGasUnits, isError: isGasError } = useEstimateGas({
     chainId: chain.id,
@@ -25,13 +30,7 @@ export function useWithdrawFees({ account, amount, isConnected }: Params) {
       args: [amount, account ?? zeroAddress],
       functionName: "requestWithdraw",
     }),
-    query: {
-      enabled:
-        amount > 0n &&
-        isConnected &&
-        stakedBalance !== undefined &&
-        stakedBalance >= amount,
-    },
+    query: { enabled: canEstimate },
     to: stakingVaultAddress,
   });
 

--- a/web/src/pages/earn/hooks/useWithdrawFees.ts
+++ b/web/src/pages/earn/hooks/useWithdrawFees.ts
@@ -23,7 +23,11 @@ export function useWithdrawFees({ account, amount, isConnected }: Params) {
     amount > 0n && isConnected && account !== undefined && hasEnoughBalance;
 
   // Estimate gas for requestWithdraw
-  const { data: withdrawGasUnits, isError: isGasError } = useEstimateGas({
+  const {
+    data: withdrawGasUnits,
+    isEnabled,
+    isError: isGasError,
+  } = useEstimateGas({
     chainId: chain.id,
     data: encodeFunctionData({
       abi: stakingVaultAbi,
@@ -42,6 +46,7 @@ export function useWithdrawFees({ account, amount, isConnected }: Params) {
 
   return useNetworkFee({
     fees: withdrawFees,
+    isEnabled,
     isError: isFeeEstimateError,
   });
 }

--- a/web/src/pages/earn/hooks/useWithdrawFees.ts
+++ b/web/src/pages/earn/hooks/useWithdrawFees.ts
@@ -1,0 +1,48 @@
+import { useEstimateFees } from "@hemilabs/react-hooks/useEstimateFees";
+import { getStakingVaultAddress, stakingVaultAbi } from "@vetro/earn";
+import { useMainnet } from "hooks/useMainnet";
+import { useNetworkFee } from "hooks/useNetworkFee";
+import { useStakedBalance } from "hooks/useStakedBalance";
+import { type Address, encodeFunctionData, zeroAddress } from "viem";
+import { useEstimateGas } from "wagmi";
+
+type Params = {
+  account: Address | undefined;
+  amount: bigint;
+  isConnected: boolean;
+};
+
+export function useWithdrawFees({ account, amount, isConnected }: Params) {
+  const chain = useMainnet();
+  const stakingVaultAddress = getStakingVaultAddress(chain.id);
+  const { data: stakedBalance } = useStakedBalance();
+
+  // Estimate gas for requestWithdraw
+  const { data: withdrawGasUnits, isError: isGasError } = useEstimateGas({
+    chainId: chain.id,
+    data: encodeFunctionData({
+      abi: stakingVaultAbi,
+      args: [amount, account ?? zeroAddress],
+      functionName: "requestWithdraw",
+    }),
+    query: {
+      enabled:
+        amount > 0n &&
+        isConnected &&
+        stakedBalance !== undefined &&
+        stakedBalance >= amount,
+    },
+    to: stakingVaultAddress,
+  });
+
+  const { fees: withdrawFees, isError: isFeeEstimateError } = useEstimateFees({
+    chainId: chain.id,
+    gasUnits: withdrawGasUnits,
+    isGasUnitsError: isGasError,
+  });
+
+  return useNetworkFee({
+    fees: withdrawFees,
+    isError: isFeeEstimateError,
+  });
+}

--- a/web/src/utils/erc20StateOverride.ts
+++ b/web/src/utils/erc20StateOverride.ts
@@ -12,7 +12,6 @@ import {
 // the estimation call will revert due to insufficient allowance.
 // This state override lets us update the internal storage view so the user does not have to
 // perform an approval transaction before the operation, and thus the gas estimation can be calculated.
-// Thanks, Claude!
 export function createErc20AllowanceStateOverride({
   owner,
   spender,

--- a/web/stories/feesContainer.stories.tsx
+++ b/web/stories/feesContainer.stories.tsx
@@ -8,6 +8,9 @@ const meta: Meta<typeof FeesContainer> = {
     children: {
       control: false,
     },
+    isError: {
+      control: "boolean",
+    },
     label: {
       control: "text",
     },
@@ -33,6 +36,41 @@ export const Default: Story = {
     ),
     label: "1000 USDC = 999 VUSD",
     totalFees: "$0.40",
+  },
+  render: (args) => (
+    <div className="w-md">
+      <FeesContainer {...args} />
+    </div>
+  ),
+};
+
+export const Loading: Story = {
+  args: {
+    children: (
+      <>
+        <FeeDetails label="Network Fee" />
+        <FeeDetails label="Percentage Fee" />
+      </>
+    ),
+    label: "1000 USDC = 999 VUSD",
+  },
+  render: (args) => (
+    <div className="w-md">
+      <FeesContainer {...args} />
+    </div>
+  ),
+};
+
+export const Error: Story = {
+  args: {
+    children: (
+      <>
+        <FeeDetails isError label="Network Fee" />
+        <FeeDetails isError label="Percentage Fee" />
+      </>
+    ),
+    isError: true,
+    label: "1000 USDC = 999 VUSD",
   },
   render: (args) => (
     <div className="w-md">


### PR DESCRIPTION
### Description

This PR replaces placeholder fee with dynamic gas estimation in deposit and withdraw forms. Fetches ETH price from API and converts gas costs to USD.

Key changes:
- Add useEthPrice hook to fetch ETH/USD price
- Add useNetworkFee hook to convert gas to USD
- Add useDepositFees and useWithdrawFees hooks with state override to simulate allowance during estimation
- Update FeeDetails and FeesContainer to handle loading/error states
- Bump @hemilabs/react-hooks to 1.3.0

### Screenshots

https://github.com/user-attachments/assets/a34b0427-b0a6-45e3-beab-61b29cb30666

### Related issue(s)

Related to #23 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
