### PR TITLE
Show individual strategies in yield chart

### DIFF
--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -15,8 +15,8 @@
       "title": "Monitor protocol analytics",
       "tvl-label": "Total Value Locked (TVL)",
       "yield-label": "Yield allocation",
-      "yield-value": "{{count}} protocol",
-      "yield-value_other": "{{count}} protocols"
+      "yield-value": "{{count}} strategy",
+      "yield-value_other": "{{count}} strategies"
     },
     "borrow": {
       "activity": {

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -15,8 +15,8 @@
       "title": "Monitorear analíticas del protocolo",
       "tvl-label": "Valor Total Bloqueado (TVL)",
       "yield-label": "Asignación de yield",
-      "yield-value": "{{count}} protocolo",
-      "yield-value_other": "{{count}} protocolos"
+      "yield-value": "{{count}} estrategia",
+      "yield-value_other": "{{count}} estrategias"
     },
     "borrow": {
       "activity": {

--- a/web/src/pages/analytics/components/allocationCard/allocationLegend.tsx
+++ b/web/src/pages/analytics/components/allocationCard/allocationLegend.tsx
@@ -32,7 +32,7 @@ export const AllocationLegend = ({
         >
           <div className="flex items-center gap-3">
             <div className={`rounded-px size-1.5 shrink-0 ${color}`} />
-            <span className="text-b-medium text-gray-900">{label}:</span>
+            <span className="text-b-medium text-gray-900">{label}</span>
           </div>
           <span className="text-b-medium text-right text-gray-900">
             {formatUsd(amount)}

--- a/web/src/pages/analytics/utils.ts
+++ b/web/src/pages/analytics/utils.ts
@@ -18,11 +18,6 @@ const colorPalette = [
 const assignColor = (index: number) =>
   colorPalette[index % colorPalette.length] ?? "bg-gray-400";
 
-// Extracts the protocol name from a strategy name.
-// e.g. "Morpho SkyMoney USDT Savings" → "Morpho"
-const extractProtocol = (strategyName: string) =>
-  strategyName.split(" ")[0] ?? strategyName;
-
 const priceDecimals = 8;
 
 const findToken = (tokenAddress: string, whitelistedTokens: Token[]) =>
@@ -60,8 +55,8 @@ export const toTvlItems = ({
   });
 
 // Transforms /analytics/treasury response into yield allocation items,
-// grouping active strategies by protocol across all tokens.
-// amount: sum of USD value per strategy within each protocol.
+// one item per active strategy across all tokens.
+// amount: USD value = (totalDebt / 10^decimals) × (latestPrice / 10^8)
 export const toYieldItems = function ({
   treasuryTokens = [],
   whitelistedTokens = [],
@@ -69,7 +64,7 @@ export const toYieldItems = function ({
   treasuryTokens?: TreasuryToken[];
   whitelistedTokens?: Token[];
 }) {
-  const protocolMap = new Map<string, number>();
+  const items: { amount: number; color: string; label: string }[] = [];
 
   for (const {
     activeStrategies,
@@ -81,18 +76,12 @@ export const toYieldItems = function ({
     const price = Number(formatUnits(BigInt(latestPrice), priceDecimals));
 
     for (const { name, totalDebt } of activeStrategies) {
-      const protocol = extractProtocol(name);
-      const usdAmount =
-        Number(formatUnits(BigInt(totalDebt), decimals)) * price;
-      protocolMap.set(protocol, (protocolMap.get(protocol) ?? 0) + usdAmount);
+      const amount = Number(formatUnits(BigInt(totalDebt), decimals)) * price;
+      if (amount > 0) {
+        items.push({ amount, color: assignColor(items.length), label: name });
+      }
     }
   }
 
-  return Array.from(protocolMap.entries())
-    .filter(([, amount]) => amount > 0)
-    .map(([protocol, amount], index) => ({
-      amount,
-      color: assignColor(index),
-      label: protocol,
-    }));
+  return items;
 };


### PR DESCRIPTION
### Description

This PR replaces the protocol-level grouping with one bar per active strategy, so "Morpho SkyMoney USDT Savings" and "Morpho AlphaPing USDC Core" appear as separate entries instead of a single "Morpho" bar. Also removes the trailing colon from legend labels and updates the i18n count label from "protocol(s)" to "strategy/strategies".

### Screenshots

<img width="567" height="331" alt="Captura de Tela 2026-03-19 às 19 46 49" src="https://github.com/user-attachments/assets/f6739497-2a56-4472-84c6-867de1c5dd1f" />

### Related issue(s)

Related to #145 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
