### PR TITLE
Fix Analytics icon scaling and color in mobile nav

### DIFF
--- a/web/src/components/navbar/analyticsIcon.tsx
+++ b/web/src/components/navbar/analyticsIcon.tsx
@@ -5,15 +5,16 @@ export const AnalyticsIcon = (props: ComponentProps<"svg">) => (
     xmlns="http://www.w3.org/2000/svg"
     width="16"
     height="16"
+    viewBox="0 0 16 16"
     fill="none"
     {...props}
   >
     <path
-      fill="#416BFF"
+      fill="currentColor"
       d="M13.975 6.5c.028.277-.199.5-.475.5h-4a.5.5 0 0 1-.5-.5v-4c0-.275.225-.502.5-.474A5.002 5.002 0 0 1 13.974 6.5h.001Z"
     />
     <path
-      fill="#416BFF"
+      fill="currentColor"
       d="M6.5 4.026c.276-.028.5.199.5.475v4a.5.5 0 0 0 .5.5h4c.276 0 .503.225.475.5A5 5 0 1 1 6.5 4.026Z"
     />
   </svg>


### PR DESCRIPTION
### Description

This PR adds the SVG viewBox, fixing the paths drawn in a 16x16 coordinate space to not scale when CSS applied size-12 (48px). Also replaced hardcoded fill color with currentColor so the parent's active/inactive Tailwind classes take effect.

### Screenshots

Before:
<img width="285" height="234" alt="Captura de Tela 2026-03-23 às 15 44 26" src="https://github.com/user-attachments/assets/f79475b7-1176-42ba-b5c3-c9f371abc9f4" />

After:
<img width="437" height="350" alt="Captura de Tela 2026-03-23 às 15 49 34" src="https://github.com/user-attachments/assets/898d22d2-bedb-401e-8cea-4c870702b858" />


### Related issue(s)

Closes #251 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
