### PR TITLE
Redeem form Part I

### DIFF
--- a/web/src/components/feesContainer.tsx
+++ b/web/src/components/feesContainer.tsx
@@ -8,7 +8,7 @@ import feesSvg from "./icons/fees.svg";
 type Props = {
   children: ReactNode;
   isError?: boolean;
-  label: ReactNode;
+  label?: ReactNode;
   totalFees?: string;
 };
 
@@ -34,8 +34,8 @@ export function FeesContainer({ children, isError, label, totalFees }: Props) {
         role="button"
         tabIndex={0}
       >
-        <span className="font-semibold text-gray-900">{label}</span>
-        <div className="flex items-center gap-2">
+        {label && <span className="font-semibold text-gray-900">{label}</span>}
+        <div className="ml-auto flex items-center gap-2">
           {!isOpen && (
             <>
               <img alt="Fees icon" height="16" src={feesSvg} width="16" />

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -22,6 +22,7 @@ import { Form } from "./form";
 import { SubmitButton } from "./submitButton";
 import { type DepositFlowStatus, SwapDepositDrawer } from "./swapDepositDrawer";
 import { SwapFees } from "./swapFees";
+import { ToTokenBalance } from "./toTokenBalance";
 import { getSwapErrors } from "./validation";
 
 type Props = {
@@ -185,7 +186,7 @@ export function Deposit({
         onSubmit={handleSubmit}
         onToggle={onToggle}
         outputValue={outputValue}
-        toToken={toToken}
+        toBalance={<ToTokenBalance token={toToken} />}
         toTokenSelector={<TokenSelectorReadOnly {...toToken} />}
       >
         <SubmitButton

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -19,6 +19,7 @@ import type { Token } from "types";
 import { formatAmount } from "utils/token";
 
 import { Form } from "./form";
+import { OutputLabel } from "./outputLabel";
 import { SubmitButton } from "./submitButton";
 import { type DepositFlowStatus, SwapDepositDrawer } from "./swapDepositDrawer";
 import { SwapFees } from "./swapFees";
@@ -201,12 +202,17 @@ export function Deposit({
       <SwapFees
         amountBigInt={amountBigInt}
         approveAmount={approveAmount}
-        fromInputValue={fromInputValue}
         fromToken={fromToken}
         operationGasEstimation={operationGasEstimation}
-        outputValue={outputValue}
+        outputLabel={
+          <OutputLabel
+            fromInputValue={fromInputValue}
+            fromToken={fromToken}
+            outputValue={outputValue}
+            toToken={toToken}
+          />
+        }
         protocolFee={protocolFee}
-        toToken={toToken}
       />
       {isDrawerOpen && flowStatus !== "idle" && (
         <SwapDepositDrawer

--- a/web/src/components/swapForm/form.tsx
+++ b/web/src/components/swapForm/form.tsx
@@ -21,6 +21,7 @@ type Props = {
   onToggle: VoidFunction;
   outputValue: string;
   toBalance?: ReactNode;
+  toLabel?: string;
   toTokenSelector: ReactNode;
 };
 
@@ -36,6 +37,7 @@ export function Form({
   onToggle,
   outputValue,
   toBalance,
+  toLabel,
   toTokenSelector,
 }: Props) {
   const ethereumChain = useMainnet();
@@ -81,7 +83,7 @@ export function Form({
           <TokenInput
             balance={toBalance}
             disabled
-            label={t("pages.swap.form.you-will-receive")}
+            label={toLabel ?? t("pages.swap.form.you-will-receive")}
             tokenSelector={toTokenSelector}
             value={outputValue}
           />

--- a/web/src/components/swapForm/form.tsx
+++ b/web/src/components/swapForm/form.tsx
@@ -20,7 +20,7 @@ type Props = {
   onSubmit: (e: FormEvent) => void;
   onToggle: VoidFunction;
   outputValue: string;
-  toToken: Token;
+  toBalance?: ReactNode;
   toTokenSelector: ReactNode;
 };
 
@@ -35,7 +35,7 @@ export function Form({
   onSubmit,
   onToggle,
   outputValue,
-  toToken,
+  toBalance,
   toTokenSelector,
 }: Props) {
   const ethereumChain = useMainnet();
@@ -44,12 +44,6 @@ export function Form({
   const { data: fromTokenBalance, isError: isFromTokenBalanceError } =
     useTokenBalance({
       address: fromToken.address,
-      chainId: ethereumChain.id,
-    });
-
-  const { data: toTokenBalance, isError: isToTokenBalanceError } =
-    useTokenBalance({
-      address: toToken.address,
       chainId: ethereumChain.id,
     });
 
@@ -85,16 +79,7 @@ export function Form({
         </div>
         <div className="px-2">
           <TokenInput
-            balance={
-              <Balance
-                label={t("pages.swap.form.balance")}
-                value={formatAmount({
-                  amount: toTokenBalance,
-                  decimals: toToken.decimals,
-                  isError: isToTokenBalanceError,
-                })}
-              />
-            }
+            balance={toBalance}
             disabled
             label={t("pages.swap.form.you-will-receive")}
             tokenSelector={toTokenSelector}

--- a/web/src/components/swapForm/form.tsx
+++ b/web/src/components/swapForm/form.tsx
@@ -1,5 +1,6 @@
 import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
 import { TokenInput } from "components/tokenInput";
+import { Balance } from "components/tokenInput/balance";
 import { useMainnet } from "hooks/useMainnet";
 import type { FormEvent, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
@@ -60,12 +61,16 @@ export function Form({
       >
         <div className="px-2">
           <TokenInput
-            balanceLabel={t("pages.swap.form.balance")}
-            balanceValue={formatAmount({
-              amount: fromTokenBalance,
-              decimals: fromToken.decimals,
-              isError: isFromTokenBalanceError,
-            })}
+            balance={
+              <Balance
+                label={t("pages.swap.form.balance")}
+                value={formatAmount({
+                  amount: fromTokenBalance,
+                  decimals: fromToken.decimals,
+                  isError: isFromTokenBalanceError,
+                })}
+              />
+            }
             errorKey={errorKey}
             label={t("pages.swap.form.you-are-swapping")}
             maxButton={maxButton}
@@ -80,12 +85,16 @@ export function Form({
         </div>
         <div className="px-2">
           <TokenInput
-            balanceLabel={t("pages.swap.form.balance")}
-            balanceValue={formatAmount({
-              amount: toTokenBalance,
-              decimals: toToken.decimals,
-              isError: isToTokenBalanceError,
-            })}
+            balance={
+              <Balance
+                label={t("pages.swap.form.balance")}
+                value={formatAmount({
+                  amount: toTokenBalance,
+                  decimals: toToken.decimals,
+                  isError: isToTokenBalanceError,
+                })}
+              />
+            }
             disabled
             label={t("pages.swap.form.you-will-receive")}
             tokenSelector={toTokenSelector}

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -1,0 +1,247 @@
+import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
+import { useNeedsApproval } from "@hemilabs/react-hooks/useNeedsApproval";
+import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
+import { getGatewayAddress } from "@vetro/gateway";
+import { ApproveSection } from "components/approveSection";
+import { Toast } from "components/base/toast";
+import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
+import { TokenDropdown } from "components/tokenDropdown";
+import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
+import { useEstimateRedeemGas } from "hooks/useEstimateRedeemGas";
+import { useMainnet } from "hooks/useMainnet";
+import { usePreviewRedeem } from "hooks/usePreviewRedeem";
+import { useRedeem } from "hooks/useRedeem";
+import { useRedeemFee } from "hooks/useRedeemFee";
+import { useSwapFeesDisplay } from "hooks/useSwapFeesDisplay";
+import { type FormEvent, useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { Token } from "types";
+import { formatAmount } from "utils/token";
+import { useAccount } from "wagmi";
+
+import { Form } from "./form";
+import { OutputLabel } from "./outputLabel";
+import { SubmitButton } from "./submitButton";
+import { SwapFees } from "./swapFees";
+import { type RedeemFlowStatus, SwapRedeemDrawer } from "./swapRedeemDrawer";
+import { ToTokenBalance } from "./toTokenBalance";
+import { getSwapErrors } from "./validation";
+
+type Props = {
+  amountBigInt: bigint;
+  approve10x: boolean;
+  approveAmount: bigint | undefined;
+  fromInputValue: string;
+  fromToken: Token;
+  onInputChange: (value: string) => void;
+  onMaxClick: (maxValue: string) => void;
+  onToggle: VoidFunction;
+  onTokenChange: (token: Token) => void;
+  onToggleApprove10x: VoidFunction;
+  toToken: Token;
+  whitelistedTokens: Token[];
+};
+
+export function OneStepRedeem({
+  amountBigInt,
+  approve10x,
+  approveAmount,
+  fromInputValue,
+  fromToken,
+  onInputChange,
+  onMaxClick,
+  onToggle,
+  onToggleApprove10x,
+  onTokenChange,
+  toToken,
+  whitelistedTokens,
+}: Props) {
+  const { address } = useAccount();
+  const ethereumChain = useMainnet();
+  const { t } = useTranslation();
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const handleDrawerClose = useCallback(() => setIsDrawerOpen(false), []);
+  const [flowStatus, setFlowStatus] = useState<RedeemFlowStatus>("idle");
+  const [showToast, setShowToast] = useState(false);
+  const [startedWithApproval, setStartedWithApproval] = useState(false);
+
+  const { data: fromTokenBalance } = useTokenBalance({
+    address: fromToken.address,
+    chainId: ethereumChain.id,
+  });
+
+  const { data: nativeBalanceData } = useNativeBalance(ethereumChain.id);
+  const nativeBalance = nativeBalanceData?.value;
+
+  const { data: needsApproval } = useNeedsApproval({
+    amount: amountBigInt,
+    spender: getGatewayAddress(ethereumChain.id),
+    token: fromToken,
+  });
+
+  const { data: redeemPreview, isError: isPreviewError } = usePreviewRedeem({
+    peggedTokenIn: amountBigInt,
+    tokenOut: toToken.address,
+  });
+
+  const operationGasEstimation = useEstimateRedeemGas({
+    enabled: amountBigInt > 0n && !!redeemPreview && !!address,
+    minAmountOut: redeemPreview ?? 0n,
+    peggedToken: fromToken,
+    peggedTokenIn: amountBigInt,
+    receiver: address!,
+    tokenOut: toToken.address,
+  });
+
+  const protocolFee = useRedeemFee();
+
+  const redeemMutation = useRedeem({
+    approveAmount,
+    onEmitter(emitter) {
+      emitter.on("user-signed-approval", () => setFlowStatus("approving"));
+      emitter.on("approve-transaction-succeeded", () =>
+        setFlowStatus("approved"),
+      );
+      emitter.on("approve-transaction-reverted", () =>
+        setFlowStatus("approve-error"),
+      );
+      emitter.on("user-signing-approval-error", () =>
+        setFlowStatus("approve-error"),
+      );
+      emitter.on("pre-redeem", () => setFlowStatus("redeem-ready"));
+      emitter.on("user-signed-redeem", () => setFlowStatus("redeeming"));
+      emitter.on("redeem-transaction-succeeded", function () {
+        setFlowStatus("redeemed");
+        setShowToast(true);
+      });
+      emitter.on("redeem-transaction-reverted", () =>
+        setFlowStatus("redeem-error"),
+      );
+      emitter.on("user-signing-redeem-error", () =>
+        setFlowStatus("redeem-error"),
+      );
+      emitter.on("redeem-failed-validation", () =>
+        setFlowStatus("redeem-error"),
+      );
+    },
+    peggedTokenIn: amountBigInt,
+    tokenOut: toToken.address,
+  });
+
+  const inputError = getSwapErrors({
+    amount: amountBigInt,
+    nativeBalance,
+    tokenBalance: fromTokenBalance,
+  });
+
+  const outputValue = formatAmount({
+    amount: redeemPreview,
+    decimals: toToken.decimals,
+    isError: isPreviewError,
+  });
+
+  const { networkFeeDisplay, protocolFeeDisplay, totalFeesDisplay } =
+    useSwapFeesDisplay({
+      amountBigInt,
+      approveAmount,
+      fromToken,
+      operationGasEstimation,
+      protocolFee,
+    });
+
+  const balancesLoaded =
+    nativeBalance !== undefined && fromTokenBalance !== undefined;
+
+  const handleRetry = function () {
+    setFlowStatus(startedWithApproval ? "approving" : "redeem-ready");
+    redeemMutation.mutate();
+  };
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!inputError) {
+      setStartedWithApproval(!!needsApproval);
+      setFlowStatus(needsApproval ? "approving" : "redeem-ready");
+      redeemMutation.mutate();
+      setIsDrawerOpen(true);
+    }
+  }
+
+  return (
+    <>
+      <Form
+        errorKey={balancesLoaded ? inputError : undefined}
+        fromInputValue={fromInputValue}
+        fromToken={fromToken}
+        fromTokenSelector={
+          <TokenSelectorReadOnly
+            logoURI={fromToken.logoURI}
+            symbol={fromToken.symbol}
+          />
+        }
+        maxButton={
+          <SetMaxErc20Balance onClick={onMaxClick} token={fromToken} />
+        }
+        onInputChange={onInputChange}
+        onSubmit={handleSubmit}
+        onToggle={onToggle}
+        outputValue={outputValue}
+        toBalance={<ToTokenBalance token={toToken} />}
+        toTokenSelector={
+          <TokenDropdown
+            onChange={onTokenChange}
+            tokens={whitelistedTokens}
+            value={toToken}
+          />
+        }
+      >
+        <SubmitButton
+          actionText={t("pages.swap.form.redeem")}
+          inputError={inputError}
+          isPreviewError={isPreviewError}
+          previewValue={redeemPreview}
+          token={fromToken}
+        />
+      </Form>
+      <ApproveSection active={approve10x} onToggle={onToggleApprove10x} />
+      <SwapFees
+        amountBigInt={amountBigInt}
+        approveAmount={approveAmount}
+        fromToken={fromToken}
+        operationGasEstimation={operationGasEstimation}
+        outputLabel={
+          <OutputLabel
+            fromInputValue={fromInputValue}
+            fromToken={fromToken}
+            outputValue={outputValue}
+            toToken={toToken}
+          />
+        }
+        protocolFee={protocolFee}
+      />
+      {isDrawerOpen && flowStatus !== "idle" && (
+        <SwapRedeemDrawer
+          flowStatus={flowStatus}
+          fromAmount={fromInputValue}
+          fromToken={fromToken}
+          networkFee={networkFeeDisplay}
+          onClose={handleDrawerClose}
+          onRetry={handleRetry}
+          outputValue={outputValue}
+          protocolFee={protocolFeeDisplay}
+          showApproveStep={startedWithApproval}
+          toToken={toToken}
+          totalFees={totalFeesDisplay}
+        />
+      )}
+      {showToast && (
+        <Toast
+          closable
+          description={t("pages.swap.toast.deposit-description")}
+          onClose={() => setShowToast(false)}
+          title={t("pages.swap.toast.deposit-title")}
+        />
+      )}
+    </>
+  );
+}

--- a/web/src/components/swapForm/redeem.tsx
+++ b/web/src/components/swapForm/redeem.tsx
@@ -1,24 +1,9 @@
-import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
-import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
-import { ApproveSection } from "components/approveSection";
-import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
-import { TokenDropdown } from "components/tokenDropdown";
-import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
-import { useEstimateRedeemGas } from "hooks/useEstimateRedeemGas";
-import { useMainnet } from "hooks/useMainnet";
-import { usePreviewRedeem } from "hooks/usePreviewRedeem";
-import { useRedeem } from "hooks/useRedeem";
-import { useRedeemFee } from "hooks/useRedeemFee";
-import { type FormEvent } from "react";
-import { useTranslation } from "react-i18next";
+import { useRedeemDelay } from "hooks/useRedeemDelay";
 import type { Token } from "types";
-import { formatAmount } from "utils/token";
 import { useAccount } from "wagmi";
 
-import { Form } from "./form";
-import { SubmitButton } from "./submitButton";
-import { SwapFees } from "./swapFees";
-import { getSwapErrors } from "./validation";
+import { OneStepRedeem } from "./oneStepRedeem";
+import { TwoStepRedeem } from "./twoStepRedeem";
 
 type Props = {
   amountBigInt: bigint;
@@ -35,123 +20,21 @@ type Props = {
   whitelistedTokens: Token[];
 };
 
-export function Redeem({
-  amountBigInt,
-  approve10x,
-  approveAmount,
-  fromInputValue,
-  fromToken,
-  onInputChange,
-  onMaxClick,
-  onToggle,
-  onToggleApprove10x,
-  onTokenChange,
-  toToken,
-  whitelistedTokens,
-}: Props) {
+export function Redeem(props: Props) {
   const { address } = useAccount();
-  const ethereumChain = useMainnet();
-  const { t } = useTranslation();
+  const { data: redeemDelay, isLoading } = useRedeemDelay();
 
-  const { data: fromTokenBalance } = useTokenBalance({
-    address: fromToken.address,
-    chainId: ethereumChain.id,
-  });
-
-  const { data: nativeBalanceData } = useNativeBalance(ethereumChain.id);
-  const nativeBalance = nativeBalanceData?.value;
-
-  const { data: redeemPreview, isError: isPreviewError } = usePreviewRedeem({
-    peggedTokenIn: amountBigInt,
-    tokenOut: toToken.address,
-  });
-
-  const operationGasEstimation = useEstimateRedeemGas({
-    enabled: amountBigInt > 0n && !!redeemPreview && !!address,
-    minAmountOut: redeemPreview ?? 0n,
-    peggedToken: fromToken,
-    peggedTokenIn: amountBigInt,
-    receiver: address!,
-    tokenOut: toToken.address,
-  });
-
-  const protocolFee = useRedeemFee();
-
-  const redeemMutation = useRedeem({
-    approveAmount,
-    peggedTokenIn: amountBigInt,
-    tokenOut: toToken.address,
-  });
-
-  const inputError = getSwapErrors({
-    amount: amountBigInt,
-    nativeBalance,
-    tokenBalance: fromTokenBalance,
-  });
-
-  const outputValue = formatAmount({
-    amount: redeemPreview,
-    decimals: toToken.decimals,
-    isError: isPreviewError,
-  });
-
-  const balancesLoaded =
-    nativeBalance !== undefined && fromTokenBalance !== undefined;
-
-  function handleSubmit(e: FormEvent) {
-    e.preventDefault();
-    if (!inputError) {
-      redeemMutation.mutate();
-    }
+  // If disconnected, show the most common case which is the 2-step redeem
+  if (!address) {
+    return <TwoStepRedeem {...props} />;
   }
 
-  return (
-    <>
-      <Form
-        errorKey={balancesLoaded ? inputError : undefined}
-        fromInputValue={fromInputValue}
-        fromToken={fromToken}
-        fromTokenSelector={
-          <TokenSelectorReadOnly
-            logoURI={fromToken.logoURI}
-            symbol={fromToken.symbol}
-          />
-        }
-        maxButton={
-          <SetMaxErc20Balance onClick={onMaxClick} token={fromToken} />
-        }
-        onInputChange={onInputChange}
-        onSubmit={handleSubmit}
-        onToggle={onToggle}
-        outputValue={outputValue}
-        toToken={toToken}
-        toTokenSelector={
-          <TokenDropdown
-            onChange={onTokenChange}
-            tokens={whitelistedTokens}
-            value={toToken}
-          />
-        }
-      >
-        <SubmitButton
-          actionText={t("pages.swap.form.redeem")}
-          inputError={inputError}
-          isPreviewError={isPreviewError}
-          previewValue={redeemPreview}
-          token={fromToken}
-        />
-      </Form>
-      <ApproveSection active={approve10x} onToggle={onToggleApprove10x} />
-      <SwapFees
-        amountBigInt={amountBigInt}
-        approveAmount={approveAmount}
-        fromInputValue={fromInputValue}
-        fromToken={fromToken}
-        operationGasEstimation={operationGasEstimation}
-        outputValue={outputValue}
-        protocolFee={protocolFee}
-        toToken={toToken}
-      />
-    </>
-  );
+  if (isLoading) {
+    // TODO: proper loading state to be added later
+    return "...";
+  }
+
+  const hasDelay = redeemDelay !== undefined && redeemDelay > 0n;
+
+  return hasDelay ? <TwoStepRedeem {...props} /> : <OneStepRedeem {...props} />;
 }

--- a/web/src/components/swapForm/swapFees.tsx
+++ b/web/src/components/swapForm/swapFees.tsx
@@ -1,35 +1,30 @@
 import { FeeDetails } from "components/feeDetails";
 import { FeesContainer } from "components/feesContainer";
 import { useSwapFeesDisplay } from "hooks/useSwapFeesDisplay";
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import type { Token } from "types";
-
-import { OutputLabel } from "./outputLabel";
 
 type Props = {
   amountBigInt: bigint;
   approveAmount: bigint | undefined;
-  fromInputValue: string;
   fromToken: Token;
   operationGasEstimation: {
     fees: bigint | undefined;
     isEnabled: boolean;
     isError: boolean;
   };
-  outputValue: string;
+  outputLabel?: ReactNode;
   protocolFee: { data: bigint | undefined; isError: boolean };
-  toToken: Token;
 };
 
 export const SwapFees = function ({
   amountBigInt,
   approveAmount,
-  fromInputValue,
   fromToken,
   operationGasEstimation,
-  outputValue,
+  outputLabel,
   protocolFee,
-  toToken,
 }: Props) {
   const { t } = useTranslation();
 
@@ -44,17 +39,7 @@ export const SwapFees = function ({
 
   return (
     <div className="w-full max-w-md border-t border-gray-200">
-      <FeesContainer
-        label={
-          <OutputLabel
-            fromInputValue={fromInputValue}
-            fromToken={fromToken}
-            outputValue={outputValue}
-            toToken={toToken}
-          />
-        }
-        totalFees={totalFeesDisplay}
-      >
+      <FeesContainer label={outputLabel} totalFees={totalFeesDisplay}>
         <FeeDetails
           label={t("pages.swap.fees.network-fee")}
           value={networkFeeDisplay}

--- a/web/src/components/swapForm/swapRedeemDrawer.tsx
+++ b/web/src/components/swapForm/swapRedeemDrawer.tsx
@@ -1,0 +1,125 @@
+import { Drawer } from "components/base/drawer";
+import { DrawerLoader } from "components/base/drawer/drawerLoader";
+import { type Step, stepStatus } from "components/base/verticalStepper";
+import { Suspense, lazy, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import type { Token } from "types";
+
+const SwapProgressDrawer = lazy(() =>
+  import("./swapProgressDrawer").then((m) => ({
+    default: m.SwapProgressDrawer,
+  })),
+);
+
+export type RedeemFlowStatus =
+  | "approve-error"
+  | "approved"
+  | "approving"
+  | "idle"
+  | "redeem-error"
+  | "redeem-ready"
+  | "redeemed"
+  | "redeeming";
+
+const approveStepStatuses: Record<
+  Exclude<RedeemFlowStatus, "idle">,
+  Step["status"]
+> = {
+  "approve-error": stepStatus.failed,
+  approved: stepStatus.completed,
+  approving: stepStatus.progress,
+  "redeem-error": stepStatus.completed,
+  "redeem-ready": stepStatus.completed,
+  redeemed: stepStatus.completed,
+  redeeming: stepStatus.completed,
+};
+
+const confirmStepStatuses: Record<
+  Exclude<RedeemFlowStatus, "idle">,
+  Step["status"]
+> = {
+  "approve-error": stepStatus.notReady,
+  approved: stepStatus.notReady,
+  approving: stepStatus.notReady,
+  "redeem-error": stepStatus.failed,
+  "redeem-ready": stepStatus.ready,
+  redeemed: stepStatus.completed,
+  redeeming: stepStatus.progress,
+};
+
+type Props = {
+  flowStatus: Exclude<RedeemFlowStatus, "idle">;
+  fromAmount: string;
+  fromToken: Token;
+  networkFee: string;
+  onClose: VoidFunction;
+  onRetry: VoidFunction;
+  outputValue: string;
+  protocolFee: string;
+  showApproveStep: boolean;
+  toToken: Token;
+  totalFees: string;
+};
+
+export function SwapRedeemDrawer({
+  flowStatus,
+  fromAmount,
+  fromToken,
+  networkFee,
+  onClose,
+  onRetry,
+  outputValue,
+  protocolFee,
+  showApproveStep,
+  totalFees,
+  toToken,
+}: Props) {
+  const { t } = useTranslation();
+  useEffect(
+    function closeDrawerOnSuccess() {
+      if (flowStatus !== "redeemed") {
+        return undefined;
+      }
+      const timeoutId = setTimeout(onClose, 3000);
+      return () => clearTimeout(timeoutId);
+    },
+    [flowStatus, onClose],
+  );
+
+  const isError =
+    flowStatus === "approve-error" || flowStatus === "redeem-error";
+
+  const steps: Step[] = [
+    {
+      description: t("pages.swap.progress.confirm-description"),
+      status: confirmStepStatuses[flowStatus],
+      title: t("pages.swap.progress.confirm-title"),
+    },
+  ];
+
+  if (showApproveStep) {
+    steps.unshift({
+      description: t("pages.swap.progress.approve-description"),
+      status: approveStepStatuses[flowStatus],
+      title: t("pages.swap.progress.approve-title"),
+    });
+  }
+
+  return (
+    <Drawer onClose={onClose}>
+      <Suspense fallback={<DrawerLoader />}>
+        <SwapProgressDrawer
+          fromAmount={fromAmount}
+          fromToken={fromToken}
+          networkFee={networkFee}
+          onRetry={isError ? onRetry : undefined}
+          outputValue={outputValue}
+          protocolFee={protocolFee}
+          steps={steps}
+          toToken={toToken}
+          totalFees={totalFees}
+        />
+      </Suspense>
+    </Drawer>
+  );
+}

--- a/web/src/components/swapForm/toTokenBalance.tsx
+++ b/web/src/components/swapForm/toTokenBalance.tsx
@@ -1,0 +1,32 @@
+import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
+import { Balance } from "components/tokenInput/balance";
+import { useMainnet } from "hooks/useMainnet";
+import { useTranslation } from "react-i18next";
+import type { Token } from "types";
+import { formatAmount } from "utils/token";
+
+type Props = {
+  token: Token;
+};
+
+export const ToTokenBalance = function ({ token }: Props) {
+  const chain = useMainnet();
+  const { t } = useTranslation();
+
+  const { data: toTokenBalance, isError: isToTokenBalanceError } =
+    useTokenBalance({
+      address: token.address,
+      chainId: chain.id,
+    });
+
+  return (
+    <Balance
+      label={t("pages.swap.form.balance")}
+      value={formatAmount({
+        amount: toTokenBalance,
+        decimals: token.decimals,
+        isError: isToTokenBalanceError,
+      })}
+    />
+  );
+};

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -158,12 +158,9 @@ export function TwoStepRedeem({
       <SwapFees
         amountBigInt={amountBigInt}
         approveAmount={approveAmount}
-        fromInputValue={fromInputValue}
         fromToken={fromToken}
         operationGasEstimation={operationGasEstimation}
-        outputValue={outputValue}
         protocolFee={protocolFee}
-        toToken={toToken}
       />
       {isDrawerOpen && (
         // TODO add 2-step redeem drawer in next PR

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -1,0 +1,176 @@
+import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
+import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
+import { ApproveSection } from "components/approveSection";
+import { Drawer } from "components/base/drawer";
+import { DrawerLoader } from "components/base/drawer/drawerLoader";
+import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
+import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
+import { useEstimateRequestRedeemGas } from "hooks/useEstimateRequestRedeemGas";
+import { useMainnet } from "hooks/useMainnet";
+import { usePreviewRedeem } from "hooks/usePreviewRedeem";
+import { useRedeemFee } from "hooks/useRedeemFee";
+import { useRequestRedeem } from "hooks/useRequestRedeem";
+import { useSwapFeesDisplay } from "hooks/useSwapFeesDisplay";
+import { type FormEvent, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { Token } from "types";
+import { formatAmount } from "utils/token";
+import { useAccount } from "wagmi";
+
+import { Form } from "./form";
+import { SubmitButton } from "./submitButton";
+import { SwapFees } from "./swapFees";
+import { getSwapErrors } from "./validation";
+
+type Props = {
+  amountBigInt: bigint;
+  approve10x: boolean;
+  approveAmount: bigint | undefined;
+  fromInputValue: string;
+  fromToken: Token;
+  onInputChange: (value: string) => void;
+  onMaxClick: (maxValue: string) => void;
+  onToggle: VoidFunction;
+  onTokenChange: (token: Token) => void;
+  onToggleApprove10x: VoidFunction;
+  toToken: Token;
+  whitelistedTokens: Token[];
+};
+
+export function TwoStepRedeem({
+  amountBigInt,
+  approve10x,
+  approveAmount,
+  fromInputValue,
+  fromToken,
+  onInputChange,
+  onMaxClick,
+  onToggle,
+  onToggleApprove10x,
+  toToken,
+  whitelistedTokens,
+}: Props) {
+  const { address } = useAccount();
+  const ethereumChain = useMainnet();
+  const { t } = useTranslation();
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  const { data: fromTokenBalance } = useTokenBalance({
+    address: fromToken.address,
+    chainId: ethereumChain.id,
+  });
+
+  const { data: nativeBalanceData } = useNativeBalance(ethereumChain.id);
+  const nativeBalance = nativeBalanceData?.value;
+
+  const { data: redeemPreview, isError: isPreviewError } = usePreviewRedeem({
+    peggedTokenIn: amountBigInt,
+    tokenOut: toToken.address,
+  });
+
+  const operationGasEstimation = useEstimateRequestRedeemGas({
+    enabled: amountBigInt > 0n && !!address,
+    owner: address,
+    peggedToken: fromToken,
+    peggedTokenIn: amountBigInt,
+  });
+
+  const protocolFee = useRedeemFee();
+
+  const requestRedeemMutation = useRequestRedeem({
+    peggedTokenAmount: amountBigInt,
+  });
+
+  const inputError = getSwapErrors({
+    amount: amountBigInt,
+    nativeBalance,
+    tokenBalance: fromTokenBalance,
+  });
+
+  const outputValue = formatAmount({
+    amount: redeemPreview,
+    decimals: toToken.decimals,
+    isError: isPreviewError,
+  });
+
+  useSwapFeesDisplay({
+    amountBigInt,
+    approveAmount,
+    fromToken,
+    operationGasEstimation,
+    protocolFee,
+  });
+
+  const balancesLoaded =
+    nativeBalance !== undefined && fromTokenBalance !== undefined;
+
+  const redeemableForText = t("pages.swap.form.redeemable-for", {
+    allButLast: whitelistedTokens
+      .slice(0, -1)
+      .map((tk) => tk.symbol)
+      .join(", "),
+    count: whitelistedTokens.length,
+    last: whitelistedTokens.at(-1)!.symbol,
+    symbol: whitelistedTokens[0]?.symbol,
+  });
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!inputError) {
+      requestRedeemMutation.mutate();
+      setIsDrawerOpen(true);
+    }
+  }
+
+  return (
+    <>
+      <Form
+        errorKey={balancesLoaded ? inputError : undefined}
+        fromInputValue={fromInputValue}
+        fromToken={fromToken}
+        fromTokenSelector={
+          <TokenSelectorReadOnly
+            logoURI={fromToken.logoURI}
+            symbol={fromToken.symbol}
+          />
+        }
+        maxButton={
+          <SetMaxErc20Balance onClick={onMaxClick} token={fromToken} />
+        }
+        onInputChange={onInputChange}
+        onSubmit={handleSubmit}
+        onToggle={onToggle}
+        outputValue={outputValue}
+        toLabel={t("pages.swap.form.you-will-receive-approximately")}
+        toTokenSelector={
+          <span className="text-sm font-semibold">{redeemableForText}</span>
+        }
+      >
+        <SubmitButton
+          actionText={t("pages.swap.form.redeem")}
+          inputError={inputError}
+          isPreviewError={isPreviewError}
+          previewValue={redeemPreview}
+          token={fromToken}
+        />
+      </Form>
+      <ApproveSection active={approve10x} onToggle={onToggleApprove10x} />
+      <SwapFees
+        amountBigInt={amountBigInt}
+        approveAmount={approveAmount}
+        fromInputValue={fromInputValue}
+        fromToken={fromToken}
+        operationGasEstimation={operationGasEstimation}
+        outputValue={outputValue}
+        protocolFee={protocolFee}
+        toToken={toToken}
+      />
+      {isDrawerOpen && (
+        // TODO add 2-step redeem drawer in next PR
+        <Drawer onClose={() => setIsDrawerOpen(false)}>
+          <DrawerLoader />
+        </Drawer>
+      )}
+    </>
+  );
+}

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -10,7 +10,6 @@ import { useMainnet } from "hooks/useMainnet";
 import { usePreviewRedeem } from "hooks/usePreviewRedeem";
 import { useRedeemFee } from "hooks/useRedeemFee";
 import { useRequestRedeem } from "hooks/useRequestRedeem";
-import { useSwapFeesDisplay } from "hooks/useSwapFeesDisplay";
 import { type FormEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Token } from "types";
@@ -91,14 +90,6 @@ export function TwoStepRedeem({
     amount: redeemPreview,
     decimals: toToken.decimals,
     isError: isPreviewError,
-  });
-
-  useSwapFeesDisplay({
-    amountBigInt,
-    approveAmount,
-    fromToken,
-    operationGasEstimation,
-    protocolFee,
   });
 
   const balancesLoaded =

--- a/web/src/components/tokenInput/index.tsx
+++ b/web/src/components/tokenInput/index.tsx
@@ -1,11 +1,9 @@
 import type { ReactNode } from "react";
 
-import { Balance } from "./balance";
 import { getTextColor } from "./utils";
 
 type Props = {
-  balanceLabel: string;
-  balanceValue: string;
+  balance?: ReactNode;
   disabled?: boolean;
   errorKey?: string;
   label: string;
@@ -16,8 +14,7 @@ type Props = {
 };
 
 export const TokenInput = ({
-  balanceLabel,
-  balanceValue,
+  balance,
   disabled = false,
   errorKey,
   label,
@@ -40,10 +37,12 @@ export const TokenInput = ({
     </div>
     <div className="mt-2 flex items-center justify-between">
       <span className="text-xsm text-gray-500">${value}</span>
-      <div className="text-xsm flex items-center gap-1">
-        <Balance label={balanceLabel} value={balanceValue} />
-        {maxButton}
-      </div>
+      {balance || maxButton ? (
+        <div className="text-xsm flex items-center gap-1">
+          {balance}
+          {maxButton}
+        </div>
+      ) : null}
     </div>
   </div>
 );

--- a/web/src/hooks/useEstimateRequestRedeemGas.ts
+++ b/web/src/hooks/useEstimateRequestRedeemGas.ts
@@ -1,0 +1,66 @@
+import { useEstimateFees } from "@hemilabs/react-hooks/useEstimateFees";
+import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
+import { getGatewayAddress } from "@vetro/gateway";
+import { encodeRequestRedeem } from "@vetro/gateway/actions";
+import type { Token } from "types";
+import { createErc20AllowanceStateOverride } from "utils/erc20StateOverride";
+import type { Address } from "viem";
+import { useEstimateGas } from "wagmi";
+
+import { useMainnet } from "./useMainnet";
+
+type Params = {
+  enabled?: boolean;
+  owner: Address | undefined;
+  peggedToken: Token;
+  peggedTokenIn: bigint;
+};
+
+export const useEstimateRequestRedeemGas = function ({
+  enabled = true,
+  owner,
+  peggedToken,
+  peggedTokenIn,
+}: Params) {
+  const ethereumChain = useMainnet();
+  const { data: tokenBalance } = useTokenBalance(peggedToken);
+
+  const gatewayAddress = getGatewayAddress(ethereumChain.id);
+
+  const data = encodeRequestRedeem({
+    peggedTokenAmount: peggedTokenIn,
+  });
+
+  const {
+    data: gasUnits,
+    isEnabled,
+    isError: isGasUnitsError,
+  } = useEstimateGas({
+    chainId: ethereumChain.id,
+    data,
+    query: {
+      enabled:
+        enabled &&
+        peggedTokenIn > 0n &&
+        tokenBalance !== undefined &&
+        tokenBalance >= peggedTokenIn,
+    },
+    stateOverride: createErc20AllowanceStateOverride({
+      owner,
+      spender: gatewayAddress,
+      token: peggedToken,
+    }),
+    to: gatewayAddress,
+  });
+
+  const feeEstimation = useEstimateFees({
+    chainId: ethereumChain.id,
+    gasUnits,
+    isGasUnitsError,
+  });
+
+  return {
+    ...feeEstimation,
+    isEnabled,
+  };
+};

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -131,8 +131,11 @@
         "insufficient-gas": "Insufficient ETH for gas",
         "preview-error": "Failed to calculate amount to receive",
         "redeem": "Redeem",
+        "redeemable-for_one": "Redeemable for {{symbol}}",
+        "redeemable-for_other": "Redeemable for {{allButLast}} and {{last}}",
         "you-are-swapping": "You are swapping",
-        "you-will-receive": "You will receive"
+        "you-will-receive": "You will receive",
+        "you-will-receive-approximately": "You will receive (approximately)"
       },
       "progress": {
         "approve-description": "This allows the app to use this token for your swap.",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -131,8 +131,11 @@
         "insufficient-gas": "ETH insuficiente para gas",
         "preview-error": "No se pudo calcular el monto a recibir",
         "redeem": "Canjear",
+        "redeemable-for_one": "Intercambiable por {{symbol}}",
+        "redeemable-for_other": "Intercambiable por {{allButLast}} y {{last}}",
         "you-are-swapping": "Vas a intercambiar",
-        "you-will-receive": "Vas a recibir"
+        "you-will-receive": "Vas a recibir",
+        "you-will-receive-approximately": "Vas a recibir (aproximadamente)"
       },
       "progress": {
         "approve-description": "Esto permite que la app use este token para su intercambio.",

--- a/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
@@ -9,6 +9,7 @@ import { FeeDetails } from "components/feeDetails";
 import { FeesContainer } from "components/feesContainer";
 import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
 import { TokenInput } from "components/tokenInput";
+import { Balance } from "components/tokenInput/balance";
 import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
 import { useMainnet } from "hooks/useMainnet";
 import { useStakeDeposit } from "hooks/useStakeDeposit";
@@ -249,8 +250,12 @@ export function StakeDepositForm({
     <form className="flex flex-1 flex-col" onSubmit={handleSubmit}>
       <div className="p-6">
         <TokenInput
-          balanceLabel={t("pages.earn.stake.available-to-deposit")}
-          balanceValue={formattedBalance}
+          balance={
+            <Balance
+              label={t("pages.earn.stake.available-to-deposit")}
+              value={formattedBalance}
+            />
+          }
           errorKey={balancesLoaded ? inputError : undefined}
           label={t("pages.earn.stake.you-will-stake")}
           maxButton={

--- a/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
@@ -5,6 +5,7 @@ import { FeeDetails } from "components/feeDetails";
 import { FeesContainer } from "components/feesContainer";
 import { SetMaxStakedBalance } from "components/setMaxStakedBalance";
 import { TokenInput } from "components/tokenInput";
+import { Balance } from "components/tokenInput/balance";
 import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
 import { useMainnet } from "hooks/useMainnet";
 import { useStakedBalance } from "hooks/useStakedBalance";
@@ -156,8 +157,12 @@ export function StakeWithdrawForm({
     <form className="flex flex-1 flex-col" onSubmit={handleSubmit}>
       <div className="p-6">
         <TokenInput
-          balanceLabel={t("pages.earn.stake.available-to-withdraw")}
-          balanceValue={formattedBalance}
+          balance={
+            <Balance
+              label={t("pages.earn.stake.available-to-withdraw")}
+              value={formattedBalance}
+            />
+          }
           errorKey={balancesLoaded ? inputError : undefined}
           label={t("pages.earn.stake.you-will-withdraw")}
           maxButton={


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR:

- f0902c4228471f96eb9e570b6fec405e025ed18c Updates the `TokenInput` to compose with a custom Balance token (So we can omit it in the 2-step redeem form)
- 6df2f44f6674dc0b67c7d871a0359d0de676b53f Updates the `SwapForm` for the same
- d9d9c2bb657cd4f91eeaeee45c46176f6faa91bd Adds the `TwoStepRedeem` form, without the Drawer (a loading is shown instead)
- 21f9a4a415212dd724908d24d563cd39a7253472 Makes the conversion `1 VUSD = X <Token>` optional for the 2 step request redeem, as it's unknown which token will be used.
- f73b843b9073472d1ed532d735760bbf53ed383c Adds the one-step `redeem` drawer, that whitelisted users (or users when the delay is not enabled) will use 


Note: Rounding/formatting of numbers and gas values is still pending

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Redeem in one step, when the user is either whitelisted or the delay is not enabled

https://github.com/user-attachments/assets/877c72db-1921-4b23-9397-ea01a04c65cf

The form for the 2 step (drawer not developed yet)


<img width="1105" height="830" alt="image" src="https://github.com/user-attachments/assets/fab3ff8a-332b-47e6-99e7-9ad1e5f79efa" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #6

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.