### PR TITLE
Timestamps are strings!

### DIFF
--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -35,20 +35,24 @@ export async function getApy() {
     end: end.toString(),
     start: start.toString(),
   };
-  const { vaultHistories: history } = await subgraph.runQuery<{
-    vaultHistories: { timestamp: number; shareValue: string }[];
+  const { vaultHistories } = await subgraph.runQuery<{
+    vaultHistories: { timestamp: string; shareValue: string }[];
   }>(query, variables);
-  if (!Array.isArray(history)) {
+  if (!Array.isArray(vaultHistories)) {
     throw new Error("Invalid subgraph response for vault history");
   }
-  if (!history.length || history.length < 2) {
+  if (!vaultHistories.length || vaultHistories.length < 2) {
     return {
       "7d": 0,
     };
   }
 
-  const days = history.map((h) => Math.floor(h.timestamp / secsPerDay));
-  const values = history.map((h) => parseBigIntStringToFloat(h.shareValue, 18));
+  const days = vaultHistories.map((h) =>
+    Math.floor(Number.parseInt(h.timestamp) / secsPerDay),
+  );
+  const values = vaultHistories.map((h) =>
+    parseBigIntStringToFloat(h.shareValue, 18),
+  );
   const delta = linearRegression(days, values).a;
   const apy = ((delta * 365) / values[values.length - 1]) * 100;
   return {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

As I suspected and :copilot: said in its [comment](https://github.com/vetro-protocol/vetro-monorepo/pull/47#pullrequestreview-3774256693) on PR #47, the `timestamp`s are returned as strings. It would have worked anyway but this PR makes that explicit.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #47

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
