### PR TITLE
Make rows in markets table clickable

### DIFF
--- a/web/src/components/base/table/index.tsx
+++ b/web/src/components/base/table/index.tsx
@@ -6,7 +6,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { Fragment, type ReactNode, useMemo } from "react";
+import { type MouseEvent, Fragment, type ReactNode, useMemo } from "react";
 import Skeleton from "react-loading-skeleton";
 import { screenBreakpoints } from "styles/breakpoints";
 
@@ -114,7 +114,20 @@ const TableBody = <TData,>({
           <Fragment key={row.id}>
             <tr
               className={`flex w-full items-center border-b border-gray-200 bg-white px-16 ${onRowClick ? "cursor-pointer hover:bg-gray-50" : ""}`}
-              onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+              onClick={
+                onRowClick
+                  ? function (e: MouseEvent<HTMLTableRowElement>) {
+                      if (
+                        (e.target as HTMLElement).closest(
+                          "a, button, input, select, textarea, [role='button']",
+                        )
+                      ) {
+                        return;
+                      }
+                      onRowClick(row.original);
+                    }
+                  : undefined
+              }
               role={onRowClick ? "link" : undefined}
             >
               {row.getVisibleCells().map((cell) => (

--- a/web/src/components/base/table/index.tsx
+++ b/web/src/components/base/table/index.tsx
@@ -40,6 +40,7 @@ type Props<TData> = {
   getRowId?: (row: TData) => string;
   loading?: boolean;
   maxBodyHeight?: string;
+  onRowClick?: (row: TData) => void;
   placeholder?: ReactNode;
   priorityColumnIdsOnSmall?: string[];
   renderAfterRow?: (row: TData) => ReactNode;
@@ -85,6 +86,7 @@ const TableHeader = <TData,>({
 type TableBodyProps<TData> = {
   getColumnClassName: (columnId: string, meta?: string) => string;
   maxBodyHeight?: string;
+  onRowClick?: (row: TData) => void;
   renderAfterRow?: (row: TData) => ReactNode;
   table: TanStackTable<TData>;
 };
@@ -92,6 +94,7 @@ type TableBodyProps<TData> = {
 const TableBody = <TData,>({
   getColumnClassName,
   maxBodyHeight,
+  onRowClick,
   renderAfterRow,
   table,
 }: TableBodyProps<TData>) => (
@@ -109,7 +112,11 @@ const TableBody = <TData,>({
       <tbody>
         {table.getRowModel().rows.map((row) => (
           <Fragment key={row.id}>
-            <tr className="flex w-full items-center border-b border-gray-200 px-16">
+            <tr
+              className={`flex w-full items-center border-b border-gray-200 bg-white px-16 ${onRowClick ? "cursor-pointer hover:bg-gray-50" : ""}`}
+              onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+              role={onRowClick ? "link" : undefined}
+            >
               {row.getVisibleCells().map((cell) => (
                 <Column
                   className={getColumnClassName(
@@ -137,6 +144,7 @@ export function Table<TData>({
   getRowId,
   loading = false,
   maxBodyHeight,
+  onRowClick,
   placeholder,
   priorityColumnIdsOnSmall,
   renderAfterRow,
@@ -211,6 +219,7 @@ export function Table<TData>({
           <TableBody
             getColumnClassName={getColumnClassName}
             maxBodyHeight={maxBodyHeight}
+            onRowClick={onRowClick}
             renderAfterRow={renderAfterRow}
             table={table}
           />

--- a/web/src/components/borrow/marketsTable.tsx
+++ b/web/src/components/borrow/marketsTable.tsx
@@ -9,6 +9,7 @@ import { TokenLogo } from "components/tokenLogo";
 import { type MarketData, useMarketsData } from "hooks/borrow/useMarketsData";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate, useParams } from "react-router";
 import { type Hash, formatUnits } from "viem";
 
 type Props = {
@@ -16,8 +17,13 @@ type Props = {
 };
 
 export function MarketsTable({ marketIds }: Props) {
+  const { lang } = useParams();
+  const navigate = useNavigate();
   const { t } = useTranslation();
   const { data, isLoading } = useMarketsData(marketIds);
+
+  const handleRowClick = (row: MarketData) =>
+    navigate(`/${lang}/borrow/${row.marketId}`);
 
   const columns = useMemo(
     (): ColumnDef<MarketData>[] => [
@@ -123,7 +129,12 @@ export function MarketsTable({ marketIds }: Props) {
   return (
     <>
       <TopSection title={t("pages.borrow.markets-title")} />
-      <Table columns={columns} data={data} loading={isLoading} />
+      <Table
+        columns={columns}
+        data={data}
+        loading={isLoading}
+        onRowClick={handleRowClick}
+      />
     </>
   );
 }

--- a/web/stories/table.stories.tsx
+++ b/web/stories/table.stories.tsx
@@ -147,6 +147,16 @@ export const Empty: Story = {
   ),
 };
 
+export const ClickableRows: Story = {
+  render: () => (
+    <Table
+      columns={columns}
+      data={sampleData}
+      onRowClick={(row) => alert(`Clicked row id: ${row.id}`)}
+    />
+  ),
+};
+
 export const WithRenderAfterRow: Story = {
   render: () => (
     <Table


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR:

- Adds the `bg-white` to the table rows (they were transparent)
- Then, adds the option to make a table clickable

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/3faa82a4-b994-487e-9c96-d5ca4ae6ecf4

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #222

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
