### PR TITLE
Integrate analytics treasury with real API

### DIFF
--- a/web/src/components/tooltip/index.tsx
+++ b/web/src/components/tooltip/index.tsx
@@ -6,9 +6,10 @@ import "./tooltip.css";
 type Props = {
   children: ReactNode;
   content: ReactNode;
+  stretch?: boolean;
 };
 
-export const Tooltip = ({ children, content }: Props) => (
+export const Tooltip = ({ children, content, stretch = false }: Props) => (
   <RcTooltip
     overlay={
       <div className="text-b-medium max-w-xs rounded-md bg-gray-900 px-1.5 py-1 text-white">
@@ -19,6 +20,8 @@ export const Tooltip = ({ children, content }: Props) => (
     showArrow={false}
     trigger={["hover"]}
   >
-    <div className="w-fit cursor-pointer">{children}</div>
+    <div className={`cursor-pointer ${stretch ? "size-full" : "w-fit"}`}>
+      {children}
+    </div>
   </RcTooltip>
 );

--- a/web/src/hooks/useAnalyticsTreasury.ts
+++ b/web/src/hooks/useAnalyticsTreasury.ts
@@ -1,55 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
+import fetch from "fetch-plus-plus";
 import type { TreasuryToken } from "pages/analytics/types";
+import { isValidUrl } from "utils/url";
 
-// Mock data matching the shape of GET /analytics/treasury.
-// Will be replaced by the actual API call in a future PR.
-const mockData: TreasuryToken[] = [
-  {
-    activeStrategies: [
-      { name: "Morpho SkyMoney USDT Savings", totalDebt: "37500000000000" },
-      { name: "Aave USDT", totalDebt: "0" },
-    ],
-    latestPrice: "100010000",
-    tokenAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
-    totalDebt: "37500000000000",
-    withdrawable: "37500000000000",
-  },
-  {
-    activeStrategies: [
-      { name: "Morpho AlphaPing USDC Core", totalDebt: "37500000000000" },
-    ],
-    latestPrice: "99991000",
-    tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-    totalDebt: "37500000000000",
-    withdrawable: "37500000000000",
-  },
-  {
-    activeStrategies: [
-      {
-        name: "Summer.fi DAI Savings",
-        totalDebt: "37500000000000000000000000",
-      },
-      { name: "Compound DAI", totalDebt: "0" },
-    ],
-    latestPrice: "100000000",
-    tokenAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-    totalDebt: "37500000000000000000000000",
-    withdrawable: "37500000000000000000000000",
-  },
-  {
-    activeStrategies: [{ name: "Morpho HemiBTC CDPs", totalDebt: "125000000" }],
-    latestPrice: "10000000000000",
-    tokenAddress: "0x06ea695B91700071B161A434fED42D1DcbAD9f00",
-    totalDebt: "125000000",
-    withdrawable: "125000000",
-  },
-];
+const apiUrl = import.meta.env.VITE_VETRO_API_URL;
 
 export const useAnalyticsTreasury = () =>
   useQuery({
+    enabled: apiUrl !== undefined && isValidUrl(apiUrl),
     queryFn: () =>
-      new Promise<TreasuryToken[]>((resolve) =>
-        setTimeout(() => resolve(mockData), 2000),
-      ),
+      fetch(`${apiUrl}/analytics/treasury`) as Promise<TreasuryToken[]>,
     queryKey: ["analytics-treasury"],
+    refetchInterval: 5 * 60 * 1000, // 5 minutes
+    retry: 2,
   });

--- a/web/src/pages/analytics/components/allocationCard/allocationChart.tsx
+++ b/web/src/pages/analytics/components/allocationCard/allocationChart.tsx
@@ -1,3 +1,6 @@
+import { TokenLogo } from "components/tokenLogo";
+import { Tooltip } from "components/tooltip";
+
 import type { AllocationItem } from "../../types";
 
 const skeletonBars = 4;
@@ -21,15 +24,35 @@ export const AllocationChart = ({
     <div className="mx-6 flex h-full gap-1 border-x border-gray-200 bg-white p-1 md:mx-14">
       {!isLoading &&
         !isError &&
-        items.map(({ amount, color, label }) => (
-          <div
-            className={`h-full cursor-pointer rounded-sm transition-opacity ${color} ${hoveredLabel && hoveredLabel !== label ? "opacity-20" : ""}`}
-            key={label}
-            onMouseEnter={() => onHover(label)}
-            onMouseLeave={() => onHover(null)}
-            style={{ flex: amount }}
-          />
-        ))}
+        items.map(function ({ amount, color, label, logoURI, tooltip }) {
+          const barClass = `h-full cursor-pointer rounded-sm transition-opacity ${color} ${hoveredLabel && hoveredLabel !== label ? "opacity-20" : ""}`;
+          const bar = (
+            <div
+              className={barClass}
+              onMouseEnter={() => onHover(label)}
+              onMouseLeave={() => onHover(null)}
+            />
+          );
+          return (
+            <div key={label} className="h-full" style={{ flex: amount }}>
+              {tooltip ? (
+                <Tooltip
+                  content={
+                    <div className="flex items-center gap-1.5">
+                      <TokenLogo logoURI={logoURI ?? ""} symbol={label} />
+                      {tooltip}
+                    </div>
+                  }
+                  stretch
+                >
+                  {bar}
+                </Tooltip>
+              ) : (
+                bar
+              )}
+            </div>
+          );
+        })}
       {isError && <div className="h-full flex-1 rounded-sm bg-gray-200" />}
       {isLoading &&
         Array.from({ length: skeletonBars }).map((_, i) => (

--- a/web/src/pages/analytics/index.tsx
+++ b/web/src/pages/analytics/index.tsx
@@ -25,16 +25,21 @@ export const Analytics = function () {
     isLoading: isTotalsLoading,
   } = useAnalyticsTotals();
   const { data: vusd } = useVusd();
-  const { data: whitelistedTokens } = useWhitelistedTokens();
+  const {
+    data: whitelistedTokens,
+    isError: isWhitelistedTokensError,
+    isLoading: isWhitelistedTokensLoading,
+  } = useWhitelistedTokens();
+
+  const isTokensLoading = isTreasuryLoading || isWhitelistedTokensLoading;
+  const isTokensError = isTreasuryError || isWhitelistedTokensError;
+  const tokens = { treasuryTokens: treasury, whitelistedTokens };
 
   const tvlValue = totals
     ? formatUsd(Number(formatUnits(BigInt(totals.vusdMinted), vusd.decimals)))
     : "";
 
-  const yieldItems = toYieldItems({
-    treasuryTokens: treasury ?? [],
-    whitelistedTokens: whitelistedTokens ?? [],
-  });
+  const yieldItems = toYieldItems(tokens);
   const yieldValue = treasury
     ? t("pages.analytics.yield-value", { count: yieldItems.length })
     : "";
@@ -45,19 +50,16 @@ export const Analytics = function () {
       <div className="flex flex-col border-t border-gray-200 md:flex-row md:divide-x md:divide-gray-200">
         <AllocationCard
           icon={<DatabaseIcon />}
-          isError={isTreasuryError || isTotalsError}
-          isLoading={isTreasuryLoading || isTotalsLoading}
-          items={toTvlItems({
-            treasuryTokens: treasury ?? [],
-            whitelistedTokens: whitelistedTokens ?? [],
-          })}
+          isError={isTokensError || isTotalsError}
+          isLoading={isTokensLoading || isTotalsLoading}
+          items={toTvlItems(tokens)}
           label={t("pages.analytics.tvl-label")}
           value={tvlValue}
         />
         <AllocationCard
           icon={<PieChartIcon />}
-          isError={isTreasuryError}
-          isLoading={isTreasuryLoading}
+          isError={isTokensError}
+          isLoading={isTokensLoading}
           items={yieldItems}
           label={t("pages.analytics.yield-label")}
           value={yieldValue}

--- a/web/src/pages/analytics/index.tsx
+++ b/web/src/pages/analytics/index.tsx
@@ -2,6 +2,7 @@ import { PageTitle } from "components/base/pageTitle";
 import { useAnalyticsTotals } from "hooks/useAnalyticsTotals";
 import { useAnalyticsTreasury } from "hooks/useAnalyticsTreasury";
 import { useVusd } from "hooks/useVusd";
+import { useWhitelistedTokens } from "hooks/useWhitelistedTokens";
 import { useTranslation } from "react-i18next";
 import { formatUsd } from "utils/currency";
 import { formatUnits } from "viem";
@@ -24,12 +25,16 @@ export const Analytics = function () {
     isLoading: isTotalsLoading,
   } = useAnalyticsTotals();
   const { data: vusd } = useVusd();
+  const { data: whitelistedTokens } = useWhitelistedTokens();
 
   const tvlValue = totals
     ? formatUsd(Number(formatUnits(BigInt(totals.vusdMinted), vusd.decimals)))
     : "";
 
-  const yieldItems = toYieldItems(treasury ?? []);
+  const yieldItems = toYieldItems({
+    treasuryTokens: treasury ?? [],
+    whitelistedTokens: whitelistedTokens ?? [],
+  });
   const yieldValue = treasury
     ? t("pages.analytics.yield-value", { count: yieldItems.length })
     : "";
@@ -42,7 +47,10 @@ export const Analytics = function () {
           icon={<DatabaseIcon />}
           isError={isTreasuryError || isTotalsError}
           isLoading={isTreasuryLoading || isTotalsLoading}
-          items={toTvlItems(treasury ?? [])}
+          items={toTvlItems({
+            treasuryTokens: treasury ?? [],
+            whitelistedTokens: whitelistedTokens ?? [],
+          })}
           label={t("pages.analytics.tvl-label")}
           value={tvlValue}
         />

--- a/web/src/pages/analytics/types.ts
+++ b/web/src/pages/analytics/types.ts
@@ -5,6 +5,8 @@ export type AllocationItem = {
   amount: number;
   color: string;
   label: string;
+  logoURI?: string;
+  tooltip?: string;
 };
 
 // Raw response shape from GET /analytics/treasury.

--- a/web/src/pages/analytics/utils.ts
+++ b/web/src/pages/analytics/utils.ts
@@ -1,4 +1,5 @@
 import type { Token } from "types";
+import { formatNumber } from "utils/format";
 import { formatUnits } from "viem";
 
 import type { TreasuryToken } from "./types";
@@ -34,23 +35,27 @@ const findToken = (tokenAddress: string, whitelistedTokens: Token[]) =>
 // withdrawable includes idle funds + deployed strategies (vs totalDebt = strategies only).
 // tokenDecimals sourced from whitelistedTokens; falls back to 18 for unknown tokens.
 export const toTvlItems = ({
-  treasuryTokens,
-  whitelistedTokens,
+  treasuryTokens = [],
+  whitelistedTokens = [],
 }: {
-  treasuryTokens: TreasuryToken[];
-  whitelistedTokens: Token[];
+  treasuryTokens?: TreasuryToken[];
+  whitelistedTokens?: Token[];
 }) =>
   treasuryTokens.map(function (
     { latestPrice, tokenAddress, withdrawable },
     index,
   ) {
     const token = findToken(tokenAddress, whitelistedTokens);
+    const decimals = token?.decimals ?? 18;
+    const symbol = token?.symbol ?? tokenAddress.slice(0, 6);
     return {
       amount:
-        Number(formatUnits(BigInt(withdrawable), token?.decimals ?? 18)) *
+        Number(formatUnits(BigInt(withdrawable), decimals)) *
         Number(formatUnits(BigInt(latestPrice), priceDecimals)),
       color: assignColor(index),
-      label: token?.symbol ?? tokenAddress.slice(0, 6),
+      label: symbol,
+      logoURI: token?.logoURI,
+      tooltip: `${formatNumber(formatUnits(BigInt(withdrawable), decimals))} ${symbol}`,
     };
   });
 
@@ -58,11 +63,11 @@ export const toTvlItems = ({
 // grouping active strategies by protocol across all tokens.
 // amount: sum of USD value per strategy within each protocol.
 export const toYieldItems = function ({
-  treasuryTokens,
-  whitelistedTokens,
+  treasuryTokens = [],
+  whitelistedTokens = [],
 }: {
-  treasuryTokens: TreasuryToken[];
-  whitelistedTokens: Token[];
+  treasuryTokens?: TreasuryToken[];
+  whitelistedTokens?: Token[];
 }) {
   const protocolMap = new Map<string, number>();
 

--- a/web/src/pages/analytics/utils.ts
+++ b/web/src/pages/analytics/utils.ts
@@ -1,6 +1,7 @@
-import { knownTokens } from "utils/tokenList";
+import type { Token } from "types";
+import { formatUnits } from "viem";
 
-import type { AllocationItem, TreasuryToken } from "./types";
+import type { TreasuryToken } from "./types";
 
 const colorPalette = [
   "bg-blue-400",
@@ -21,37 +22,69 @@ const assignColor = (index: number) =>
 const extractProtocol = (strategyName: string) =>
   strategyName.split(" ")[0] ?? strategyName;
 
+const priceDecimals = 8;
+
+const findToken = (tokenAddress: string, whitelistedTokens: Token[]) =>
+  whitelistedTokens.find(
+    (t) => t.address.toLowerCase() === tokenAddress.toLowerCase(),
+  );
+
 // Transforms /analytics/treasury response into TVL allocation items.
-// amount is a placeholder proportional to totalDebt — real USD computation
-// (using tokenDecimals × latestPrice) will be added when integrating the live API.
-export const toTvlItems = (tokens: TreasuryToken[]): AllocationItem[] =>
-  tokens.map(({ tokenAddress, totalDebt }, index) => ({
-    amount: Number(totalDebt),
+// amount: USD value = (withdrawable / 10^decimals) × (latestPrice / 10^8)
+// withdrawable includes idle funds + deployed strategies (vs totalDebt = strategies only).
+// tokenDecimals sourced from whitelistedTokens; falls back to 18 for unknown tokens.
+export const toTvlItems = ({
+  treasuryTokens,
+  whitelistedTokens,
+}: {
+  treasuryTokens: TreasuryToken[];
+  whitelistedTokens: Token[];
+}) =>
+  treasuryTokens.map(({ latestPrice, tokenAddress, withdrawable }, index) => ({
+    amount:
+      Number(
+        formatUnits(
+          BigInt(withdrawable),
+          findToken(tokenAddress, whitelistedTokens)?.decimals ?? 18,
+        ),
+      ) * Number(formatUnits(BigInt(latestPrice), priceDecimals)),
     color: assignColor(index),
     label:
-      knownTokens.find(
-        (t) => t.address.toLowerCase() === tokenAddress.toLowerCase(),
-      )?.symbol ?? tokenAddress.slice(0, 6),
+      findToken(tokenAddress, whitelistedTokens)?.symbol ??
+      tokenAddress.slice(0, 6),
   }));
 
 // Transforms /analytics/treasury response into yield allocation items,
 // grouping active strategies by protocol across all tokens.
-// amount is a placeholder proportional to strategy count — real USD computation
-// will be added when integrating the live API.
-export const toYieldItems = function (
-  tokens: TreasuryToken[],
-): AllocationItem[] {
+// amount: sum of USD value per strategy within each protocol.
+export const toYieldItems = function ({
+  treasuryTokens,
+  whitelistedTokens,
+}: {
+  treasuryTokens: TreasuryToken[];
+  whitelistedTokens: Token[];
+}) {
   const protocolMap = new Map<string, number>();
 
-  for (const { activeStrategies } of tokens) {
-    for (const { name } of activeStrategies) {
+  for (const {
+    activeStrategies,
+    latestPrice,
+    tokenAddress,
+  } of treasuryTokens) {
+    const token = findToken(tokenAddress, whitelistedTokens);
+    const decimals = token?.decimals ?? 18;
+    const price = Number(formatUnits(BigInt(latestPrice), priceDecimals));
+
+    for (const { name, totalDebt } of activeStrategies) {
       const protocol = extractProtocol(name);
-      protocolMap.set(protocol, (protocolMap.get(protocol) ?? 0) + 1);
+      const usdAmount =
+        Number(formatUnits(BigInt(totalDebt), decimals)) * price;
+      protocolMap.set(protocol, (protocolMap.get(protocol) ?? 0) + usdAmount);
     }
   }
 
-  return Array.from(protocolMap.entries()).map(([protocol, count], index) => ({
-    amount: count,
+  return Array.from(protocolMap.entries()).map(([protocol, amount], index) => ({
+    amount,
     color: assignColor(index),
     label: protocol,
   }));

--- a/web/src/pages/analytics/utils.ts
+++ b/web/src/pages/analytics/utils.ts
@@ -40,19 +40,19 @@ export const toTvlItems = ({
   treasuryTokens: TreasuryToken[];
   whitelistedTokens: Token[];
 }) =>
-  treasuryTokens.map(({ latestPrice, tokenAddress, withdrawable }, index) => ({
-    amount:
-      Number(
-        formatUnits(
-          BigInt(withdrawable),
-          findToken(tokenAddress, whitelistedTokens)?.decimals ?? 18,
-        ),
-      ) * Number(formatUnits(BigInt(latestPrice), priceDecimals)),
-    color: assignColor(index),
-    label:
-      findToken(tokenAddress, whitelistedTokens)?.symbol ??
-      tokenAddress.slice(0, 6),
-  }));
+  treasuryTokens.map(function (
+    { latestPrice, tokenAddress, withdrawable },
+    index,
+  ) {
+    const token = findToken(tokenAddress, whitelistedTokens);
+    return {
+      amount:
+        Number(formatUnits(BigInt(withdrawable), token?.decimals ?? 18)) *
+        Number(formatUnits(BigInt(latestPrice), priceDecimals)),
+      color: assignColor(index),
+      label: token?.symbol ?? tokenAddress.slice(0, 6),
+    };
+  });
 
 // Transforms /analytics/treasury response into yield allocation items,
 // grouping active strategies by protocol across all tokens.
@@ -83,9 +83,11 @@ export const toYieldItems = function ({
     }
   }
 
-  return Array.from(protocolMap.entries()).map(([protocol, amount], index) => ({
-    amount,
-    color: assignColor(index),
-    label: protocol,
-  }));
+  return Array.from(protocolMap.entries())
+    .filter(([, amount]) => amount > 0)
+    .map(([protocol, amount], index) => ({
+      amount,
+      color: assignColor(index),
+      label: protocol,
+    }));
 };


### PR DESCRIPTION
### Description

This replaces mock data with a real fetch to /analytics/treasury. Compute USD amounts using withdrawable × latestPrice for TVL composition, and totalDebt × latestPrice per strategy for yield allocation. Token decimals now sourced from useWhitelistedTokens (react-query cache) instead of the static knownTokens list.

#### TVL Composition (first card)

USD per token = (withdrawable / 10^tokenDecimals) × (latestPrice / 10^8)

  - withdrawable: total assets the treasury controls
  - tokenDecimals: sourced from useWhitelistedTokens (react-query cache, reads from chain)
  - latestPrice: price feed value stored in the Treasury contract

#### Yield Allocation (second card)

  USD per strategy = (strategy.totalDebt / 10^tokenDecimals) × (latestPrice / 10^8)

Strategies are then grouped by protocol name (first word of the strategy name, e.g. "Morpho SkyMoney USDT Savings"... "Morpho"), and USD values are summed per protocol across all tokens.

We use totalDebt here (not withdrawable) because yield is only generated by capital actively deployed in strategies.. idle funds don't earn yield. The card title shows the count of unique protocols in the result.

### Screenshots

https://github.com/user-attachments/assets/3f41f3d0-97f6-4649-84c3-d2343b288789

### Related issue(s)

Related to #145 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
