### PR TITLE
Fix subgraph exit ticket ids

### DIFF
--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vetro-app-subgraph",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "scripts": {
     "prebuild": "npm run codegen",

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -30,7 +30,7 @@ export function handleBlock(block: ethereum.Block): void {
 }
 
 export function handleWithdrawRequested(event: WithdrawRequested): void {
-  const id = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}`;
+  const id = event.params.requestId.toString();
   const entity = new ExitTicket(id);
 
   entity.owner = event.params.owner;
@@ -45,7 +45,7 @@ export function handleWithdrawRequested(event: WithdrawRequested): void {
 }
 
 export function handleWithdrawCancelled(event: WithdrawCancelled): void {
-  const id = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}`;
+  const id = event.params.requestId.toString();
   const entity = ExitTicket.load(id);
   if (entity == null) {
     return;
@@ -57,7 +57,7 @@ export function handleWithdrawCancelled(event: WithdrawCancelled): void {
 }
 
 export function handleWithdrawClaimed(event: WithdrawClaimed): void {
-  const id = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}`;
+  const id = event.params.requestId.toString();
   const entity = ExitTicket.load(id);
   if (entity == null) {
     return;

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -134,7 +134,7 @@ describe("handleWithdrawRequested", function () {
     );
     handleWithdrawRequested(event);
 
-    const id = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}`;
+    const id = requestId.toString();
     assert.entityCount("ExitTicket", 1);
     assert.fieldEquals("ExitTicket", id, "owner", ownerAddress.toHexString());
     assert.fieldEquals("ExitTicket", id, "assets", assets.toString());
@@ -170,7 +170,7 @@ describe("handleWithdrawCancelled", function () {
     );
     handleWithdrawRequested(requestEvent);
 
-    const id = `${requestEvent.transaction.hash.toHex()}-${requestEvent.logIndex.toString()}`;
+    const id = requestId.toString();
     assert.entityCount("ExitTicket", 1);
 
     const cancelEvent = createWithdrawCancelledEvent(
@@ -227,7 +227,7 @@ describe("handleWithdrawClaimed", function () {
     );
     handleWithdrawRequested(requestEvent);
 
-    const id = `${requestEvent.transaction.hash.toHex()}-${requestEvent.logIndex.toString()}`;
+    const id = requestId.toString();
     assert.entityCount("ExitTicket", 1);
 
     const claimEvent = createWithdrawClaimedEvent(


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The exit ticket entities where using the tx hash and event log index as id, which made no sense as there was no way to recover the original id from the claim or cancel events! The simplest and correct approach was to use the request id. This PR does exactly that. Thanks @ArturDolzan for finding the bug!

The PR also update the tests and bumps the subgraph version. A new subgraph has to be deployed and published. See: https://github.com/vetro-protocol/vetro-monorepo/tree/master/subgraph#deployment

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
