### PR TITLE
Remove double bottom border from table body

### DIFF
--- a/web/src/components/base/table/index.tsx
+++ b/web/src/components/base/table/index.tsx
@@ -99,7 +99,7 @@ const TableBody = <TData,>({
   table,
 }: TableBodyProps<TData>) => (
   <div
-    className={`border-b border-gray-200 ${maxBodyHeight ? "overflow-y-auto" : ""}`}
+    className={maxBodyHeight ? "overflow-y-auto" : undefined}
     style={{
       maxHeight: maxBodyHeight,
       ...(maxBodyHeight && {


### PR DESCRIPTION
### Description

The TableBody wrapper had border-b border-gray-200, but each row already has its own border-b. This caused a double line at the bottom of every table. Removing the redundant wrapper border fixes all four tables that use this base component.

### Screenshots

https://github.com/user-attachments/assets/254704b6-f88b-4b49-a5b5-82f16e7c6b83

### Related issue(s)

Closes #205 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
