### PR TITLE
Fix race condition on settle

### DIFF
--- a/web/src/hooks/useCancelWithdraw.ts
+++ b/web/src/hooks/useCancelWithdraw.ts
@@ -104,10 +104,6 @@ export const useCancelWithdraw = function ({
       queryClient.invalidateQueries({
         queryKey: stakedKey,
       });
-
-      queryClient.invalidateQueries({
-        queryKey: exitTicketsQueryKey(account),
-      });
     },
   });
 };

--- a/web/src/hooks/useClaimWithdraw.ts
+++ b/web/src/hooks/useClaimWithdraw.ts
@@ -102,10 +102,6 @@ export const useClaimWithdraw = function ({
       queryClient.invalidateQueries({
         queryKey: stakedKey,
       });
-
-      queryClient.invalidateQueries({
-        queryKey: exitTicketsQueryKey(account),
-      });
     },
   });
 };

--- a/web/src/hooks/useClaimWithdrawBatch.ts
+++ b/web/src/hooks/useClaimWithdrawBatch.ts
@@ -110,10 +110,6 @@ export const useClaimWithdrawBatch = function ({
       queryClient.invalidateQueries({
         queryKey: stakedKey,
       });
-
-      queryClient.invalidateQueries({
-        queryKey: exitTicketsQueryKey(account),
-      });
     },
   });
 };

--- a/web/src/hooks/useStakeWithdraw.ts
+++ b/web/src/hooks/useStakeWithdraw.ts
@@ -132,10 +132,6 @@ export const useStakeWithdraw = function ({
       queryClient.invalidateQueries({
         queryKey: stakedKey,
       });
-
-      queryClient.invalidateQueries({
-        queryKey: exitTicketsQueryKey(account),
-      });
     },
   });
 };


### PR DESCRIPTION
### Description

This PR removes invalidation from onSettled to prevent the subgraph race condition where the immediate refetch overwrites the optimistic update before the new block is indexed.

### Screenshots

No UI changes

### Related issue(s)

Related to #23 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
