### PR TITLE
Add swap deposit drawer with progress tracking

### DIFF
--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -24,6 +24,8 @@ export { gatewayAbi } from "./abi/gatewayAbi.js";
 // Export gateway address utility
 export { getGatewayAddress } from "./getGatewayAddress.js";
 
+export { type DepositEvents, type RedeemEvents } from "./types.js";
+
 // Export factory functions for .extend() pattern
 export const gatewayPublicActions = () => (client: Client) => ({
   getMintFee: (params: Parameters<typeof getMintFee>[1]) =>

--- a/web/src/components/base/verticalStepper/index.tsx
+++ b/web/src/components/base/verticalStepper/index.tsx
@@ -59,7 +59,7 @@ export const VerticalStepper = ({ steps }: Props) => (
     {steps.map((step, index) => (
       <div className="flex gap-4" key={`${step.title}-${index}`}>
         {/* Step circle with connector line */}
-        <div className="relative flex shrink-0 flex-col items-center">
+        <div className="relative mt-0.5 flex shrink-0 flex-col items-center">
           {step.status === stepStatus.completed ? (
             <div className="relative z-10 flex size-4 items-center justify-center rounded-full bg-blue-500">
               <CheckIcon />
@@ -91,7 +91,7 @@ export const VerticalStepper = ({ steps }: Props) => (
         </div>
 
         {/* Step content */}
-        <div className="flex flex-col gap-0.5 text-sm leading-5">
+        <div className="text-xsm flex flex-col gap-0.5 leading-5">
           <p className="font-semibold text-gray-900">{step.title}</p>
           <p className="text-gray-500">{step.description}</p>
         </div>

--- a/web/src/components/base/verticalStepper/index.tsx
+++ b/web/src/components/base/verticalStepper/index.tsx
@@ -9,7 +9,7 @@ export const stepStatus = {
 
 type StepStatus = (typeof stepStatus)[keyof typeof stepStatus];
 
-type Step = {
+export type Step = {
   description: string;
   status: StepStatus;
   title: string;

--- a/web/src/components/feesContainer.tsx
+++ b/web/src/components/feesContainer.tsx
@@ -8,7 +8,7 @@ import feesSvg from "./icons/fees.svg";
 type Props = {
   children: ReactNode;
   isError?: boolean;
-  label: string;
+  label: ReactNode;
   totalFees?: string;
 };
 

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -1,5 +1,7 @@
 import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
+import { useNeedsApproval } from "@hemilabs/react-hooks/useNeedsApproval";
 import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
+import { getGatewayAddress } from "@vetro/gateway";
 import { ApproveSection } from "components/approveSection";
 import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
 import { TokenDropdown } from "components/tokenDropdown";
@@ -9,13 +11,15 @@ import { useEstimateDepositGas } from "hooks/useEstimateDepositGas";
 import { useMainnet } from "hooks/useMainnet";
 import { useMintFee } from "hooks/useMintFee";
 import { usePreviewDeposit } from "hooks/usePreviewDeposit";
-import { type FormEvent } from "react";
+import { useSwapFeesDisplay } from "hooks/useSwapFeesDisplay";
+import { type FormEvent, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Token } from "types";
 import { formatAmount } from "utils/token";
 
 import { Form } from "./form";
 import { SubmitButton } from "./submitButton";
+import { type DepositFlowStatus, SwapDepositDrawer } from "./swapDepositDrawer";
 import { SwapFees } from "./swapFees";
 import { getSwapErrors } from "./validation";
 
@@ -50,6 +54,12 @@ export function Deposit({
 }: Props) {
   const ethereumChain = useMainnet();
   const { t } = useTranslation();
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const handleDrawerClose = useCallback(() => setIsDrawerOpen(false), []);
+  const [flowStatus, setFlowStatus] = useState<DepositFlowStatus>("idle");
+  // Captures whether approval was needed when the flow started, because
+  // useNeedsApproval flips to false after a successful approval tx.
+  const [startedWithApproval, setStartedWithApproval] = useState(false);
 
   const { data: fromTokenBalance } = useTokenBalance({
     address: fromToken.address,
@@ -57,7 +67,12 @@ export function Deposit({
   });
 
   const { data: nativeBalanceData } = useNativeBalance(ethereumChain.id);
-  const nativeBalance = nativeBalanceData?.value;
+
+  const { data: needsApproval } = useNeedsApproval({
+    amount: amountBigInt,
+    spender: getGatewayAddress(ethereumChain.id),
+    token: fromToken,
+  });
 
   const { data: depositPreview, isError: isDepositPreviewError } =
     usePreviewDeposit({
@@ -76,8 +91,33 @@ export function Deposit({
   const depositMutation = useDeposit({
     amountIn: amountBigInt,
     approveAmount,
+    onEmitter(emitter) {
+      emitter.on("user-signed-approval", () => setFlowStatus("approving"));
+      emitter.on("approve-transaction-succeeded", () =>
+        setFlowStatus("approved"),
+      );
+      emitter.on("approve-transaction-reverted", () =>
+        setFlowStatus("approve-error"),
+      );
+      emitter.on("user-signing-approval-error", () =>
+        setFlowStatus("approve-error"),
+      );
+      emitter.on("pre-deposit", () => setFlowStatus("deposit-ready"));
+      emitter.on("user-signed-deposit", () => setFlowStatus("depositing"));
+      emitter.on("deposit-transaction-succeeded", () =>
+        setFlowStatus("deposited"),
+      );
+      emitter.on("deposit-transaction-reverted", () =>
+        setFlowStatus("deposit-error"),
+      );
+      emitter.on("user-signing-deposit-error", () =>
+        setFlowStatus("deposit-error"),
+      );
+    },
     tokenIn: fromToken.address,
   });
+
+  const nativeBalance = nativeBalanceData?.value;
 
   const inputError = getSwapErrors({
     amount: amountBigInt,
@@ -91,15 +131,29 @@ export function Deposit({
     isError: isDepositPreviewError,
   });
 
+  const { networkFeeDisplay, protocolFeeDisplay, totalFeesDisplay } =
+    useSwapFeesDisplay({
+      amountBigInt,
+      approveAmount,
+      fromInputValue,
+      fromToken,
+      operationGasEstimation,
+      protocolFee,
+    });
+
   const balancesLoaded =
     nativeBalance !== undefined && fromTokenBalance !== undefined;
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (!inputError) {
+      setStartedWithApproval(!!needsApproval);
+      setFlowStatus(needsApproval ? "approving" : "deposit-ready");
       depositMutation.mutate();
+      setIsDrawerOpen(true);
     }
   }
+
   return (
     <>
       <Form
@@ -142,6 +196,20 @@ export function Deposit({
         protocolFee={protocolFee}
         toToken={toToken}
       />
+      {isDrawerOpen && flowStatus !== "idle" && (
+        <SwapDepositDrawer
+          flowStatus={flowStatus}
+          fromAmount={fromInputValue}
+          fromToken={fromToken}
+          networkFee={networkFeeDisplay}
+          onClose={handleDrawerClose}
+          outputValue={outputValue}
+          protocolFee={protocolFeeDisplay}
+          showApproveStep={startedWithApproval}
+          toToken={toToken}
+          totalFees={totalFeesDisplay}
+        />
+      )}
     </>
   );
 }

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -135,7 +135,6 @@ export function Deposit({
     useSwapFeesDisplay({
       amountBigInt,
       approveAmount,
-      fromInputValue,
       fromToken,
       operationGasEstimation,
       protocolFee,

--- a/web/src/components/swapForm/outputLabel.tsx
+++ b/web/src/components/swapForm/outputLabel.tsx
@@ -1,0 +1,22 @@
+import type { Token } from "types";
+
+export const OutputLabel = function ({
+  fromInputValue,
+  fromToken,
+  outputValue,
+  toToken,
+}: {
+  fromInputValue: string;
+  fromToken: Token;
+  outputValue: string;
+  toToken: Token;
+}) {
+  if (fromInputValue === "0") {
+    return null;
+  }
+  return (
+    <>
+      {`${fromInputValue} ${fromToken.symbol} = ${outputValue} ${toToken.symbol}`}
+    </>
+  );
+};

--- a/web/src/components/swapForm/swapDepositDrawer.tsx
+++ b/web/src/components/swapForm/swapDepositDrawer.tsx
@@ -1,0 +1,119 @@
+import { Drawer } from "components/base/drawer";
+import { DrawerLoader } from "components/base/drawer/drawerLoader";
+import { type Step, stepStatus } from "components/base/verticalStepper";
+import { Suspense, lazy, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import type { Token } from "types";
+
+const SwapProgressDrawer = lazy(() =>
+  import("./swapProgressDrawer").then((m) => ({
+    default: m.SwapProgressDrawer,
+  })),
+);
+
+export type DepositFlowStatus =
+  | "approve-error"
+  | "approved"
+  | "approving"
+  | "deposit-error"
+  | "deposit-ready"
+  | "deposited"
+  | "depositing"
+  | "idle";
+
+const approveStepStatuses: Record<
+  Exclude<DepositFlowStatus, "idle">,
+  Step["status"]
+> = {
+  "approve-error": stepStatus.ready,
+  approved: stepStatus.completed,
+  approving: stepStatus.progress,
+  "deposit-error": stepStatus.completed,
+  "deposit-ready": stepStatus.completed,
+  deposited: stepStatus.completed,
+  depositing: stepStatus.completed,
+};
+
+const confirmStepStatuses: Record<
+  Exclude<DepositFlowStatus, "idle">,
+  Step["status"]
+> = {
+  "approve-error": stepStatus.notReady,
+  approved: stepStatus.notReady,
+  approving: stepStatus.notReady,
+  "deposit-error": stepStatus.ready,
+  "deposit-ready": stepStatus.ready,
+  deposited: stepStatus.completed,
+  depositing: stepStatus.progress,
+};
+
+type Props = {
+  flowStatus: Exclude<DepositFlowStatus, "idle">;
+  fromAmount: string;
+  fromToken: Token;
+  networkFee: string;
+  onClose: VoidFunction;
+  outputValue: string;
+  protocolFee: string;
+  showApproveStep: boolean;
+  toToken: Token;
+  totalFees: string;
+};
+
+export function SwapDepositDrawer({
+  flowStatus,
+  fromAmount,
+  fromToken,
+  networkFee,
+  onClose,
+  outputValue,
+  protocolFee,
+  showApproveStep,
+  totalFees,
+  toToken,
+}: Props) {
+  const { t } = useTranslation();
+  useEffect(
+    function closeDrawerOnSuccess() {
+      if (flowStatus !== "deposited") {
+        return undefined;
+      }
+      const timeoutId = setTimeout(onClose, 3000);
+      return () => clearTimeout(timeoutId);
+    },
+    [flowStatus, onClose],
+  );
+
+  const steps: Step[] = [
+    {
+      description: t("pages.swap.progress.confirm-description"),
+      status: confirmStepStatuses[flowStatus],
+      title: t("pages.swap.progress.confirm-title"),
+    },
+  ];
+
+  if (showApproveStep) {
+    steps.unshift({
+      description: t("pages.swap.progress.approve-description"),
+      status: approveStepStatuses[flowStatus],
+      title: t("pages.swap.progress.approve-title"),
+    });
+  }
+
+  return (
+    <Drawer onClose={onClose}>
+      <Suspense fallback={<DrawerLoader />}>
+        <SwapProgressDrawer
+          fromAmount={fromAmount}
+          fromToken={fromToken}
+          networkFee={networkFee}
+          outputValue={outputValue}
+          protocolFee={protocolFee}
+          steps={steps}
+          toToken={toToken}
+          totalFees={totalFees}
+        />
+      </Suspense>
+    </Drawer>
+  );
+}

--- a/web/src/components/swapForm/swapFees.tsx
+++ b/web/src/components/swapForm/swapFees.tsx
@@ -1,12 +1,10 @@
-import { useEstimateApproveErc20Fees } from "@hemilabs/react-hooks/useEstimateApproveErc20Fees";
-import { useNeedsApproval } from "@hemilabs/react-hooks/useNeedsApproval";
-import { getGatewayAddress } from "@vetro/gateway";
 import { FeeDetails } from "components/feeDetails";
 import { FeesContainer } from "components/feesContainer";
-import { useMainnet } from "hooks/useMainnet";
+import { useSwapFeesDisplay } from "hooks/useSwapFeesDisplay";
 import { useTranslation } from "react-i18next";
 import type { Token } from "types";
-import { formatAmount } from "utils/token";
+
+import { OutputLabel } from "./outputLabel";
 
 type Props = {
   amountBigInt: bigint;
@@ -23,14 +21,6 @@ type Props = {
   toToken: Token;
 };
 
-// only add up fees when all are available
-const sumFees = function (fees: (bigint | undefined)[]) {
-  if (fees.every((fee): fee is bigint => fee !== undefined)) {
-    return fees.reduce((sum, fee) => sum + fee, 0n);
-  }
-  return undefined;
-};
-
 export const SwapFees = function ({
   amountBigInt,
   approveAmount,
@@ -42,73 +32,33 @@ export const SwapFees = function ({
   toToken,
 }: Props) {
   const { t } = useTranslation();
-  const ethereumChain = useMainnet();
-  const gatewayAddress = getGatewayAddress(ethereumChain.id);
 
-  const { data: needsApproval } = useNeedsApproval({
-    amount: amountBigInt,
-    spender: gatewayAddress,
-    token: fromToken,
-  });
-
-  const { fees: approvalFee, isError: isApprovalFeeError } =
-    useEstimateApproveErc20Fees({
-      amount: approveAmount ?? amountBigInt,
-      enabled: needsApproval,
-      spender: gatewayAddress,
-      token: fromToken,
+  const { networkFeeDisplay, protocolFeeDisplay, totalFeesDisplay } =
+    useSwapFeesDisplay({
+      amountBigInt,
+      approveAmount,
+      fromInputValue,
+      fromToken,
+      operationGasEstimation,
+      protocolFee,
     });
-
-  const {
-    fees: operationFee,
-    isEnabled: isOperationGasEstimationEnabled,
-    isError: isOperationFeeError,
-  } = operationGasEstimation;
-
-  const { data: protocolFeeData, isError: isProtocolFeeError } = protocolFee;
-
-  const networkFeeWei = needsApproval
-    ? sumFees([approvalFee, operationFee])
-    : operationFee;
-
-  const hasNetworkFeeError = needsApproval
-    ? isApprovalFeeError || isOperationFeeError
-    : isOperationFeeError;
-
-  const totalFeesWei = sumFees([networkFeeWei, protocolFeeData]);
-
-  const networkFeeDisplay = formatAmount({
-    amount: networkFeeWei,
-    decimals: ethereumChain.nativeCurrency.decimals,
-    isError: hasNetworkFeeError,
-    symbol: ethereumChain.nativeCurrency.symbol,
-  });
-
-  const protocolFeeDisplay = formatAmount({
-    amount: protocolFeeData,
-    decimals: ethereumChain.nativeCurrency.decimals,
-    isError: isProtocolFeeError,
-    symbol: ethereumChain.nativeCurrency.symbol,
-  });
-
-  const totalFeesDisplay = formatAmount({
-    amount: totalFeesWei,
-    decimals: ethereumChain.nativeCurrency.decimals,
-    isError: hasNetworkFeeError || isProtocolFeeError,
-    symbol: ethereumChain.nativeCurrency.symbol,
-  });
-
-  const label = `${fromInputValue} ${fromToken.symbol} = ${outputValue} ${toToken.symbol}`;
 
   return (
     <div className="w-full max-w-md border-t border-gray-200">
       <FeesContainer
-        label={label}
-        totalFees={isOperationGasEstimationEnabled ? totalFeesDisplay : "-"}
+        label={
+          <OutputLabel
+            fromInputValue={fromInputValue}
+            fromToken={fromToken}
+            outputValue={outputValue}
+            toToken={toToken}
+          />
+        }
+        totalFees={totalFeesDisplay}
       >
         <FeeDetails
           label={t("pages.swap.fees.network-fee")}
-          value={isOperationGasEstimationEnabled ? networkFeeDisplay : "-"}
+          value={networkFeeDisplay}
         />
         <FeeDetails
           label={t("pages.swap.fees.fixed-protocol-fee")}

--- a/web/src/components/swapForm/swapFees.tsx
+++ b/web/src/components/swapForm/swapFees.tsx
@@ -37,7 +37,6 @@ export const SwapFees = function ({
     useSwapFeesDisplay({
       amountBigInt,
       approveAmount,
-      fromInputValue,
       fromToken,
       operationGasEstimation,
       protocolFee,

--- a/web/src/components/swapForm/swapProgressDrawer.tsx
+++ b/web/src/components/swapForm/swapProgressDrawer.tsx
@@ -1,0 +1,105 @@
+import { DrawerTitle } from "components/base/drawer/drawerTitle";
+import { type Step, VerticalStepper } from "components/base/verticalStepper";
+import { FeeDetails } from "components/feeDetails";
+import { FeesContainer } from "components/feesContainer";
+import { TokenLogo } from "components/tokenLogo";
+import { useTranslation } from "react-i18next";
+import type { Token } from "types";
+
+import { OutputLabel } from "./outputLabel";
+
+type Props = {
+  fromAmount: string;
+  fromToken: Token;
+  networkFee: string;
+  outputValue: string;
+  protocolFee: string;
+  steps: Step[];
+  toToken: Token;
+  totalFees: string;
+};
+
+export function SwapProgressDrawer({
+  fromAmount,
+  fromToken,
+  networkFee,
+  outputValue,
+  protocolFee,
+  steps,
+  totalFees,
+  toToken,
+}: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="flex h-full flex-col">
+        <DrawerTitle>{t("pages.swap.progress.title")}</DrawerTitle>
+
+        <div className="flex flex-col gap-10 border-y border-gray-200 bg-gray-50 p-6">
+          <div className="flex flex-col gap-2">
+            <p className="text-xsm text-gray-500">
+              {t("pages.swap.form.you-are-swapping")}
+            </p>
+            <div className="flex items-center gap-3">
+              <p className="flex items-center gap-x-2 text-4xl leading-10 font-semibold tracking-tight text-gray-900">
+                <span>{fromAmount}</span>
+                <span className="text-gray-500">{fromToken.symbol}</span>
+              </p>
+              <TokenLogo {...fromToken} size="large" />
+            </div>
+            <p className="text-xsm text-gray-500">${fromAmount}</p>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <p className="text-xsm text-gray-500">
+              {t("pages.swap.form.you-will-receive")}
+            </p>
+            <div className="flex items-center gap-3">
+              <p className="flex items-center gap-x-2 text-4xl leading-10 font-semibold tracking-tight text-gray-900">
+                <span>{outputValue}</span>
+                <span className="text-gray-500">{toToken.symbol}</span>
+              </p>
+              <TokenLogo {...toToken} size="large" />
+            </div>
+            <p className="text-xsm text-gray-500">${outputValue}</p>
+          </div>
+        </div>
+
+        <FeesContainer
+          label={
+            <OutputLabel
+              fromInputValue={fromAmount}
+              fromToken={fromToken}
+              outputValue={outputValue}
+              toToken={toToken}
+            />
+          }
+          totalFees={totalFees}
+        >
+          <FeeDetails
+            label={t("pages.swap.fees.network-fee")}
+            value={networkFee}
+          />
+          <FeeDetails
+            label={t("pages.swap.fees.fixed-protocol-fee")}
+            value={protocolFee}
+          />
+        </FeesContainer>
+
+        <div className="flex-1" />
+
+        {steps.length > 0 && (
+          <div className="flex flex-col gap-2 px-6 pb-6">
+            <p className="text-[11px] leading-4 font-medium tracking-wide text-gray-500">
+              {t("pages.swap.progress.swap-progress")}
+            </p>
+            <div className="border-t border-gray-200">
+              <VerticalStepper steps={steps} />
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/web/src/components/tokenLogo/index.tsx
+++ b/web/src/components/tokenLogo/index.tsx
@@ -1,9 +1,17 @@
 import { useEffect, useState } from "react";
 import type { Token } from "types";
 
-type Props = Pick<Token, "logoURI" | "symbol">;
+const sizeClasses = {
+  base: "size-5",
+  large: "size-8",
+};
 
-export const TokenLogo = function ({ logoURI, symbol }: Props) {
+type Props = Pick<Token, "logoURI" | "symbol"> & {
+  size?: keyof typeof sizeClasses;
+};
+
+export const TokenLogo = function ({ logoURI, size = "base", symbol }: Props) {
+  const sizeClass = sizeClasses[size];
   const [hasError, setHasError] = useState(false);
 
   useEffect(
@@ -15,7 +23,9 @@ export const TokenLogo = function ({ logoURI, symbol }: Props) {
 
   if (!logoURI || hasError) {
     return (
-      <div className="flex size-5 items-center justify-center overflow-hidden rounded-full border border-solid border-white bg-neutral-50 text-[8px] font-semibold text-neutral-700">
+      <div
+        className={`flex ${sizeClass} items-center justify-center overflow-hidden rounded-full border border-solid border-white bg-neutral-50 text-[8px] font-semibold text-neutral-700`}
+      >
         {symbol}
       </div>
     );
@@ -24,7 +34,7 @@ export const TokenLogo = function ({ logoURI, symbol }: Props) {
   return (
     <img
       alt={`${symbol} logo`}
-      className="size-5 rounded-full"
+      className={`${sizeClass} rounded-full`}
       onError={() => setHasError(true)}
       src={logoURI}
     />

--- a/web/src/hooks/useDeposit.ts
+++ b/web/src/hooks/useDeposit.ts
@@ -3,8 +3,9 @@ import { useEnsureConnectedTo } from "@hemilabs/react-hooks/useEnsureConnectedTo
 import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { getGatewayAddress } from "@vetro/gateway";
+import { type DepositEvents, getGatewayAddress } from "@vetro/gateway";
 import { deposit } from "@vetro/gateway/actions";
+import type { EventEmitter } from "events";
 import type { Address } from "viem";
 import { useAccount } from "wagmi";
 
@@ -19,10 +20,12 @@ import { useVusd } from "./useVusd";
 export const useDeposit = function ({
   amountIn,
   approveAmount,
+  onEmitter,
   tokenIn,
 }: {
   amountIn: bigint;
   approveAmount?: bigint;
+  onEmitter?: (emitter: EventEmitter<DepositEvents>) => void;
   tokenIn: Address;
 }) {
   const { address: account } = useAccount();
@@ -77,6 +80,8 @@ export const useDeposit = function ({
         receiver: account,
         tokenIn,
       });
+
+      onEmitter?.(emitter);
 
       emitter.on("approve-transaction-reverted", function (receipt) {
         queryClient.invalidateQueries({

--- a/web/src/hooks/useMainnet.ts
+++ b/web/src/hooks/useMainnet.ts
@@ -1,4 +1,4 @@
-import { mainnet } from "viem/chains";
+import { mainnet } from "networks/mainnet";
 
 // TODO implement mainnet|testnet selector
 export const useMainnet = () => mainnet;

--- a/web/src/hooks/useSwapFeesDisplay.ts
+++ b/web/src/hooks/useSwapFeesDisplay.ts
@@ -1,0 +1,99 @@
+import { useEstimateApproveErc20Fees } from "@hemilabs/react-hooks/useEstimateApproveErc20Fees";
+import { useNeedsApproval } from "@hemilabs/react-hooks/useNeedsApproval";
+import { getGatewayAddress } from "@vetro/gateway";
+import type { Token } from "types";
+import { formatAmount } from "utils/token";
+
+import { useMainnet } from "./useMainnet";
+
+// only add up fees when all are available
+const sumFees = function (fees: (bigint | undefined)[]) {
+  if (fees.every((fee): fee is bigint => fee !== undefined)) {
+    return fees.reduce((sum, fee) => sum + fee, 0n);
+  }
+  return undefined;
+};
+
+export const useSwapFeesDisplay = function ({
+  amountBigInt,
+  approveAmount,
+  fromToken,
+  operationGasEstimation,
+  protocolFee,
+}: {
+  amountBigInt: bigint;
+  approveAmount: bigint | undefined;
+  fromInputValue: string;
+  fromToken: Token;
+  operationGasEstimation: {
+    fees: bigint | undefined;
+    isEnabled: boolean;
+    isError: boolean;
+  };
+  protocolFee: { data: bigint | undefined; isError: boolean };
+}) {
+  const ethereumChain = useMainnet();
+  const gatewayAddress = getGatewayAddress(ethereumChain.id);
+
+  const { data: needsApproval } = useNeedsApproval({
+    amount: amountBigInt,
+    spender: gatewayAddress,
+    token: fromToken,
+  });
+
+  const { fees: approvalFee, isError: isApprovalFeeError } =
+    useEstimateApproveErc20Fees({
+      amount: approveAmount ?? amountBigInt,
+      enabled: needsApproval,
+      spender: gatewayAddress,
+      token: fromToken,
+    });
+
+  const {
+    fees: operationFee,
+    isEnabled: isOperationGasEstimationEnabled,
+    isError: isOperationFeeError,
+  } = operationGasEstimation;
+
+  const { data: protocolFeeData, isError: isProtocolFeeError } = protocolFee;
+
+  const networkFeeWei = needsApproval
+    ? sumFees([approvalFee, operationFee])
+    : operationFee;
+
+  const hasNetworkFeeError = needsApproval
+    ? isApprovalFeeError || isOperationFeeError
+    : isOperationFeeError;
+
+  const totalFeesWei = sumFees([networkFeeWei, protocolFeeData]);
+
+  const networkFeeDisplay = formatAmount({
+    amount: networkFeeWei,
+    decimals: ethereumChain.nativeCurrency.decimals,
+    isError: hasNetworkFeeError,
+    symbol: ethereumChain.nativeCurrency.symbol,
+  });
+
+  const protocolFeeDisplay = formatAmount({
+    amount: protocolFeeData,
+    decimals: ethereumChain.nativeCurrency.decimals,
+    isError: isProtocolFeeError,
+    symbol: ethereumChain.nativeCurrency.symbol,
+  });
+
+  const totalFeesDisplay = formatAmount({
+    amount: totalFeesWei,
+    decimals: ethereumChain.nativeCurrency.decimals,
+    isError: hasNetworkFeeError || isProtocolFeeError,
+    symbol: ethereumChain.nativeCurrency.symbol,
+  });
+
+  return {
+    isOperationGasEstimationEnabled,
+    networkFeeDisplay: isOperationGasEstimationEnabled
+      ? networkFeeDisplay
+      : "-",
+    protocolFeeDisplay,
+    totalFeesDisplay: isOperationGasEstimationEnabled ? totalFeesDisplay : "-",
+  };
+};

--- a/web/src/hooks/useSwapFeesDisplay.ts
+++ b/web/src/hooks/useSwapFeesDisplay.ts
@@ -23,7 +23,6 @@ export const useSwapFeesDisplay = function ({
 }: {
   amountBigInt: bigint;
   approveAmount: bigint | undefined;
-  fromInputValue: string;
   fromToken: Token;
   operationGasEstimation: {
     fees: bigint | undefined;

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -79,6 +79,14 @@
         "you-are-swapping": "You are swapping",
         "you-will-receive": "You will receive"
       },
+      "progress": {
+        "approve-description": "This allows the app to use this token for your swap.",
+        "approve-title": "Approve in wallet",
+        "confirm-description": "Review the details and confirm the swap in your wallet.",
+        "confirm-title": "Confirm swap",
+        "swap-progress": "Swap progress",
+        "title": "Swap in progress"
+      },
       "select-option": "Select token to swap",
       "title": "Swap stablecoins for VUSD and back"
     }

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -79,6 +79,14 @@
         "you-are-swapping": "Vas a intercambiar",
         "you-will-receive": "Vas a recibir"
       },
+      "progress": {
+        "approve-description": "Esto permite que la app use este token para su intercambio.",
+        "approve-title": "Aprobar en billetera",
+        "confirm-description": "Revise los detalles y confirme el intercambio en su billetera.",
+        "confirm-title": "Confirmar intercambio",
+        "swap-progress": "Progreso del intercambio",
+        "title": "Intercambio en progreso"
+      },
       "select-option": "Seleccione el token a intercambiar",
       "title": "Intercambie stablecoins por VUSD y viceversa"
     }


### PR DESCRIPTION
### Description

Add a drawer that shows real-time progress during the deposit swap flow, including approval and confirmation steps with a vertical stepper.

**Key changes:**
- New `SwapDepositDrawer` and `SwapProgressDrawer` components that display swap amounts, fees, and step-by-step progress
- Extract fee calculation logic into a reusable `useSwapFeesDisplay` hook, shared between the swap form and the drawer
- Support a `size` prop on `TokenLogo` for larger logos in the drawer
- Export `DepositEvents` and `RedeemEvents` types from `@vetro/gateway`
- Fix vertical stepper sizing and alignment

**Pending:**
- Toast notifications
- Failed/error states
- Rounding the numbers

**Commits:**
- 2d1db5e Export types from @vetro/gateway package
- caad419 Update useMainnet hook to use local fork
- a1efd37 Update token logo for multiple sizes
- 4479697 Add swap deposit drawer
- 7c24803 Fix vertical stepper size and alignment

### Screenshots

https://github.com/user-attachments/assets/72763471-75e9-4213-8edb-6d3647181855

(The vertical stepper text is not properly aligned in the video but I fixed it in this PR)

### Related issue(s)

Related to #6

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.