### PR TITLE
Add loading skeleton form for Swap page

### DIFF
--- a/web/src/components/approveSection.tsx
+++ b/web/src/components/approveSection.tsx
@@ -30,7 +30,7 @@ const contentPaddingClasses = {
 type Props = {
   active: boolean;
   contentPadding?: keyof typeof contentPaddingClasses;
-  onToggle: VoidFunction;
+  onToggle?: VoidFunction;
 };
 
 export const ApproveSection = function ({

--- a/web/src/components/base/toggleButton.tsx
+++ b/web/src/components/base/toggleButton.tsx
@@ -1,6 +1,6 @@
 type Props = {
   active: boolean;
-  onClick: VoidFunction;
+  onClick?: VoidFunction;
 };
 
 export const ToggleButton = ({ active, onClick }: Props) => (

--- a/web/src/components/swapForm/index.tsx
+++ b/web/src/components/swapForm/index.tsx
@@ -9,6 +9,7 @@ import { parseTokenUnits } from "utils/token";
 import { Deposit } from "./deposit";
 import { Redeem } from "./redeem";
 import { swapFormReducer } from "./swapFormReducer";
+import { SwapFormSkeleton } from "./swapFormSkeleton";
 import type { SwapFormState } from "./types";
 
 type SwapFormContentProps = {
@@ -95,8 +96,7 @@ export function SwapForm() {
   const { data: whitelistedTokens } = useWhitelistedTokens();
 
   if (vusd === undefined || whitelistedTokens === undefined) {
-    // TODO improve loading state https://github.com/vetro-protocol/vetro-monorepo/issues/111
-    return "...";
+    return <SwapFormSkeleton />;
   }
 
   return (

--- a/web/src/components/swapForm/redeem.tsx
+++ b/web/src/components/swapForm/redeem.tsx
@@ -3,6 +3,7 @@ import type { Token } from "types";
 import { useAccount } from "wagmi";
 
 import { OneStepRedeem } from "./oneStepRedeem";
+import { RedeemSkeleton } from "./redeemSkeleton";
 import { TwoStepRedeem } from "./twoStepRedeem";
 
 type Props = {
@@ -30,8 +31,7 @@ export function Redeem(props: Props) {
   }
 
   if (isLoading) {
-    // TODO: proper loading state to be added later
-    return "...";
+    return <RedeemSkeleton fromToken={props.fromToken} />;
   }
 
   const hasDelay = redeemDelay !== undefined && redeemDelay > 0n;

--- a/web/src/components/swapForm/redeemSkeleton.tsx
+++ b/web/src/components/swapForm/redeemSkeleton.tsx
@@ -1,0 +1,63 @@
+import { ApproveSection } from "components/approveSection";
+import { Button } from "components/base/button";
+import { TokenInput } from "components/tokenInput";
+import { Balance } from "components/tokenInput/balance";
+import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
+import { TokenSelectorSkeleton } from "components/tokenSelectorSkeleton";
+import { useTranslation } from "react-i18next";
+import type { Token } from "types";
+
+import { SwapToggleButton } from "./swapToggleButton";
+import { TreasuryReserves } from "./treasuryReserves";
+
+type Props = {
+  fromToken: Token;
+};
+
+export function RedeemSkeleton({ fromToken }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="flex w-full justify-center border-y border-gray-200 bg-gray-100">
+        <div className="xs:border-x flex w-full max-w-md flex-col gap-0.5 border-gray-200 bg-white pt-2">
+          <div className="md:px-2">
+            <TokenInput
+              balance={
+                <Balance label={t("pages.swap.form.balance")} value="-" />
+              }
+              disabled
+              label={t("pages.swap.form.you-are-swapping")}
+              tokenSelector={<TokenSelectorReadOnly {...fromToken} />}
+              value="0"
+            />
+          </div>
+
+          <div className="relative flex h-0 items-center justify-center">
+            <SwapToggleButton />
+          </div>
+
+          <div className="md:px-2">
+            <TokenInput
+              balance={
+                <Balance label={t("pages.swap.form.balance")} value="-" />
+              }
+              disabled
+              label={t("pages.swap.form.you-will-receive")}
+              tokenSelector={<TokenSelectorSkeleton />}
+              value="0"
+            />
+          </div>
+
+          <div className="mt-2 flex w-full flex-col border-t border-gray-200 px-2 py-3">
+            <Button disabled size="xLarge" type="button">
+              {t("pages.swap.form.connect-wallet")}
+            </Button>
+          </div>
+        </div>
+      </div>
+      <ApproveSection active={false} />
+      <TreasuryReserves />
+    </>
+  );
+}

--- a/web/src/components/swapForm/swapFormSkeleton.tsx
+++ b/web/src/components/swapForm/swapFormSkeleton.tsx
@@ -1,0 +1,57 @@
+import { ApproveSection } from "components/approveSection";
+import { Button } from "components/base/button";
+import { TokenInput } from "components/tokenInput";
+import { Balance } from "components/tokenInput/balance";
+import { TokenSelectorSkeleton } from "components/tokenSelectorSkeleton";
+import { useTranslation } from "react-i18next";
+
+import { SwapToggleButton } from "./swapToggleButton";
+import { TreasuryReserves } from "./treasuryReserves";
+
+export function SwapFormSkeleton() {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="flex w-full justify-center border-y border-gray-200 bg-gray-100">
+        <div className="xs:border-x flex w-full max-w-md flex-col gap-0.5 border-gray-200 bg-white pt-2">
+          <div className="md:px-2">
+            <TokenInput
+              balance={
+                <Balance label={t("pages.swap.form.balance")} value="-" />
+              }
+              disabled
+              label={t("pages.swap.form.you-are-swapping")}
+              tokenSelector={<TokenSelectorSkeleton />}
+              value="0"
+            />
+          </div>
+
+          <div className="relative flex h-0 items-center justify-center">
+            <SwapToggleButton />
+          </div>
+
+          <div className="md:px-2">
+            <TokenInput
+              balance={
+                <Balance label={t("pages.swap.form.balance")} value="-" />
+              }
+              disabled
+              label={t("pages.swap.form.you-will-receive")}
+              tokenSelector={<TokenSelectorSkeleton />}
+              value="0"
+            />
+          </div>
+
+          <div className="mt-2 flex w-full flex-col border-t border-gray-200 px-2 py-3">
+            <Button disabled size="xLarge" type="button">
+              {t("pages.swap.form.connect-wallet")}
+            </Button>
+          </div>
+        </div>
+      </div>
+      <ApproveSection active={false} />
+      <TreasuryReserves />
+    </>
+  );
+}

--- a/web/src/components/swapForm/swapToggleButton.tsx
+++ b/web/src/components/swapForm/swapToggleButton.tsx
@@ -1,7 +1,7 @@
 import swapToggle from "components/icons/swapToggle.svg";
 
 type Props = {
-  onClick: VoidFunction;
+  onClick?: VoidFunction;
 };
 
 export const SwapToggleButton = ({ onClick }: Props) => (

--- a/web/src/components/tokenSelectorSkeleton.tsx
+++ b/web/src/components/tokenSelectorSkeleton.tsx
@@ -1,0 +1,8 @@
+import Skeleton from "react-loading-skeleton";
+
+export const TokenSelectorSkeleton = () => (
+  <div className="flex items-center gap-1.5 rounded-full bg-white/5 py-1.5 pr-3 pl-1.5 leading-none shadow-sm">
+    <Skeleton circle height={20} width={20} />
+    <Skeleton height={14} width={40} />
+  </div>
+);


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR improves the loading state in the swap page by adding a skeleton form.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Desktop loading

https://github.com/user-attachments/assets/6674ff4a-cce6-4367-b336-d0d647e33da2

Tablet loading

https://github.com/user-attachments/assets/b9075ee2-b497-4d1a-aade-636924d3d3ea

Mobile loading

https://github.com/user-attachments/assets/8bdd4cf9-18aa-4ac4-a937-271bdb447c8a

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #111 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
