### PR TITLE
Add activity tracking to swap page

### DIFF
--- a/web/src/components/swapForm/cancelRedeemModal.tsx
+++ b/web/src/components/swapForm/cancelRedeemModal.tsx
@@ -1,10 +1,12 @@
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { Button } from "components/base/button";
 import { Modal } from "components/base/modal";
+import { useActivityTracking } from "hooks/useActivityTracking";
 import { useCancelRedeemRequest } from "hooks/useCancelRedeemRequest";
 import { useVusd } from "hooks/useVusd";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { formatUnits } from "viem";
 import { useAccount } from "wagmi";
 
 type Props = {
@@ -24,23 +26,44 @@ export function CancelRedeemModal({
   const { t } = useTranslation();
   const { data: vusd } = useVusd();
 
+  const { onCompleted, onFailed, onPending, onTransactionHash } =
+    useActivityTracking({
+      page: "swap",
+      text: t("pages.swap.activity.cancel-redeem-text", {
+        amount: formatUnits(redeemableAmount, vusd.decimals),
+        symbol: vusd.symbol,
+      }),
+      title: `${t("nav.swap")} · ${t("pages.swap.redeem-vault.cancel-redeem")}`,
+    });
+
   const { mutate } = useCancelRedeemRequest({
     onEmitter(emitter) {
       emitter.on("pre-cancel-redeem-request", () => setIsCancelling(true));
+      emitter.on("user-signed-cancel-redeem-request", function (hash) {
+        onTransactionHash(hash);
+        onPending();
+      });
       emitter.on("cancel-redeem-request-transaction-succeeded", function () {
+        onCompleted();
         onClose();
         onSuccess();
       });
-      emitter.on("cancel-redeem-request-failed", () => setIsCancelling(false));
-      emitter.on("cancel-redeem-request-failed-validation", () =>
-        setIsCancelling(false),
-      );
-      emitter.on("cancel-redeem-request-transaction-reverted", () =>
-        setIsCancelling(false),
-      );
-      emitter.on("user-signing-cancel-redeem-request-error", () =>
-        setIsCancelling(false),
-      );
+      emitter.on("cancel-redeem-request-failed", function () {
+        onFailed();
+        setIsCancelling(false);
+      });
+      emitter.on("cancel-redeem-request-failed-validation", function () {
+        onFailed();
+        setIsCancelling(false);
+      });
+      emitter.on("cancel-redeem-request-transaction-reverted", function () {
+        onFailed();
+        setIsCancelling(false);
+      });
+      emitter.on("user-signing-cancel-redeem-request-error", function () {
+        onFailed();
+        setIsCancelling(false);
+      });
     },
     redeemableAmount,
   });

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -8,6 +8,7 @@ import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
 import { TokenDropdown } from "components/tokenDropdown";
 import { TokenInput } from "components/tokenInput";
 import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
+import { useActivityTracking } from "hooks/useActivityTracking";
 import { useDeposit } from "hooks/useDeposit";
 import { useEstimateDepositGas } from "hooks/useEstimateDepositGas";
 import { useMainnet } from "hooks/useMainnet";
@@ -85,6 +86,24 @@ export function Deposit({
       tokenIn: fromToken.address,
     });
 
+  const outputValue = formatAmount({
+    amount: depositPreview,
+    decimals: toToken.decimals,
+    isError: isDepositPreviewError,
+  });
+
+  const { onCompleted, onFailed, onPending, onTransactionHash } =
+    useActivityTracking({
+      page: "swap",
+      text: t("pages.swap.activity.swap-text", {
+        fromAmount: fromInputValue,
+        fromSymbol: fromToken.symbol,
+        toAmount: outputValue,
+        toSymbol: toToken.symbol,
+      }),
+      title: t("nav.swap"),
+    });
+
   const protocolFee = useMintFee();
 
   const operationGasEstimation = useEstimateDepositGas({
@@ -108,21 +127,32 @@ export function Deposit({
         setFlowStatus("approve-error"),
       );
       emitter.on("pre-deposit", () => setFlowStatus("deposit-ready"));
-      emitter.on("user-signed-deposit", () => setFlowStatus("depositing"));
-      emitter.on("deposit-failed", () => setFlowStatus("deposit-error"));
+      emitter.on("user-signed-deposit", function (hash) {
+        onTransactionHash(hash);
+        onPending();
+        setFlowStatus("depositing");
+      });
+      emitter.on("deposit-failed", function () {
+        onFailed();
+        setFlowStatus("deposit-error");
+      });
       emitter.on("deposit-transaction-succeeded", function () {
+        onCompleted();
         setFlowStatus("deposited");
         setShowToast(true);
       });
-      emitter.on("deposit-transaction-reverted", () =>
-        setFlowStatus("deposit-error"),
-      );
-      emitter.on("user-signing-deposit-error", () =>
-        setFlowStatus("deposit-error"),
-      );
-      emitter.on("deposit-failed-validation", () =>
-        setFlowStatus("deposit-error"),
-      );
+      emitter.on("deposit-transaction-reverted", function () {
+        onFailed();
+        setFlowStatus("deposit-error");
+      });
+      emitter.on("user-signing-deposit-error", function () {
+        onFailed();
+        setFlowStatus("deposit-error");
+      });
+      emitter.on("deposit-failed-validation", function () {
+        onFailed();
+        setFlowStatus("deposit-error");
+      });
     },
     tokenIn: fromToken.address,
   });
@@ -133,12 +163,6 @@ export function Deposit({
     amount: amountBigInt,
     nativeBalance,
     tokenBalance: fromTokenBalance,
-  });
-
-  const outputValue = formatAmount({
-    amount: depositPreview,
-    decimals: toToken.decimals,
-    isError: isDepositPreviewError,
   });
 
   const { networkFeeDisplay, protocolFeeDisplay, totalFeesDisplay } =

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -8,6 +8,7 @@ import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
 import { TokenDropdown } from "components/tokenDropdown";
 import { TokenInput } from "components/tokenInput";
 import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
+import { useActivityTracking } from "hooks/useActivityTracking";
 import { useEstimateRedeemGas } from "hooks/useEstimateRedeemGas";
 import { useMainnet } from "hooks/useMainnet";
 import { usePreviewRedeem } from "hooks/usePreviewRedeem";
@@ -85,6 +86,24 @@ export function OneStepRedeem({
     tokenOut: toToken.address,
   });
 
+  const outputValue = formatAmount({
+    amount: redeemPreview,
+    decimals: toToken.decimals,
+    isError: isPreviewError,
+  });
+
+  const { onCompleted, onFailed, onPending, onTransactionHash } =
+    useActivityTracking({
+      page: "swap",
+      text: t("pages.swap.activity.swap-text", {
+        fromAmount: fromInputValue,
+        fromSymbol: fromToken.symbol,
+        toAmount: outputValue,
+        toSymbol: toToken.symbol,
+      }),
+      title: t("nav.swap"),
+    });
+
   const operationGasEstimation = useEstimateRedeemGas({
     enabled: !!address,
     minAmountOut: redeemPreview ?? 0n,
@@ -110,20 +129,28 @@ export function OneStepRedeem({
         setFlowStatus("approve-error"),
       );
       emitter.on("pre-redeem", () => setFlowStatus("redeem-ready"));
-      emitter.on("user-signed-redeem", () => setFlowStatus("redeeming"));
+      emitter.on("user-signed-redeem", function (hash) {
+        onTransactionHash(hash);
+        onPending();
+        setFlowStatus("redeeming");
+      });
       emitter.on("redeem-transaction-succeeded", function () {
+        onCompleted();
         setFlowStatus("redeemed");
         setShowToast(true);
       });
-      emitter.on("redeem-transaction-reverted", () =>
-        setFlowStatus("redeem-error"),
-      );
-      emitter.on("user-signing-redeem-error", () =>
-        setFlowStatus("redeem-error"),
-      );
-      emitter.on("redeem-failed-validation", () =>
-        setFlowStatus("redeem-error"),
-      );
+      emitter.on("redeem-transaction-reverted", function () {
+        onFailed();
+        setFlowStatus("redeem-error");
+      });
+      emitter.on("user-signing-redeem-error", function () {
+        onFailed();
+        setFlowStatus("redeem-error");
+      });
+      emitter.on("redeem-failed-validation", function () {
+        onFailed();
+        setFlowStatus("redeem-error");
+      });
     },
     peggedTokenIn: amountBigInt,
     tokenOut: toToken.address,
@@ -133,12 +160,6 @@ export function OneStepRedeem({
     amount: amountBigInt,
     nativeBalance,
     tokenBalance: fromTokenBalance,
-  });
-
-  const outputValue = formatAmount({
-    amount: redeemPreview,
-    decimals: toToken.decimals,
-    isError: isPreviewError,
   });
 
   const { networkFeeDisplay, protocolFeeDisplay, totalFeesDisplay } =

--- a/web/src/components/swapForm/redeemVault.tsx
+++ b/web/src/components/swapForm/redeemVault.tsx
@@ -1,5 +1,6 @@
 import { TopSection } from "components/base/table/topSection";
 import { Toast } from "components/base/toast";
+import { useActivityTracking } from "hooks/useActivityTracking";
 import { useEstimateRedeemGas } from "hooks/useEstimateRedeemGas";
 import { useGetRedeemRequest } from "hooks/useGetRedeemRequest";
 import { usePreviewRedeem } from "hooks/usePreviewRedeem";
@@ -49,6 +50,24 @@ export function RedeemVault({ whitelistedTokens }: Props) {
     tokenOut: toToken.address,
   });
 
+  const outputValue = formatAmount({
+    amount: redeemPreview,
+    decimals: toToken.decimals,
+    isError: isPreviewError,
+  });
+
+  const { onCompleted, onFailed, onPending, onTransactionHash } =
+    useActivityTracking({
+      page: "swap",
+      text: t("pages.swap.activity.claim-redeem-text", {
+        fromAmount: fromInputValue,
+        fromSymbol: vusd.symbol,
+        toAmount: outputValue,
+        toSymbol: toToken.symbol,
+      }),
+      title: `${t("nav.swap")} · ${t("pages.swap.redeem-vault.redeem")}`,
+    });
+
   const operationGasEstimation = useEstimateRedeemGas({
     enabled: !!address,
     minAmountOut: redeemPreview ?? 0n,
@@ -72,29 +91,31 @@ export function RedeemVault({ whitelistedTokens }: Props) {
   const redeemMutation = useRedeem({
     onEmitter(emitter) {
       emitter.on("pre-redeem", () => setFlowStatus("redeem-ready"));
-      emitter.on("user-signed-redeem", () => setFlowStatus("redeeming"));
+      emitter.on("user-signed-redeem", function (hash) {
+        onTransactionHash(hash);
+        onPending();
+        setFlowStatus("redeeming");
+      });
       emitter.on("redeem-transaction-succeeded", function () {
+        onCompleted();
         setFlowStatus("redeemed");
         setToastType("redeem");
       });
-      emitter.on("redeem-transaction-reverted", () =>
-        setFlowStatus("redeem-error"),
-      );
-      emitter.on("user-signing-redeem-error", () =>
-        setFlowStatus("redeem-error"),
-      );
-      emitter.on("redeem-failed-validation", () =>
-        setFlowStatus("redeem-error"),
-      );
+      emitter.on("redeem-transaction-reverted", function () {
+        onFailed();
+        setFlowStatus("redeem-error");
+      });
+      emitter.on("user-signing-redeem-error", function () {
+        onFailed();
+        setFlowStatus("redeem-error");
+      });
+      emitter.on("redeem-failed-validation", function () {
+        onFailed();
+        setFlowStatus("redeem-error");
+      });
     },
     peggedTokenIn: amountBigInt,
     tokenOut: toToken.address,
-  });
-
-  const outputValue = formatAmount({
-    amount: redeemPreview,
-    decimals: toToken.decimals,
-    isError: isPreviewError,
   });
 
   const handleMaxClick = () =>

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -8,6 +8,7 @@ import { Toast } from "components/base/toast";
 import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
 import { StripedDivider } from "components/stripedDivider";
 import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
+import { useActivityTracking } from "hooks/useActivityTracking";
 import { useEstimateRequestRedeemGas } from "hooks/useEstimateRequestRedeemGas";
 import { useMainnet } from "hooks/useMainnet";
 import { usePreviewRedeem } from "hooks/usePreviewRedeem";
@@ -112,6 +113,16 @@ export function TwoStepRedeem({
     tokenOut: toToken.address,
   });
 
+  const { onCompleted, onFailed, onPending, onTransactionHash } =
+    useActivityTracking({
+      page: "swap",
+      text: t("pages.swap.activity.request-redeem-text", {
+        amount: fromInputValue,
+        symbol: fromToken.symbol,
+      }),
+      title: t("nav.swap"),
+    });
+
   const operationGasEstimation = useEstimateRequestRedeemGas({
     enabled: !!address,
     owner: address,
@@ -137,23 +148,29 @@ export function TwoStepRedeem({
       emitter.on("pre-request-redeem", () =>
         setFlowStatus("request-redeem-ready"),
       );
-      emitter.on("user-signed-request-redeem", () =>
-        setFlowStatus("request-redeeming"),
-      );
+      emitter.on("user-signed-request-redeem", function (hash) {
+        onTransactionHash(hash);
+        onPending();
+        setFlowStatus("request-redeeming");
+      });
       emitter.on("request-redeem-transaction-succeeded", function () {
+        onCompleted();
         setFlowStatus("request-redeemed");
         setShowToast(true);
         redeemVaultRef.current?.scrollIntoView({ behavior: "smooth" });
       });
-      emitter.on("request-redeem-transaction-reverted", () =>
-        setFlowStatus("request-redeem-error"),
-      );
-      emitter.on("user-signing-request-redeem-error", () =>
-        setFlowStatus("request-redeem-error"),
-      );
-      emitter.on("request-redeem-failed-validation", () =>
-        setFlowStatus("request-redeem-error"),
-      );
+      emitter.on("request-redeem-transaction-reverted", function () {
+        onFailed();
+        setFlowStatus("request-redeem-error");
+      });
+      emitter.on("user-signing-request-redeem-error", function () {
+        onFailed();
+        setFlowStatus("request-redeem-error");
+      });
+      emitter.on("request-redeem-failed-validation", function () {
+        onFailed();
+        setFlowStatus("request-redeem-error");
+      });
     },
     peggedTokenAmount: amountBigInt,
   });

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -181,6 +181,12 @@
       "title": "Hello Faq"
     },
     "swap": {
+      "activity": {
+        "cancel-redeem-text": "{{amount}} {{symbol}} sent back to wallet",
+        "claim-redeem-text": "{{fromAmount}} {{fromSymbol}} redeemed for {{toAmount}} {{toSymbol}}",
+        "request-redeem-text": "{{amount}} {{symbol}} sent to redeem vault",
+        "swap-text": "{{fromAmount}} {{fromSymbol}} to {{toAmount}} {{toSymbol}}"
+      },
       "fees": {
         "fixed-protocol-fee": "Fixed Protocol Fee",
         "network-fee": "Network Fee",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -186,6 +186,12 @@
       "title": "Hola FAQ"
     },
     "swap": {
+      "activity": {
+        "cancel-redeem-text": "{{amount}} {{symbol}} devuelto a la billetera",
+        "claim-redeem-text": "{{fromAmount}} {{fromSymbol}} canjeado por {{toAmount}} {{toSymbol}}",
+        "request-redeem-text": "{{amount}} {{symbol}} enviado al vault de canje",
+        "swap-text": "{{fromAmount}} {{fromSymbol}} a {{toAmount}} {{toSymbol}}"
+      },
       "fees": {
         "fixed-protocol-fee": "Tarifa de Protocolo Fija",
         "network-fee": "Tarifa de Red",


### PR DESCRIPTION
### Description

This PR wires useActivityTracking into all swap form components (deposit, one-step redeem, request redeem, claim from vault, cancel redeem). It also adds swap-specific i18n activity keys in en/es following the designer-approved taxonomy.

### Screenshots

https://github.com/user-attachments/assets/10dcfad5-e1fb-4ac2-a018-ef925e332547

### Related issue(s)

Related to #142 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
