### PR TITLE
Add approve step for whitelisted users in redeem

### DIFF
--- a/packages/gateway/src/actions/wallet/redeem.ts
+++ b/packages/gateway/src/actions/wallet/redeem.ts
@@ -16,6 +16,7 @@ import { gatewayAbi } from "../../abi/gatewayAbi.js";
 import { getGatewayAddress } from "../../getGatewayAddress.js";
 import type { RedeemEvents } from "../../types.js";
 import { getPeggedToken } from "../public/getPeggedToken.js";
+import { isInstantRedeemWhitelisted } from "../public/isInstantRedeemWhitelisted.js";
 
 export type RedeemParams = {
   approveAmount?: bigint;
@@ -158,52 +159,66 @@ const runRedeem = (
       // already validated
       const gatewayAddress = getGatewayAddress(walletClient.chain!.id);
 
-      // Get the pegged token address
-      const peggedTokenAddress = await getPeggedToken(walletClient, {
+      // Check if user is whitelisted for instant redeem
+      const isWhitelisted = await isInstantRedeemWhitelisted(walletClient, {
+        account: walletClient.account!.address,
         address: gatewayAddress,
       });
 
-      // Check current allowance for pegged token
-      const currentAllowance = await allowance(walletClient, {
-        address: peggedTokenAddress,
-        owner: walletClient.account!.address,
-        spender: gatewayAddress,
-      });
+      // Approval is only needed for whitelisted users (instant redeem burns pegged tokens)
+      // and this requires enough allowance. For non-whitelisted users,
+      // the redeem function will just transfer the tokenOut to the user
+      if (isWhitelisted) {
+        // Get the pegged token address
+        const peggedTokenAddress = await getPeggedToken(walletClient, {
+          address: gatewayAddress,
+        });
 
-      // If allowance is insufficient, approve first
-      if (currentAllowance < peggedTokenIn) {
-        emitter.emit("pre-approve");
-
-        const approvalHash = await approve(walletClient, {
+        // Check current allowance for pegged token
+        const currentAllowance = await allowance(walletClient, {
           address: peggedTokenAddress,
-          amount: approveAmount,
+          owner: walletClient.account!.address,
           spender: gatewayAddress,
-        }).catch(function (error: Error) {
-          emitter.emit("user-signing-approval-error", error);
         });
 
-        if (!approvalHash) {
-          return;
+        // If allowance is insufficient, approve first
+        if (currentAllowance < peggedTokenIn) {
+          emitter.emit("pre-approve");
+
+          const approvalHash = await approve(walletClient, {
+            address: peggedTokenAddress,
+            amount: approveAmount,
+            spender: gatewayAddress,
+          }).catch(function (error: Error) {
+            emitter.emit("user-signing-approval-error", error);
+          });
+
+          if (!approvalHash) {
+            return;
+          }
+
+          emitter.emit("user-signed-approval", approvalHash);
+
+          const approvalReceipt = await waitForTransactionReceipt(
+            walletClient,
+            {
+              hash: approvalHash,
+            },
+          ).catch(function (error: Error) {
+            emitter.emit("redeem-failed", error);
+          });
+
+          if (!approvalReceipt) {
+            return;
+          }
+
+          if (approvalReceipt.status === "reverted") {
+            emitter.emit("approve-transaction-reverted", approvalReceipt);
+            return;
+          }
+
+          emitter.emit("approve-transaction-succeeded", approvalReceipt);
         }
-
-        emitter.emit("user-signed-approval", approvalHash);
-
-        const approvalReceipt = await waitForTransactionReceipt(walletClient, {
-          hash: approvalHash,
-        }).catch(function (error: Error) {
-          emitter.emit("redeem-failed", error);
-        });
-
-        if (!approvalReceipt) {
-          return;
-        }
-
-        if (approvalReceipt.status === "reverted") {
-          emitter.emit("approve-transaction-reverted", approvalReceipt);
-          return;
-        }
-
-        emitter.emit("approve-transaction-succeeded", approvalReceipt);
       }
 
       emitter.emit("pre-redeem");

--- a/packages/gateway/test/wallet/redeem.test.ts
+++ b/packages/gateway/test/wallet/redeem.test.ts
@@ -11,10 +11,15 @@ import { allowance, approve } from "viem-erc20/actions";
 import { describe, expect, it, vi } from "vitest";
 
 import { getPeggedToken } from "../../src/actions/public/getPeggedToken";
+import { isInstantRedeemWhitelisted } from "../../src/actions/public/isInstantRedeemWhitelisted";
 import { redeem } from "../../src/actions/wallet/redeem";
 
 vi.mock("../../src/actions/public/getPeggedToken", () => ({
   getPeggedToken: vi.fn(),
+}));
+
+vi.mock("../../src/actions/public/isInstantRedeemWhitelisted", () => ({
+  isInstantRedeemWhitelisted: vi.fn(),
 }));
 
 vi.mock("viem/actions", () => ({
@@ -290,42 +295,6 @@ describe("redeem", function () {
     expect(onSettled).toHaveBeenCalledOnce();
   });
 
-  it("should approve with approveAmount when provided and allowance is insufficient", async function () {
-    const successReceipt = {
-      status: "success",
-    } as TransactionReceipt;
-
-    const approveAmount = validParameters.peggedTokenIn * BigInt(10);
-
-    vi.mocked(getPeggedToken).mockResolvedValue(mockPeggedTokenAddress);
-    vi.mocked(allowance).mockResolvedValue(
-      validParameters.peggedTokenIn - BigInt(1),
-    );
-    vi.mocked(approve).mockResolvedValue(zeroHash);
-    vi.mocked(writeContract).mockResolvedValue(zeroHash);
-    vi.mocked(waitForTransactionReceipt)
-      .mockResolvedValueOnce(successReceipt)
-      .mockResolvedValueOnce(successReceipt);
-
-    const { emitter, promise } = redeem(mockWalletClient, {
-      ...validParameters,
-      approveAmount,
-    });
-
-    const onSettled = vi.fn();
-    emitter.on("redeem-settled", onSettled);
-
-    await promise;
-
-    expect(approve).toHaveBeenCalledWith(
-      mockWalletClient,
-      expect.objectContaining({
-        amount: approveAmount,
-      }),
-    );
-    expect(onSettled).toHaveBeenCalledOnce();
-  });
-
   it("should emit 'redeem-failed-validation' if minAmountOut is not a bigint", async function () {
     const parameters = { ...validParameters, minAmountOut: 900 };
 
@@ -368,11 +337,50 @@ describe("redeem", function () {
     expect(onSettled).toHaveBeenCalledOnce();
   });
 
-  it("should skip approval if allowance is sufficient and proceed to redeem", async function () {
+  it("should skip approval if user is not whitelisted and proceed to redeem", async function () {
     const receipt = {
       status: "success",
     } as TransactionReceipt;
 
+    vi.mocked(isInstantRedeemWhitelisted).mockResolvedValue(false);
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt);
+
+    const { emitter, promise } = redeem(mockWalletClient, validParameters);
+
+    const onPreApprove = vi.fn();
+    const onPreRedeem = vi.fn();
+    const onUserSignedRedeem = vi.fn();
+    const onRedeemTransactionSucceeded = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("pre-approve", onPreApprove);
+    emitter.on("pre-redeem", onPreRedeem);
+    emitter.on("user-signed-redeem", onUserSignedRedeem);
+    emitter.on("redeem-transaction-succeeded", onRedeemTransactionSucceeded);
+    emitter.on("redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onPreApprove).not.toHaveBeenCalled();
+    expect(approve).not.toHaveBeenCalled();
+    expect(allowance).not.toHaveBeenCalled();
+    expect(getPeggedToken).not.toHaveBeenCalled();
+    expect(onPreRedeem).toHaveBeenCalledOnce();
+    expect(onUserSignedRedeem).toHaveBeenCalledExactlyOnceWith(zeroHash);
+    expect(onRedeemTransactionSucceeded).toHaveBeenCalledExactlyOnceWith(
+      receipt,
+    );
+    expect(writeContract).toHaveBeenCalledOnce();
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should skip approval if whitelisted and allowance is sufficient", async function () {
+    const receipt = {
+      status: "success",
+    } as TransactionReceipt;
+
+    vi.mocked(isInstantRedeemWhitelisted).mockResolvedValue(true);
     vi.mocked(getPeggedToken).mockResolvedValue(mockPeggedTokenAddress);
     vi.mocked(allowance).mockResolvedValue(validParameters.peggedTokenIn);
     vi.mocked(writeContract).mockResolvedValue(zeroHash);
@@ -414,11 +422,12 @@ describe("redeem", function () {
     expect(onSettled).toHaveBeenCalledOnce();
   });
 
-  it("should approve first if allowance is insufficient, then redeem", async function () {
+  it("should approve first if whitelisted and allowance is insufficient, then redeem", async function () {
     const successReceipt = {
       status: "success",
     } as TransactionReceipt;
 
+    vi.mocked(isInstantRedeemWhitelisted).mockResolvedValue(true);
     vi.mocked(getPeggedToken).mockResolvedValue(mockPeggedTokenAddress);
     vi.mocked(allowance).mockResolvedValue(
       validParameters.peggedTokenIn - BigInt(1),
@@ -464,7 +473,45 @@ describe("redeem", function () {
     expect(onSettled).toHaveBeenCalledOnce();
   });
 
+  it("should approve with approveAmount when provided and whitelisted with insufficient allowance", async function () {
+    const successReceipt = {
+      status: "success",
+    } as TransactionReceipt;
+
+    const approveAmount = validParameters.peggedTokenIn * BigInt(10);
+
+    vi.mocked(isInstantRedeemWhitelisted).mockResolvedValue(true);
+    vi.mocked(getPeggedToken).mockResolvedValue(mockPeggedTokenAddress);
+    vi.mocked(allowance).mockResolvedValue(
+      validParameters.peggedTokenIn - BigInt(1),
+    );
+    vi.mocked(approve).mockResolvedValue(zeroHash);
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt)
+      .mockResolvedValueOnce(successReceipt)
+      .mockResolvedValueOnce(successReceipt);
+
+    const { emitter, promise } = redeem(mockWalletClient, {
+      ...validParameters,
+      approveAmount,
+    });
+
+    const onSettled = vi.fn();
+    emitter.on("redeem-settled", onSettled);
+
+    await promise;
+
+    expect(approve).toHaveBeenCalledWith(
+      mockWalletClient,
+      expect.objectContaining({
+        amount: approveAmount,
+      }),
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
   it("should emit 'user-signing-approval-error' when approval signing fails", async function () {
+    vi.mocked(isInstantRedeemWhitelisted).mockResolvedValue(true);
     vi.mocked(getPeggedToken).mockResolvedValue(mockPeggedTokenAddress);
     vi.mocked(allowance).mockResolvedValue(
       validParameters.peggedTokenIn - BigInt(1),
@@ -495,6 +542,7 @@ describe("redeem", function () {
       status: "reverted",
     } as TransactionReceipt;
 
+    vi.mocked(isInstantRedeemWhitelisted).mockResolvedValue(true);
     vi.mocked(getPeggedToken).mockResolvedValue(mockPeggedTokenAddress);
     vi.mocked(allowance).mockResolvedValue(
       validParameters.peggedTokenIn - BigInt(1),
@@ -532,6 +580,7 @@ describe("redeem", function () {
   });
 
   it("should emit 'redeem-failed' when approval receipt fails", async function () {
+    vi.mocked(isInstantRedeemWhitelisted).mockResolvedValue(true);
     vi.mocked(getPeggedToken).mockResolvedValue(mockPeggedTokenAddress);
     vi.mocked(allowance).mockResolvedValue(
       validParameters.peggedTokenIn - BigInt(1),
@@ -562,8 +611,7 @@ describe("redeem", function () {
   });
 
   it("should emit 'user-signing-redeem-error' when redeem signing fails", async function () {
-    vi.mocked(getPeggedToken).mockResolvedValue(mockPeggedTokenAddress);
-    vi.mocked(allowance).mockResolvedValue(validParameters.peggedTokenIn);
+    vi.mocked(isInstantRedeemWhitelisted).mockResolvedValue(false);
     vi.mocked(writeContract).mockRejectedValue(
       new Error("Redeem signing error"),
     );
@@ -588,8 +636,7 @@ describe("redeem", function () {
   });
 
   it("should emit 'redeem-failed' when redeem receipt fails", async function () {
-    vi.mocked(getPeggedToken).mockResolvedValue(mockPeggedTokenAddress);
-    vi.mocked(allowance).mockResolvedValue(validParameters.peggedTokenIn);
+    vi.mocked(isInstantRedeemWhitelisted).mockResolvedValue(false);
     vi.mocked(writeContract).mockResolvedValue(zeroHash);
     vi.mocked(waitForTransactionReceipt).mockRejectedValue(
       new Error("Receipt error"),
@@ -620,8 +667,7 @@ describe("redeem", function () {
       status: "reverted",
     } as TransactionReceipt;
 
-    vi.mocked(getPeggedToken).mockResolvedValue(mockPeggedTokenAddress);
-    vi.mocked(allowance).mockResolvedValue(validParameters.peggedTokenIn);
+    vi.mocked(isInstantRedeemWhitelisted).mockResolvedValue(false);
     vi.mocked(writeContract).mockResolvedValue(zeroHash);
     vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt);
 
@@ -672,6 +718,7 @@ describe("redeem", function () {
   });
 
   it("should emit 'unexpected-error' when getPeggedToken fails", async function () {
+    vi.mocked(isInstantRedeemWhitelisted).mockResolvedValue(true);
     vi.mocked(getPeggedToken).mockRejectedValue(
       new Error("Failed to get pegged token"),
     );


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds the `approve` check in the `redeem` function only for whitelisted users.   
For these kinds of users, the `redeem` burns the `peggedToken` tokens from the user's wallet, so they need to approve the contract for such action.   
For non-whitelisted users, the `peggedTokens` were already locked in `requestRedeem` (See #82 ), so in the `redeem` call, the `tokenOut` tokens are released, so there's no need for an approval.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes in UI

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #6

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
