### PR TITLE
Add Retry option on deposit swap drawer

### DIFF
--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -106,6 +106,7 @@ export function Deposit({
       );
       emitter.on("pre-deposit", () => setFlowStatus("deposit-ready"));
       emitter.on("user-signed-deposit", () => setFlowStatus("depositing"));
+      emitter.on("deposit-failed", () => setFlowStatus("deposit-error"));
       emitter.on("deposit-transaction-succeeded", function () {
         setFlowStatus("deposited");
         setShowToast(true);
@@ -114,6 +115,9 @@ export function Deposit({
         setFlowStatus("deposit-error"),
       );
       emitter.on("user-signing-deposit-error", () =>
+        setFlowStatus("deposit-error"),
+      );
+      emitter.on("deposit-failed-validation", () =>
         setFlowStatus("deposit-error"),
       );
     },
@@ -145,6 +149,11 @@ export function Deposit({
 
   const balancesLoaded =
     nativeBalance !== undefined && fromTokenBalance !== undefined;
+
+  const handleRetry = function () {
+    setFlowStatus(startedWithApproval ? "approving" : "deposit-ready");
+    depositMutation.mutate();
+  };
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -205,6 +214,7 @@ export function Deposit({
           fromToken={fromToken}
           networkFee={networkFeeDisplay}
           onClose={handleDrawerClose}
+          onRetry={handleRetry}
           outputValue={outputValue}
           protocolFee={protocolFeeDisplay}
           showApproveStep={startedWithApproval}

--- a/web/src/components/swapForm/swapDepositDrawer.tsx
+++ b/web/src/components/swapForm/swapDepositDrawer.tsx
@@ -25,7 +25,7 @@ const approveStepStatuses: Record<
   Exclude<DepositFlowStatus, "idle">,
   Step["status"]
 > = {
-  "approve-error": stepStatus.ready,
+  "approve-error": stepStatus.failed,
   approved: stepStatus.completed,
   approving: stepStatus.progress,
   "deposit-error": stepStatus.completed,
@@ -41,7 +41,7 @@ const confirmStepStatuses: Record<
   "approve-error": stepStatus.notReady,
   approved: stepStatus.notReady,
   approving: stepStatus.notReady,
-  "deposit-error": stepStatus.ready,
+  "deposit-error": stepStatus.failed,
   "deposit-ready": stepStatus.ready,
   deposited: stepStatus.completed,
   depositing: stepStatus.progress,
@@ -53,6 +53,7 @@ type Props = {
   fromToken: Token;
   networkFee: string;
   onClose: VoidFunction;
+  onRetry: VoidFunction;
   outputValue: string;
   protocolFee: string;
   showApproveStep: boolean;
@@ -66,6 +67,7 @@ export function SwapDepositDrawer({
   fromToken,
   networkFee,
   onClose,
+  onRetry,
   outputValue,
   protocolFee,
   showApproveStep,
@@ -83,6 +85,9 @@ export function SwapDepositDrawer({
     },
     [flowStatus, onClose],
   );
+
+  const isError =
+    flowStatus === "approve-error" || flowStatus === "deposit-error";
 
   const steps: Step[] = [
     {
@@ -107,6 +112,7 @@ export function SwapDepositDrawer({
           fromAmount={fromAmount}
           fromToken={fromToken}
           networkFee={networkFee}
+          onRetry={isError ? onRetry : undefined}
           outputValue={outputValue}
           protocolFee={protocolFee}
           steps={steps}

--- a/web/src/components/swapForm/swapProgressDrawer.tsx
+++ b/web/src/components/swapForm/swapProgressDrawer.tsx
@@ -1,8 +1,10 @@
+import { Button } from "components/base/button";
 import { DrawerTitle } from "components/base/drawer/drawerTitle";
 import { type Step, VerticalStepper } from "components/base/verticalStepper";
 import { FeeDetails } from "components/feeDetails";
 import { FeesContainer } from "components/feesContainer";
 import { TokenLogo } from "components/tokenLogo";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Token } from "types";
 
@@ -12,6 +14,7 @@ type Props = {
   fromAmount: string;
   fromToken: Token;
   networkFee: string;
+  onRetry?: VoidFunction;
   outputValue: string;
   protocolFee: string;
   steps: Step[];
@@ -23,6 +26,7 @@ export function SwapProgressDrawer({
   fromAmount,
   fromToken,
   networkFee,
+  onRetry,
   outputValue,
   protocolFee,
   steps,
@@ -30,6 +34,22 @@ export function SwapProgressDrawer({
   toToken,
 }: Props) {
   const { t } = useTranslation();
+  const [renderRetry, setRenderRetry] = useState(false);
+  const [showRetry, setShowRetry] = useState(false);
+
+  useEffect(
+    function animateRetryButton() {
+      if (onRetry) {
+        setRenderRetry(true);
+        const frameId = requestAnimationFrame(() => setShowRetry(true));
+        return () => cancelAnimationFrame(frameId);
+      }
+      setShowRetry(false);
+      const timeoutId = setTimeout(() => setRenderRetry(false), 300);
+      return () => clearTimeout(timeoutId);
+    },
+    [onRetry],
+  );
 
   return (
     <>
@@ -96,6 +116,22 @@ export function SwapProgressDrawer({
             </p>
             <div className="border-t border-gray-200">
               <VerticalStepper steps={steps} />
+            </div>
+          </div>
+        )}
+
+        {renderRetry && (
+          <div
+            className={`grid transition-[grid-template-rows] duration-300 ease-out ${
+              showRetry ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+            }`}
+          >
+            <div className="overflow-hidden">
+              <div className="border-t border-gray-200 bg-gray-50 px-6 py-3 *:w-full">
+                <Button onClick={onRetry} size="small" variant="primary">
+                  {t("pages.swap.progress.retry")}
+                </Button>
+              </div>
             </div>
           </div>
         )}

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -97,6 +97,7 @@
         "approve-title": "Approve in wallet",
         "confirm-description": "Review the details and confirm the swap in your wallet.",
         "confirm-title": "Confirm swap",
+        "retry": "Retry",
         "swap-progress": "Swap progress",
         "title": "Swap in progress"
       },

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -97,6 +97,7 @@
         "approve-title": "Aprobar en billetera",
         "confirm-description": "Revise los detalles y confirme el intercambio en su billetera.",
         "confirm-title": "Confirmar intercambio",
+        "retry": "Reintentar",
         "swap-progress": "Progreso del intercambio",
         "title": "Intercambio en progreso"
       },


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds the failed states on the drawer + the retry option... animated!

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Approve fails

https://github.com/user-attachments/assets/2b4a79a1-0742-4684-b701-d0b317b902fe

Deposit fails

https://github.com/user-attachments/assets/3358960a-5e0f-4761-88b8-1971caea5e34

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #6

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
