### PR TITLE
Add useRequestRedeem mutation

### DIFF
--- a/web/src/hooks/useRedeem.ts
+++ b/web/src/hooks/useRedeem.ts
@@ -1,10 +1,12 @@
 import { allowanceQueryKey } from "@hemilabs/react-hooks/useAllowance";
 import { useEnsureConnectedTo } from "@hemilabs/react-hooks/useEnsureConnectedTo";
+import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { getGatewayAddress } from "@vetro/gateway";
+import { getGatewayAddress, type RedeemEvents } from "@vetro/gateway";
 import { redeem } from "@vetro/gateway/actions";
+import type { EventEmitter } from "events";
 import type { Address } from "viem";
 import { useAccount } from "wagmi";
 
@@ -18,10 +20,12 @@ import { useVusd } from "./useVusd";
 
 export const useRedeem = function ({
   approveAmount,
+  onEmitter,
   peggedTokenIn,
   tokenOut,
 }: {
   approveAmount?: bigint;
+  onEmitter?: (emitter: EventEmitter<RedeemEvents>) => void;
   peggedTokenIn: bigint;
   tokenOut: Address;
 }) {
@@ -29,6 +33,7 @@ export const useRedeem = function ({
   const { data: walletClient } = useEthereumWalletClient();
   const ensureConnectedTo = useEnsureConnectedTo();
   const ethereumChain = useMainnet();
+  const { queryKey: nativeBalanceKey } = useNativeBalance(ethereumChain.id);
   const gatewayAddress = getGatewayAddress(ethereumChain.id);
   const queryClient = useQueryClient();
 
@@ -79,6 +84,8 @@ export const useRedeem = function ({
         tokenOut,
       });
 
+      onEmitter?.(emitter);
+
       emitter.on("approve-transaction-reverted", function (receipt) {
         queryClient.invalidateQueries({
           queryKey: allowanceKey,
@@ -117,7 +124,9 @@ export const useRedeem = function ({
       queryClient.invalidateQueries({
         queryKey: vusdBalanceQueryKey,
       });
-
+      queryClient.invalidateQueries({
+        queryKey: nativeBalanceKey,
+      });
       queryClient.invalidateQueries({
         queryKey: tokenOutBalanceQueryKey,
       });

--- a/web/src/hooks/useRequestRedeem.ts
+++ b/web/src/hooks/useRequestRedeem.ts
@@ -1,0 +1,76 @@
+import { useEnsureConnectedTo } from "@hemilabs/react-hooks/useEnsureConnectedTo";
+import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
+import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
+import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getStakingVaultAddress, type RequestRedeemEvents } from "@vetro/earn";
+import { requestRedeem } from "@vetro/earn/actions";
+import type { EventEmitter } from "events";
+import { useAccount } from "wagmi";
+
+import { useEthereumWalletClient } from "./useEthereumWalletClient";
+import { useMainnet } from "./useMainnet";
+
+export const useRequestRedeem = function ({
+  onEmitter,
+  shares,
+}: {
+  onEmitter?: (emitter: EventEmitter<RequestRedeemEvents>) => void;
+  shares: bigint;
+}) {
+  const { address: account } = useAccount();
+  const chain = useMainnet();
+  const { data: walletClient } = useEthereumWalletClient();
+  const ensureConnectedTo = useEnsureConnectedTo();
+  const ethereumChain = useMainnet();
+  const { queryKey: nativeBalanceKey } = useNativeBalance(ethereumChain.id);
+  const queryClient = useQueryClient();
+  const stakingVaultAddress = getStakingVaultAddress(chain.id);
+
+  const updateNativeBalanceAfterReceipt = useUpdateNativeBalanceAfterReceipt(
+    ethereumChain.id,
+  );
+
+  const sharesBalanceKey = tokenBalanceQueryKey(
+    { address: stakingVaultAddress, chainId: chain.id },
+    account,
+  );
+
+  return useMutation({
+    async mutationFn() {
+      if (!account) {
+        throw new Error("No account connected");
+      }
+
+      await ensureConnectedTo(chain.id);
+
+      const { emitter, promise } = requestRedeem(walletClient!, {
+        owner: account,
+        shares,
+      });
+
+      emitter.on("request-redeem-transaction-reverted", function (receipt) {
+        updateNativeBalanceAfterReceipt(receipt);
+      });
+      emitter.on("request-redeem-transaction-succeeded", function (receipt) {
+        updateNativeBalanceAfterReceipt(receipt);
+        queryClient.setQueryData(
+          sharesBalanceKey,
+          (old: bigint) => old - shares,
+        );
+      });
+
+      onEmitter?.(emitter);
+
+      return promise;
+    },
+    onSettled() {
+      queryClient.invalidateQueries({
+        queryKey: nativeBalanceKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: sharesBalanceKey,
+      });
+    },
+  });
+};

--- a/web/src/hooks/useRequestRedeem.ts
+++ b/web/src/hooks/useRequestRedeem.ts
@@ -19,20 +19,19 @@ export const useRequestRedeem = function ({
   shares: bigint;
 }) {
   const { address: account } = useAccount();
-  const chain = useMainnet();
   const { data: walletClient } = useEthereumWalletClient();
   const ensureConnectedTo = useEnsureConnectedTo();
   const ethereumChain = useMainnet();
   const { queryKey: nativeBalanceKey } = useNativeBalance(ethereumChain.id);
   const queryClient = useQueryClient();
-  const stakingVaultAddress = getStakingVaultAddress(chain.id);
+  const stakingVaultAddress = getStakingVaultAddress(ethereumChain.id);
 
   const updateNativeBalanceAfterReceipt = useUpdateNativeBalanceAfterReceipt(
     ethereumChain.id,
   );
 
   const sharesBalanceKey = tokenBalanceQueryKey(
-    { address: stakingVaultAddress, chainId: chain.id },
+    { address: stakingVaultAddress, chainId: ethereumChain.id },
     account,
   );
 
@@ -42,7 +41,7 @@ export const useRequestRedeem = function ({
         throw new Error("No account connected");
       }
 
-      await ensureConnectedTo(chain.id);
+      await ensureConnectedTo(ethereumChain.id);
 
       const { emitter, promise } = requestRedeem(walletClient!, {
         owner: account,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR:

- adds `useRequestRedeem` mutation, so users can request a redeem (if not whitelisted)
- Adds the invalidation for the native balance in the `redeem` that was missing, as well as exposing the `emitter` so the UI can react to it (once it's implemented)

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

N/A

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #6

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
