### PR TITLE
Add withdraw and withdraw-all functionality

### DIFF
--- a/web/src/hooks/useClaimWithdraw.ts
+++ b/web/src/hooks/useClaimWithdraw.ts
@@ -1,0 +1,111 @@
+import { useEnsureConnectedTo } from "@hemilabs/react-hooks/useEnsureConnectedTo";
+import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
+import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
+import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getStakingVaultAddress } from "@vetro/earn";
+import { claimWithdraw } from "@vetro/earn/actions";
+import { exitTicketsQueryKey } from "pages/earn/hooks/useExitTickets";
+import type { ExitTicket } from "pages/earn/types";
+import { useAccount } from "wagmi";
+
+import { useEthereumWalletClient } from "./useEthereumWalletClient";
+import { useMainnet } from "./useMainnet";
+import { stakedBalanceQueryKey } from "./useStakedBalance";
+
+type ClaimWithdrawStatus = "claiming" | "completed" | "failed";
+
+type Params = {
+  onStatusChange: (status: ClaimWithdrawStatus) => void;
+  requestId: bigint;
+};
+
+export const useClaimWithdraw = function ({
+  onStatusChange,
+  requestId,
+}: Params) {
+  const { address: account } = useAccount();
+  const chain = useMainnet();
+  const { data: walletClient } = useEthereumWalletClient();
+  const ensureConnectedTo = useEnsureConnectedTo();
+  const queryClient = useQueryClient();
+  const stakingVaultAddress = getStakingVaultAddress(chain.id);
+  const { queryKey: nativeBalanceKey } = useNativeBalance(chain.id);
+  const updateNativeBalanceAfterReceipt = useUpdateNativeBalanceAfterReceipt(
+    chain.id,
+  );
+
+  const sharesBalanceKey = tokenBalanceQueryKey(
+    { address: stakingVaultAddress, chainId: chain.id },
+    account,
+  );
+
+  const stakedKey = stakedBalanceQueryKey({
+    account: account!,
+    chainId: chain.id,
+    stakingVaultAddress,
+  });
+
+  return useMutation({
+    async mutationFn() {
+      if (!account) {
+        throw new Error("No account connected");
+      }
+
+      await ensureConnectedTo(chain.id);
+
+      const { emitter, promise } = claimWithdraw(walletClient!, {
+        receiver: account,
+        requestId,
+      });
+
+      emitter.on("user-signed-claim-withdraw", function () {
+        onStatusChange("claiming");
+      });
+
+      emitter.on("user-signing-claim-withdraw-error", function () {
+        onStatusChange("failed");
+      });
+
+      emitter.on("claim-withdraw-transaction-reverted", function (receipt) {
+        updateNativeBalanceAfterReceipt(receipt);
+        onStatusChange("failed");
+      });
+
+      emitter.on("claim-withdraw-transaction-succeeded", function (receipt) {
+        updateNativeBalanceAfterReceipt(receipt);
+        onStatusChange("completed");
+
+        // Optimistically mark ticket as withdrawn by setting claimTxHash
+        queryClient.setQueryData(
+          exitTicketsQueryKey(account),
+          (old: ExitTicket[] | undefined) =>
+            (old ?? []).map((t) =>
+              t.requestId === requestId.toString()
+                ? { ...t, claimTxHash: receipt.transactionHash }
+                : t,
+            ),
+        );
+      });
+
+      return promise;
+    },
+    async onSettled() {
+      queryClient.invalidateQueries({
+        queryKey: nativeBalanceKey,
+      });
+
+      await queryClient.invalidateQueries({
+        queryKey: sharesBalanceKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: stakedKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: exitTicketsQueryKey(account),
+      });
+    },
+  });
+};

--- a/web/src/hooks/useClaimWithdrawBatch.ts
+++ b/web/src/hooks/useClaimWithdrawBatch.ts
@@ -1,0 +1,119 @@
+import { useEnsureConnectedTo } from "@hemilabs/react-hooks/useEnsureConnectedTo";
+import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
+import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
+import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getStakingVaultAddress } from "@vetro/earn";
+import { claimWithdrawBatch } from "@vetro/earn/actions";
+import { exitTicketsQueryKey } from "pages/earn/hooks/useExitTickets";
+import type { ExitTicket } from "pages/earn/types";
+import { useAccount } from "wagmi";
+
+import { useEthereumWalletClient } from "./useEthereumWalletClient";
+import { useMainnet } from "./useMainnet";
+import { stakedBalanceQueryKey } from "./useStakedBalance";
+
+type ClaimWithdrawBatchStatus = "claiming" | "completed" | "failed";
+
+type Params = {
+  onStatusChange: (status: ClaimWithdrawBatchStatus) => void;
+  requestIds: bigint[];
+};
+
+export const useClaimWithdrawBatch = function ({
+  onStatusChange,
+  requestIds,
+}: Params) {
+  const { address: account } = useAccount();
+  const chain = useMainnet();
+  const { data: walletClient } = useEthereumWalletClient();
+  const ensureConnectedTo = useEnsureConnectedTo();
+  const queryClient = useQueryClient();
+  const stakingVaultAddress = getStakingVaultAddress(chain.id);
+  const { queryKey: nativeBalanceKey } = useNativeBalance(chain.id);
+  const updateNativeBalanceAfterReceipt = useUpdateNativeBalanceAfterReceipt(
+    chain.id,
+  );
+
+  const sharesBalanceKey = tokenBalanceQueryKey(
+    { address: stakingVaultAddress, chainId: chain.id },
+    account,
+  );
+
+  const stakedKey = stakedBalanceQueryKey({
+    account: account!,
+    chainId: chain.id,
+    stakingVaultAddress,
+  });
+
+  const requestIdStrings = requestIds.map((id) => id.toString());
+
+  return useMutation({
+    async mutationFn() {
+      if (!account) {
+        throw new Error("No account connected");
+      }
+
+      await ensureConnectedTo(chain.id);
+
+      const { emitter, promise } = claimWithdrawBatch(walletClient!, {
+        receiver: account,
+        requestIds,
+      });
+
+      emitter.on("user-signed-claim-withdraw-batch", function () {
+        onStatusChange("claiming");
+      });
+
+      emitter.on("user-signing-claim-withdraw-batch-error", function () {
+        onStatusChange("failed");
+      });
+
+      emitter.on(
+        "claim-withdraw-batch-transaction-reverted",
+        function (receipt) {
+          updateNativeBalanceAfterReceipt(receipt);
+          onStatusChange("failed");
+        },
+      );
+
+      emitter.on(
+        "claim-withdraw-batch-transaction-succeeded",
+        function (receipt) {
+          updateNativeBalanceAfterReceipt(receipt);
+          onStatusChange("completed");
+
+          // Optimistically mark all claimed tickets as withdrawn
+          queryClient.setQueryData(
+            exitTicketsQueryKey(account),
+            (old: ExitTicket[] | undefined) =>
+              (old ?? []).map((t) =>
+                requestIdStrings.includes(t.requestId)
+                  ? { ...t, claimTxHash: receipt.transactionHash }
+                  : t,
+              ),
+          );
+        },
+      );
+
+      return promise;
+    },
+    async onSettled() {
+      queryClient.invalidateQueries({
+        queryKey: nativeBalanceKey,
+      });
+
+      await queryClient.invalidateQueries({
+        queryKey: sharesBalanceKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: stakedKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: exitTicketsQueryKey(account),
+      });
+    },
+  });
+};

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -57,8 +57,13 @@
         "view-settings": "View settings",
         "withdraw": "Withdraw",
         "withdraw-all": "Withdraw all",
+        "withdraw-all-toast-description": "All ready exit tickets have been withdrawn to your wallet.",
+        "withdraw-all-toast-title": "All withdrawals complete",
+        "withdraw-toast-description": "Your funds have been successfully withdrawn to your wallet.",
+        "withdraw-toast-title": "Withdrawal complete",
         "withdrawal-amount": "{{amount}} vUSD",
         "withdrawal-tx": "Withdrawal:",
+        "withdrawing": "Withdrawing...",
         "withdrawn": "Withdrawn"
       },
       "pool-info": {

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -57,8 +57,13 @@
         "view-settings": "Ver configuración",
         "withdraw": "Retirar",
         "withdraw-all": "Retirar todo",
+        "withdraw-all-toast-description": "Todos los tickets de salida listos han sido retirados a su billetera.",
+        "withdraw-all-toast-title": "Todos los retiros completados",
+        "withdraw-toast-description": "Sus fondos han sido retirados exitosamente a su billetera.",
+        "withdraw-toast-title": "Retiro completado",
         "withdrawal-amount": "{{amount}} vUSD",
         "withdrawal-tx": "Retiro:",
+        "withdrawing": "Retirando...",
         "withdrawn": "Retirado"
       },
       "pool-info": {

--- a/web/src/pages/earn/components/exitTickets/actionsCell.tsx
+++ b/web/src/pages/earn/components/exitTickets/actionsCell.tsx
@@ -37,6 +37,7 @@ export function ActionsCell({
   const { mutate: claimWithdraw } = useClaimWithdraw({
     onStatusChange(claimStatus) {
       if (claimStatus === "completed") {
+        setIsWithdrawing(false);
         setToastType("withdraw");
         onWithdrawingChange?.(false);
       }

--- a/web/src/pages/earn/components/exitTickets/actionsCell.tsx
+++ b/web/src/pages/earn/components/exitTickets/actionsCell.tsx
@@ -1,9 +1,12 @@
+import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { Button, ButtonIcon } from "components/base/button";
 import { Toast } from "components/base/toast";
 import { Tooltip } from "components/tooltip";
+import { useClaimWithdraw } from "hooks/useClaimWithdraw";
 import { TrashIcon } from "pages/earn/icons/trashIcon";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useAccount } from "wagmi";
 
 import type { ExitTicket } from "../../types";
 
@@ -11,30 +14,79 @@ import { DeleteTicketModal } from "./deleteTicketModal";
 import { getTicketStatus } from "./getTicketStatus";
 
 type Props = {
+  disabled?: boolean;
+  onWithdrawingChange?: (isWithdrawing: boolean) => void;
   ticket: ExitTicket;
 };
 
-export function ActionsCell({ ticket }: Props) {
+type ToastType = "delete" | "withdraw";
+
+export function ActionsCell({
+  disabled = false,
+  onWithdrawingChange,
+  ticket,
+}: Props) {
   const { t } = useTranslation();
+  const { isConnected } = useAccount();
+  const { openConnectModal } = useConnectModal();
   const status = getTicketStatus(ticket);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [showToast, setShowToast] = useState(false);
+  const [isWithdrawing, setIsWithdrawing] = useState(false);
+  const [toastType, setToastType] = useState<ToastType | null>(null);
+
+  const { mutate: claimWithdraw } = useClaimWithdraw({
+    onStatusChange(claimStatus) {
+      if (claimStatus === "completed") {
+        setToastType("withdraw");
+        onWithdrawingChange?.(false);
+      }
+      if (claimStatus === "failed") {
+        setIsWithdrawing(false);
+        onWithdrawingChange?.(false);
+      }
+    },
+    requestId: BigInt(ticket.requestId),
+  });
 
   if (status === "withdrawn") {
     return null;
   }
 
+  function handleWithdraw() {
+    setIsWithdrawing(true);
+    onWithdrawingChange?.(true);
+    claimWithdraw();
+  }
+
   return (
     <>
       <div className="flex items-center gap-3">
-        {status === "ready" && (
-          <Button size="xSmall" variant="primary">
-            {t("pages.earn.exit-tickets.withdraw")}
-          </Button>
-        )}
+        {status === "ready" &&
+          (isConnected ? (
+            <Button
+              disabled={disabled || isWithdrawing}
+              onClick={handleWithdraw}
+              size="xSmall"
+              variant="primary"
+            >
+              <span className="invisible">
+                {t("pages.earn.exit-tickets.withdrawing")}
+              </span>
+              <span className="absolute">
+                {isWithdrawing
+                  ? t("pages.earn.exit-tickets.withdrawing")
+                  : t("pages.earn.exit-tickets.withdraw")}
+              </span>
+            </Button>
+          ) : (
+            <Button onClick={openConnectModal} size="xSmall" variant="primary">
+              {t("pages.swap.form.connect-wallet")}
+            </Button>
+          ))}
         <Tooltip content={t("pages.earn.exit-tickets.delete-tooltip")}>
           <ButtonIcon
             aria-label={t("pages.earn.exit-tickets.delete-tooltip")}
+            disabled={disabled || isWithdrawing}
             onClick={() => setIsModalOpen(true)}
             size="xSmall"
             variant="secondary"
@@ -46,16 +98,24 @@ export function ActionsCell({ ticket }: Props) {
       {isModalOpen && (
         <DeleteTicketModal
           onClose={() => setIsModalOpen(false)}
-          onSuccess={() => setShowToast(true)}
+          onSuccess={() => setToastType("delete")}
           ticket={ticket}
         />
       )}
-      {showToast && (
+      {toastType === "delete" && (
         <Toast
           closable
           description={t("pages.earn.exit-tickets.delete-toast-description")}
-          onClose={() => setShowToast(false)}
+          onClose={() => setToastType(null)}
           title={t("pages.earn.exit-tickets.delete-toast-title")}
+        />
+      )}
+      {toastType === "withdraw" && (
+        <Toast
+          closable
+          description={t("pages.earn.exit-tickets.withdraw-toast-description")}
+          onClose={() => setToastType(null)}
+          title={t("pages.earn.exit-tickets.withdraw-toast-title")}
         />
       )}
     </>

--- a/web/src/pages/earn/components/exitTickets/index.tsx
+++ b/web/src/pages/earn/components/exitTickets/index.tsx
@@ -122,7 +122,7 @@ export function ExitTickets() {
     "pending",
   ]);
   const [isWithdrawingAll, setIsWithdrawingAll] = useState(false);
-  const [isWithdrawingSingle, setIsWithdrawingSingle] = useState(false);
+  const [withdrawingSingleCount, setWithdrawingSingleCount] = useState(0);
   const [showWithdrawAllToast, setShowWithdrawAllToast] = useState(false);
 
   const readyTickets = useMemo(
@@ -168,7 +168,9 @@ export function ExitTickets() {
         cooldownDuration,
         isWithdrawingAll,
         language: i18n.language,
-        onWithdrawingChange: setIsWithdrawingSingle,
+        onWithdrawingChange(isWithdrawing) {
+          setWithdrawingSingleCount((c) => c + (isWithdrawing ? 1 : -1));
+        },
         t,
       }),
     [cooldownDuration, i18n.language, isWithdrawingAll, t],
@@ -233,7 +235,7 @@ export function ExitTickets() {
               disabled={
                 readyTickets.length === 0 ||
                 isWithdrawingAll ||
-                isWithdrawingSingle
+                withdrawingSingleCount > 0
               }
               onClick={handleWithdrawAll}
               size="xSmall"

--- a/web/src/pages/earn/components/exitTickets/index.tsx
+++ b/web/src/pages/earn/components/exitTickets/index.tsx
@@ -1,3 +1,4 @@
+import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { type ColumnDef } from "@tanstack/react-table";
 import { Badge } from "components/base/badge";
 import { Button } from "components/base/button";
@@ -5,10 +6,13 @@ import { FilterMenu } from "components/base/filterMenu";
 import { StatusBadge } from "components/base/statusBadge";
 import { Table } from "components/base/table";
 import { Header } from "components/base/table/header";
+import { Toast } from "components/base/toast";
+import { useClaimWithdrawBatch } from "hooks/useClaimWithdrawBatch";
 import { TableCellsIcon } from "pages/earn/icons/tableCellsIcon";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { formatDate } from "utils/date";
+import { useAccount } from "wagmi";
 
 import { useCooldownDuration } from "../../hooks/useCooldownDuration";
 import { useExitTickets } from "../../hooks/useExitTickets";
@@ -27,11 +31,19 @@ const statusLabels = {
   withdrawn: "pages.earn.exit-tickets.withdrawn",
 } as const;
 
-const getColumns = (
-  cooldownDuration: bigint | undefined,
-  language: string,
-  t: ReturnType<typeof useTranslation>["t"],
-): ColumnDef<ExitTicket>[] => [
+const getColumns = ({
+  cooldownDuration,
+  isWithdrawingAll,
+  language,
+  onWithdrawingChange,
+  t,
+}: {
+  cooldownDuration: bigint | undefined;
+  isWithdrawingAll: boolean;
+  language: string;
+  onWithdrawingChange: (isWithdrawing: boolean) => void;
+  t: ReturnType<typeof useTranslation>["t"];
+}): ColumnDef<ExitTicket>[] => [
   {
     cell: ({ row }) => (
       <span className="text-xsm font-normal text-gray-500">
@@ -82,10 +94,17 @@ const getColumns = (
     cell: ({ row }) => <TxsCell ticket={row.original} />,
     header: () => <Header text={t("pages.earn.exit-tickets.col-txs")} />,
     id: "txs",
-    meta: { width: "112px" },
+    meta: { width: "132px" },
   },
   {
-    cell: ({ row }) => <ActionsCell ticket={row.original} />,
+    cell: ({ row }) => (
+      <ActionsCell
+        disabled={isWithdrawingAll}
+        key={row.original.requestId}
+        onWithdrawingChange={onWithdrawingChange}
+        ticket={row.original}
+      />
+    ),
     header: () => <Header text={t("pages.earn.exit-tickets.actions")} />,
     id: "actions",
     meta: { className: "justify-end", width: "150px" },
@@ -96,10 +115,38 @@ export function ExitTickets() {
   const { data: cooldownDuration } = useCooldownDuration();
   const { data, isLoading } = useExitTickets();
   const { i18n, t } = useTranslation();
+  const { isConnected } = useAccount();
+  const { openConnectModal } = useConnectModal();
   const [selectedFilters, setSelectedFilters] = useState([
     "completed",
     "pending",
   ]);
+  const [isWithdrawingAll, setIsWithdrawingAll] = useState(false);
+  const [isWithdrawingSingle, setIsWithdrawingSingle] = useState(false);
+  const [showWithdrawAllToast, setShowWithdrawAllToast] = useState(false);
+
+  const readyTickets = useMemo(
+    () => (data ?? []).filter((ticket) => getTicketStatus(ticket) === "ready"),
+    [data],
+  );
+
+  const readyRequestIds = useMemo(
+    () => readyTickets.map((ticket) => BigInt(ticket.requestId)),
+    [readyTickets],
+  );
+
+  const { mutate: claimWithdrawBatch } = useClaimWithdrawBatch({
+    onStatusChange(status) {
+      if (status === "completed") {
+        setIsWithdrawingAll(false);
+        setShowWithdrawAllToast(true);
+      }
+      if (status === "failed") {
+        setIsWithdrawingAll(false);
+      }
+    },
+    requestIds: readyRequestIds,
+  });
 
   const filterOptions = useMemo(
     () => [
@@ -116,8 +163,15 @@ export function ExitTickets() {
   );
 
   const columns = useMemo(
-    () => getColumns(cooldownDuration, i18n.language, t),
-    [cooldownDuration, i18n.language, t],
+    () =>
+      getColumns({
+        cooldownDuration,
+        isWithdrawingAll,
+        language: i18n.language,
+        onWithdrawingChange: setIsWithdrawingSingle,
+        t,
+      }),
+    [cooldownDuration, i18n.language, isWithdrawingAll, t],
   );
 
   // Filter and sort data based on selected filters and ticket status
@@ -153,12 +207,10 @@ export function ExitTickets() {
     [data, selectedFilters],
   );
 
-  const readyCount = useMemo(
-    () =>
-      (data ?? []).filter((ticket) => getTicketStatus(ticket) === "ready")
-        .length,
-    [data],
-  );
+  function handleWithdrawAll() {
+    setIsWithdrawingAll(true);
+    claimWithdrawBatch();
+  }
 
   return (
     <div>
@@ -176,10 +228,37 @@ export function ExitTickets() {
             selectedValues={selectedFilters}
           />
           <div className="h-3 w-0.5 rounded-full bg-gray-200" />
-          <Button size="xSmall" variant="primary">
-            {t("pages.earn.exit-tickets.withdraw-all")}
-            {readyCount > 0 && <Badge variant="blue">{readyCount}</Badge>}
-          </Button>
+          {isConnected ? (
+            <Button
+              disabled={
+                readyTickets.length === 0 ||
+                isWithdrawingAll ||
+                isWithdrawingSingle
+              }
+              onClick={handleWithdrawAll}
+              size="xSmall"
+              variant="primary"
+            >
+              <span className="invisible flex items-center gap-x-1">
+                {t("pages.earn.exit-tickets.withdraw-all")}
+                {readyTickets.length > 0 && (
+                  <Badge variant="blue">{readyTickets.length}</Badge>
+                )}
+              </span>
+              <span className="absolute flex items-center gap-x-1">
+                {isWithdrawingAll
+                  ? t("pages.earn.exit-tickets.withdrawing")
+                  : t("pages.earn.exit-tickets.withdraw-all")}
+                {!isWithdrawingAll && readyTickets.length > 0 && (
+                  <Badge variant="blue">{readyTickets.length}</Badge>
+                )}
+              </span>
+            </Button>
+          ) : (
+            <Button onClick={openConnectModal} size="xSmall" variant="primary">
+              {t("pages.swap.form.connect-wallet")}
+            </Button>
+          )}
         </div>
       </div>
       {/* Table */}
@@ -191,6 +270,16 @@ export function ExitTickets() {
         placeholder={<EmptyState />}
         priorityColumnIdsOnSmall={["actions"]}
       />
+      {showWithdrawAllToast && (
+        <Toast
+          closable
+          description={t(
+            "pages.earn.exit-tickets.withdraw-all-toast-description",
+          )}
+          onClose={() => setShowWithdrawAllToast(false)}
+          title={t("pages.earn.exit-tickets.withdraw-all-toast-title")}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Description

This PR wires up claimWithdraw and claimWithdrawBatch actions to exit tickets table. Individual withdraw buttons disable the batch button and vice versa. Includes optimistic cache updates, wallet connection checks, loading states without layout shift, and toast notifications on success.

### Screenshots

https://github.com/user-attachments/assets/f6613c51-3807-4ee5-97bb-df67192aede2

### Related issue(s)

Related to #23
Related to #https://github.com/vetro-protocol/vetro-monorepo/pull/93#issuecomment-3915035834

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
