### PR TITLE
Improve allocation chart bar and legend alignment

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -44,6 +44,7 @@
     0 15px 35px -5px rgba(0, 0, 0, 0.2);
 
   --spacing-5_5: 1.375rem; /* 22px */
+  --spacing-15: 3.75rem; /* 60px */
   --spacing-18: 4.5rem; /* 72px */
   --spacing-26: 6.5rem; /* 104px */
 

--- a/web/src/pages/analytics/components/allocationCard/allocationChart.tsx
+++ b/web/src/pages/analytics/components/allocationCard/allocationChart.tsx
@@ -34,7 +34,11 @@ export const AllocationChart = ({
             />
           );
           return (
-            <div key={label} className="h-full" style={{ flex: amount }}>
+            <div
+              key={label}
+              className="h-full min-w-2.5"
+              style={{ flex: amount }}
+            >
               {tooltip ? (
                 <Tooltip
                   content={

--- a/web/src/pages/analytics/components/allocationCard/allocationLegend.tsx
+++ b/web/src/pages/analytics/components/allocationCard/allocationLegend.tsx
@@ -20,7 +20,7 @@ export const AllocationLegend = ({
   items,
   onHover,
 }: Props) => (
-  <div className="flex flex-col border-b border-gray-200 px-6 md:px-14">
+  <div className="flex flex-col border-b border-gray-200 px-7 md:px-15">
     {!isLoading &&
       !isError &&
       items.map(({ amount, color, label }) => (


### PR DESCRIPTION
### Description

This PR sets a minimum width on bars so tiny-value strategies remain visible, and align legend text with bar edges by adjusting horizontal padding to match the chart's inner offset.

### Screenshots

https://github.com/user-attachments/assets/83e1220f-b7c7-4e8c-82cb-7b61e5308d63

### Related issue(s)

Related to #145 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
