### PR TITLE
Always show the redeem vault in the swap page

### DIFF
--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -22,6 +22,7 @@ import { formatAmount } from "utils/token";
 
 import { Form } from "./form";
 import { OutputLabel } from "./outputLabel";
+import { RedeemVaultSection } from "./redeemVaultSection";
 import { SubmitButton } from "./submitButton";
 import { type DepositFlowStatus, SwapDepositDrawer } from "./swapDepositDrawer";
 import { SwapFees } from "./swapFees";
@@ -247,6 +248,7 @@ export function Deposit({
         }
         protocolFee={protocolFee}
       />
+      <RedeemVaultSection whitelistedTokens={whitelistedTokens} />
       {isDrawerOpen && flowStatus !== "idle" && (
         <SwapDepositDrawer
           flowStatus={flowStatus}

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -24,6 +24,7 @@ import { useAccount } from "wagmi";
 
 import { Form } from "./form";
 import { OutputLabel } from "./outputLabel";
+import { RedeemVaultSection } from "./redeemVaultSection";
 import { SubmitButton } from "./submitButton";
 import { SwapFees } from "./swapFees";
 import { type RedeemFlowStatus, SwapRedeemDrawer } from "./swapRedeemDrawer";
@@ -254,6 +255,7 @@ export function OneStepRedeem({
         }
         protocolFee={protocolFee}
       />
+      <RedeemVaultSection whitelistedTokens={whitelistedTokens} />
       {isDrawerOpen && flowStatus !== "idle" && (
         <SwapRedeemDrawer
           flowStatus={flowStatus}

--- a/web/src/components/swapForm/redeemReadyNotification.tsx
+++ b/web/src/components/swapForm/redeemReadyNotification.tsx
@@ -36,7 +36,7 @@ export function RedeemReadyNotification() {
       // if we're already on the swap page, scroll to the redeem vault section
       el.scrollIntoView({ behavior: "smooth" });
     } else {
-      navigate(`/${lang}/swap?mode=redeem#redeem-vault`);
+      navigate(`/${lang}/swap#redeem-vault`);
     }
   }
 

--- a/web/src/components/swapForm/redeemVaultSection.tsx
+++ b/web/src/components/swapForm/redeemVaultSection.tsx
@@ -1,0 +1,35 @@
+import { StripedDivider } from "components/stripedDivider";
+import { useEffect, useRef } from "react";
+import type { Token } from "types";
+
+import { RedeemVault } from "./redeemVault";
+
+type Props = {
+  whitelistedTokens: Token[];
+};
+export const RedeemVaultSection = function ({ whitelistedTokens }: Props) {
+  const redeemVaultRef = useRef<HTMLDivElement>(null);
+
+  useEffect(function scrollIntoVault() {
+    if (window.location.hash === "#redeem-vault") {
+      redeemVaultRef.current?.scrollIntoView({ behavior: "smooth" });
+      // remove hash from the url keeping it clean
+      history.replaceState(
+        null,
+        "",
+        window.location.pathname + window.location.search,
+      );
+    }
+  }, []);
+
+  return (
+    <>
+      <div className="w-full border-b border-gray-200 bg-gray-100">
+        <StripedDivider />
+      </div>
+      <div className="w-full" id="redeem-vault" ref={redeemVaultRef}>
+        <RedeemVault whitelistedTokens={whitelistedTokens} />
+      </div>
+    </>
+  );
+};

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -6,7 +6,6 @@ import { ApproveSection } from "components/approveSection";
 import { Button } from "components/base/button";
 import { Toast } from "components/base/toast";
 import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
-import { StripedDivider } from "components/stripedDivider";
 import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
 import { useActivityTracking } from "hooks/useActivityTracking";
 import { useEstimateRequestRedeemGas } from "hooks/useEstimateRequestRedeemGas";
@@ -16,13 +15,7 @@ import { useRedeemFee } from "hooks/useRedeemFee";
 import { useRequestRedeem } from "hooks/useRequestRedeem";
 import { useSwapFeesDisplay } from "hooks/useSwapFeesDisplay";
 import { useWithdrawalDelay } from "hooks/useWithdrawalDelay";
-import {
-  type FormEvent,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { type FormEvent, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Token } from "types";
 import { getTokenListParams } from "utils/tokenList";
@@ -30,7 +23,7 @@ import { useAccount } from "wagmi";
 
 import { Form } from "./form";
 import { RedeemTutorialModal } from "./redeemTutorialModal";
-import { RedeemVault } from "./redeemVault";
+import { RedeemVaultSection } from "./redeemVaultSection";
 import { SubmitButton } from "./submitButton";
 import { SwapFees } from "./swapFees";
 import {
@@ -71,19 +64,6 @@ export function TwoStepRedeem({
   const { address } = useAccount();
   const ethereumChain = useMainnet();
   const { t } = useTranslation();
-  const redeemVaultRef = useRef<HTMLDivElement>(null);
-
-  useEffect(function scrollIntoVault() {
-    if (window.location.hash === "#redeem-vault") {
-      redeemVaultRef.current?.scrollIntoView({ behavior: "smooth" });
-      // remove hash from the url keeping it clean
-      history.replaceState(
-        null,
-        "",
-        window.location.pathname + window.location.search,
-      );
-    }
-  }, []);
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [isTutorialOpen, setIsTutorialOpen] = useState(false);
@@ -158,7 +138,9 @@ export function TwoStepRedeem({
         onCompleted();
         setFlowStatus("request-redeemed");
         setShowToast(true);
-        redeemVaultRef.current?.scrollIntoView({ behavior: "smooth" });
+        document
+          .getElementById("redeem-vault")
+          ?.scrollIntoView({ behavior: "smooth" });
       });
       emitter.on("request-redeem-transaction-reverted", function () {
         onFailed();
@@ -276,13 +258,7 @@ export function TwoStepRedeem({
         operationGasEstimation={operationGasEstimation}
         protocolFee={protocolFee}
       />
-      <div className="w-full border-b border-gray-200 bg-gray-100">
-        <StripedDivider />
-      </div>
-      <div className="w-full" id="redeem-vault" ref={redeemVaultRef}>
-        <RedeemVault whitelistedTokens={whitelistedTokens} />
-      </div>
-
+      <RedeemVaultSection whitelistedTokens={whitelistedTokens} />
       {isTutorialOpen && (
         <RedeemTutorialModal
           onClose={() => setIsTutorialOpen(false)}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The Redeem vault was only being shown when the user selected to swap VUSD > Stablecoin

Now, this PR enables the vault to be shown in all swap pages

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/e32a118d-6f24-4cda-a83a-f767b7f31af8

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #131

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
