### PR TITLE
Add configurable RPC URLs via env variables

### DIFF
--- a/web/.env
+++ b/web/.env
@@ -1,1 +1,4 @@
 VITE_PORTAL_API_URL="https://portal-api.hemi.xyz"
+VITE_RPC_URL_MAINNET=http://localhost:8545
+#VITE_RPC_URL_MAINNET=https://eth.llamarpc.com
+VITE_RPC_URL_SEPOLIA=https://rpc.sepolia.org

--- a/web/.env
+++ b/web/.env
@@ -1,4 +1,1 @@
 VITE_PORTAL_API_URL="https://portal-api.hemi.xyz"
-VITE_RPC_URL_MAINNET=http://localhost:8545
-#VITE_RPC_URL_MAINNET=https://eth.llamarpc.com
-VITE_RPC_URL_SEPOLIA=https://rpc.sepolia.org

--- a/web/src/networks/index.ts
+++ b/web/src/networks/index.ts
@@ -1,0 +1,2 @@
+export { mainnet } from "./mainnet";
+export { sepolia } from "./sepolia";

--- a/web/src/networks/mainnet.ts
+++ b/web/src/networks/mainnet.ts
@@ -1,0 +1,8 @@
+import { mainnet as mainnetDefinition } from "viem/chains";
+
+import { updateRpcUrls } from "./updateRpcUrls";
+
+export const mainnet = updateRpcUrls(
+  mainnetDefinition,
+  import.meta.env.VITE_RPC_URL_MAINNET,
+);

--- a/web/src/networks/sepolia.ts
+++ b/web/src/networks/sepolia.ts
@@ -1,0 +1,8 @@
+import { sepolia as sepoliaDefinition } from "viem/chains";
+
+import { updateRpcUrls } from "./updateRpcUrls";
+
+export const sepolia = updateRpcUrls(
+  sepoliaDefinition,
+  import.meta.env.VITE_RPC_URL_SEPOLIA,
+);

--- a/web/src/networks/updateRpcUrls.ts
+++ b/web/src/networks/updateRpcUrls.ts
@@ -1,0 +1,20 @@
+import { isValidUrl } from "utils/url";
+import { type Chain, defineChain } from "viem";
+
+export const updateRpcUrls = function (chain: Chain, rpcUrlEnv?: string) {
+  if (typeof rpcUrlEnv !== "string") {
+    return chain;
+  }
+  const urls = rpcUrlEnv.split("+").filter(isValidUrl);
+  if (urls.length > 0) {
+    return defineChain({
+      ...chain,
+      rpcUrls: {
+        default: {
+          http: urls,
+        },
+      },
+    });
+  }
+  return chain;
+};

--- a/web/src/providers/web3Provider.tsx
+++ b/web/src/providers/web3Provider.tsx
@@ -1,13 +1,18 @@
 import { getDefaultConfig, RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { mainnet, sepolia } from "viem/chains";
-import { WagmiProvider } from "wagmi";
+import { http, WagmiProvider } from "wagmi";
+
+import { mainnet, sepolia } from "../networks";
 
 const config = getDefaultConfig({
   appName: "Vetro",
   chains: [mainnet, sepolia],
   // TODO add project id for wallet connect
   projectId: "YOUR_PROJECT_ID_HERE",
+  transports: {
+    [mainnet.id]: http(),
+    [sepolia.id]: http(),
+  },
 });
 
 const queryClient = new QueryClient();


### PR DESCRIPTION
### Description

Allow overriding default RPC endpoints using `VITE_RPC_URL_MAINNET` and `VITE_RPC_URL_SEPOLIA` env vars. Supports multiple URLs separated by +.

### Screenshots

No UI changes.

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
