### PR TITLE
Add bottom border to fees section in earn forms

### DIFF
--- a/web/src/components/approveSection.tsx
+++ b/web/src/components/approveSection.tsx
@@ -22,17 +22,29 @@ const InfoIcon = () => (
   </svg>
 );
 
+const contentPaddingClasses = {
+  compact: "px-2",
+  wide: "md:px-8 px-4",
+} as const;
+
 type Props = {
   active: boolean;
+  contentPadding?: keyof typeof contentPaddingClasses;
   onToggle: VoidFunction;
 };
 
-export const ApproveSection = function ({ active, onToggle }: Props) {
+export const ApproveSection = function ({
+  active,
+  contentPadding = "compact",
+  onToggle,
+}: Props) {
   const { t } = useTranslation();
 
   return (
     <div className="w-full max-w-md border-b border-gray-200 max-md:px-4">
-      <div className="text-xsm flex cursor-default items-center gap-x-1 px-2 py-3">
+      <div
+        className={`text-xsm flex cursor-default items-center gap-x-1 py-3 ${contentPaddingClasses[contentPadding]}`}
+      >
         <span className="font-semibold text-gray-900">
           {t("pages.swap.form.approve-10x")}
         </span>

--- a/web/src/components/approveSection.tsx
+++ b/web/src/components/approveSection.tsx
@@ -23,8 +23,8 @@ const InfoIcon = () => (
 );
 
 const contentPaddingClasses = {
-  compact: "px-2",
-  wide: "md:px-8 px-4",
+  compact: "max-md:px-6 px-2",
+  wide: "px-8",
 } as const;
 
 type Props = {
@@ -41,7 +41,7 @@ export const ApproveSection = function ({
   const { t } = useTranslation();
 
   return (
-    <div className="w-full max-w-md border-b border-gray-200 max-md:px-4">
+    <div className="w-full max-w-md border-b border-gray-200">
       <div
         className={`text-xsm flex cursor-default items-center gap-x-1 py-3 ${contentPaddingClasses[contentPadding]}`}
       >

--- a/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
@@ -304,8 +304,12 @@ export function StakeDepositForm({
         />
       </div>
 
-      <div className="px-6">
-        <ApproveSection active={approve10x} onToggle={onApprove10xToggle} />
+      <ApproveSection
+        active={approve10x}
+        contentPadding="wide"
+        onToggle={onApprove10xToggle}
+      />
+      <div className="border-b border-gray-200 px-6">
         <FeesContainer
           isError={isFeeError}
           label={t("pages.earn.stake.fees-label", {

--- a/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
@@ -301,7 +301,7 @@ export function StakeWithdrawForm({
         />
       </div>
 
-      <div className="px-6">
+      <div className="border-b border-gray-200 px-6">
         <FeesContainer
           isError={isFeeError}
           label={t("pages.earn.stake.withdrawing-fees-label", {


### PR DESCRIPTION
### Description

This PR adds a border-b to the FeesContainer wrapper in stakeDepositForm and stakeWithdrawForm and exposes a contentPadding prop on ApproveSection to support wide spacing in the earn context without modifying shared components.

### Screenshots

https://github.com/user-attachments/assets/9f348b1a-54f0-4cbe-ba30-42197aa36dd7

### Related issue(s)

Closes #211 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
