### PR TITLE
Fix useRequestRedeem.ts

### DIFF
--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -24,7 +24,11 @@ export { gatewayAbi } from "./abi/gatewayAbi.js";
 // Export gateway address utility
 export { getGatewayAddress } from "./getGatewayAddress.js";
 
-export { type DepositEvents, type RedeemEvents } from "./types.js";
+export {
+  type DepositEvents,
+  type RedeemEvents,
+  type RequestRedeemEvents,
+} from "./types.js";
 
 // Export factory functions for .extend() pattern
 export const gatewayPublicActions = () => (client: Client) => ({

--- a/web/src/hooks/useRequestRedeem.ts
+++ b/web/src/hooks/useRequestRedeem.ts
@@ -3,20 +3,21 @@ import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { getStakingVaultAddress, type RequestRedeemEvents } from "@vetro/earn";
-import { requestRedeem } from "@vetro/earn/actions";
+import type { RequestRedeemEvents } from "@vetro/gateway";
+import { requestRedeem } from "@vetro/gateway/actions";
 import type { EventEmitter } from "events";
 import { useAccount } from "wagmi";
 
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
+import { useVusd } from "./useVusd";
 
 export const useRequestRedeem = function ({
   onEmitter,
-  shares,
+  peggedTokenAmount,
 }: {
   onEmitter?: (emitter: EventEmitter<RequestRedeemEvents>) => void;
-  shares: bigint;
+  peggedTokenAmount: bigint;
 }) {
   const { address: account } = useAccount();
   const { data: walletClient } = useEthereumWalletClient();
@@ -24,15 +25,12 @@ export const useRequestRedeem = function ({
   const ethereumChain = useMainnet();
   const { queryKey: nativeBalanceKey } = useNativeBalance(ethereumChain.id);
   const queryClient = useQueryClient();
-  const stakingVaultAddress = getStakingVaultAddress(ethereumChain.id);
+  const { data: vusd } = useVusd();
+
+  const vusdBalanceQueryKey = tokenBalanceQueryKey(vusd, account);
 
   const updateNativeBalanceAfterReceipt = useUpdateNativeBalanceAfterReceipt(
     ethereumChain.id,
-  );
-
-  const sharesBalanceKey = tokenBalanceQueryKey(
-    { address: stakingVaultAddress, chainId: ethereumChain.id },
-    account,
   );
 
   return useMutation({
@@ -44,8 +42,7 @@ export const useRequestRedeem = function ({
       await ensureConnectedTo(ethereumChain.id);
 
       const { emitter, promise } = requestRedeem(walletClient!, {
-        owner: account,
-        shares,
+        peggedTokenAmount,
       });
 
       emitter.on("request-redeem-transaction-reverted", function (receipt) {
@@ -54,8 +51,8 @@ export const useRequestRedeem = function ({
       emitter.on("request-redeem-transaction-succeeded", function (receipt) {
         updateNativeBalanceAfterReceipt(receipt);
         queryClient.setQueryData(
-          sharesBalanceKey,
-          (old: bigint) => old - shares,
+          vusdBalanceQueryKey,
+          (old: bigint) => old - peggedTokenAmount,
         );
       });
 
@@ -68,7 +65,7 @@ export const useRequestRedeem = function ({
         queryKey: nativeBalanceKey,
       });
       queryClient.invalidateQueries({
-        queryKey: sharesBalanceKey,
+        queryKey: vusdBalanceQueryKey,
       });
     },
   });


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

I accidentally used `requestRedeem` from the `earn` package instead of using the one from the `gateway`  package. This PR fixes that

- 3dbf878ef142f116da3dd2e88d8ba4a62add5e5b Exports the types
- 3dca6513bc8a803a2e703aa1e0b88a6feec1805d Updates the hook to use the action from `vetro/gateway` instead of `vetro/earn`

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #6

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
