### PR TITLE
Add reserve buffer to yield allocation card

### DIFF
--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -11,6 +11,7 @@
   },
   "pages": {
     "analytics": {
+      "reserve-buffer-label": "Reserve buffer",
       "title": "Monitor protocol analytics",
       "tvl-label": "Total Value Locked (TVL)",
       "yield-label": "Yield allocation",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -11,6 +11,7 @@
   },
   "pages": {
     "analytics": {
+      "reserve-buffer-label": "Reserva de liquidez",
       "title": "Monitorear analíticas del protocolo",
       "tvl-label": "Valor Total Bloqueado (TVL)",
       "yield-label": "Asignación de yield",

--- a/web/src/pages/analytics/components/allocationCard/allocationLegend.tsx
+++ b/web/src/pages/analytics/components/allocationCard/allocationLegend.tsx
@@ -20,7 +20,7 @@ export const AllocationLegend = ({
   items,
   onHover,
 }: Props) => (
-  <div className="flex flex-col border-b border-gray-200 px-7 md:px-15">
+  <div className="flex flex-1 flex-col border-b border-gray-200 px-7 md:px-15">
     {!isLoading &&
       !isError &&
       items.map(({ amount, color, label }) => (

--- a/web/src/pages/analytics/index.tsx
+++ b/web/src/pages/analytics/index.tsx
@@ -10,7 +10,12 @@ import { formatUnits } from "viem";
 import { AllocationCard } from "./components/allocationCard";
 import { DatabaseIcon } from "./icons/databaseIcon";
 import { PieChartIcon } from "./icons/pieChartIcon";
-import { toReserveBufferItem, toTvlItems, toYieldItems } from "./utils";
+import {
+  assignColor,
+  toReserveBufferAmount,
+  toTvlItems,
+  toYieldItems,
+} from "./utils";
 
 export const Analytics = function () {
   const { t } = useTranslation();
@@ -40,10 +45,14 @@ export const Analytics = function () {
     : "";
 
   const yieldItems = toYieldItems(tokens);
-  const bufferItem = toReserveBufferItem({
-    ...tokens,
-    label: t("pages.analytics.reserve-buffer-label"),
-  });
+  const bufferAmount = toReserveBufferAmount(tokens);
+  const bufferItem = bufferAmount
+    ? {
+        amount: bufferAmount,
+        color: assignColor(yieldItems.length),
+        label: t("pages.analytics.reserve-buffer-label"),
+      }
+    : null;
   const yieldValue = treasury
     ? t("pages.analytics.yield-value", { count: yieldItems.length })
     : "";

--- a/web/src/pages/analytics/index.tsx
+++ b/web/src/pages/analytics/index.tsx
@@ -46,13 +46,14 @@ export const Analytics = function () {
 
   const yieldItems = toYieldItems(tokens);
   const bufferAmount = toReserveBufferAmount(tokens);
-  const bufferItem = bufferAmount
-    ? {
-        amount: bufferAmount,
-        color: assignColor(yieldItems.length),
-        label: t("pages.analytics.reserve-buffer-label"),
-      }
-    : null;
+  const bufferItem =
+    bufferAmount > 0
+      ? {
+          amount: bufferAmount,
+          color: assignColor(yieldItems.length),
+          label: t("pages.analytics.reserve-buffer-label"),
+        }
+      : null;
   const yieldValue = treasury
     ? t("pages.analytics.yield-value", { count: yieldItems.length })
     : "";

--- a/web/src/pages/analytics/index.tsx
+++ b/web/src/pages/analytics/index.tsx
@@ -10,7 +10,7 @@ import { formatUnits } from "viem";
 import { AllocationCard } from "./components/allocationCard";
 import { DatabaseIcon } from "./icons/databaseIcon";
 import { PieChartIcon } from "./icons/pieChartIcon";
-import { toTvlItems, toYieldItems } from "./utils";
+import { toReserveBufferItem, toTvlItems, toYieldItems } from "./utils";
 
 export const Analytics = function () {
   const { t } = useTranslation();
@@ -40,6 +40,10 @@ export const Analytics = function () {
     : "";
 
   const yieldItems = toYieldItems(tokens);
+  const bufferItem = toReserveBufferItem({
+    ...tokens,
+    label: t("pages.analytics.reserve-buffer-label"),
+  });
   const yieldValue = treasury
     ? t("pages.analytics.yield-value", { count: yieldItems.length })
     : "";
@@ -60,7 +64,7 @@ export const Analytics = function () {
           icon={<PieChartIcon />}
           isError={isTokensError}
           isLoading={isTokensLoading}
-          items={yieldItems}
+          items={bufferItem ? [...yieldItems, bufferItem] : yieldItems}
           label={t("pages.analytics.yield-label")}
           value={yieldValue}
         />

--- a/web/src/pages/analytics/utils.ts
+++ b/web/src/pages/analytics/utils.ts
@@ -15,7 +15,7 @@ const colorPalette = [
   "bg-pink-400",
 ];
 
-const assignColor = (index: number) =>
+export const assignColor = (index: number) =>
   colorPalette[index % colorPalette.length] ?? "bg-gray-400";
 
 const priceDecimals = 8;
@@ -86,23 +86,19 @@ export const toYieldItems = function ({
   return items;
 };
 
-// Returns the reserve buffer as an AllocationItem, or null if the buffer is zero or negative.
+// Returns the reserve buffer amount and label, or null if the buffer is zero or negative.
 // The buffer is the idle amount not deployed to any strategy, used for instant withdrawal liquidity.
-// Color is assigned after all strategy items, keeping the palette consistent.
-export const toReserveBufferItem = function ({
-  label,
+// Color is intentionally omitted — callers assign it based on their rendering context.
+export const toReserveBufferAmount = function ({
   treasuryTokens = [],
   whitelistedTokens = [],
 }: {
-  label: string;
   treasuryTokens?: TreasuryToken[];
   whitelistedTokens?: Token[];
 }) {
   let amount = 0;
-  let strategyCount = 0;
 
   for (const {
-    activeStrategies,
     latestPrice,
     tokenAddress,
     totalDebt,
@@ -112,19 +108,11 @@ export const toReserveBufferItem = function ({
     const decimals = token?.decimals ?? 18;
     const price = Number(formatUnits(BigInt(latestPrice), priceDecimals));
 
-    for (const { totalDebt: stratDebt } of activeStrategies) {
-      if (Number(formatUnits(BigInt(stratDebt), decimals)) * price > 0) {
-        strategyCount++;
-      }
-    }
-
     amount +=
       (Number(formatUnits(BigInt(withdrawable), decimals)) -
         Number(formatUnits(BigInt(totalDebt), decimals))) *
       price;
   }
 
-  if (amount <= 0) return null;
-
-  return { amount, color: assignColor(strategyCount), label };
+  return amount > 0 ? amount : null;
 };

--- a/web/src/pages/analytics/utils.ts
+++ b/web/src/pages/analytics/utils.ts
@@ -85,3 +85,46 @@ export const toYieldItems = function ({
 
   return items;
 };
+
+// Returns the reserve buffer as an AllocationItem, or null if the buffer is zero or negative.
+// The buffer is the idle amount not deployed to any strategy, used for instant withdrawal liquidity.
+// Color is assigned after all strategy items, keeping the palette consistent.
+export const toReserveBufferItem = function ({
+  label,
+  treasuryTokens = [],
+  whitelistedTokens = [],
+}: {
+  label: string;
+  treasuryTokens?: TreasuryToken[];
+  whitelistedTokens?: Token[];
+}) {
+  let amount = 0;
+  let strategyCount = 0;
+
+  for (const {
+    activeStrategies,
+    latestPrice,
+    tokenAddress,
+    totalDebt,
+    withdrawable,
+  } of treasuryTokens) {
+    const token = findToken(tokenAddress, whitelistedTokens);
+    const decimals = token?.decimals ?? 18;
+    const price = Number(formatUnits(BigInt(latestPrice), priceDecimals));
+
+    for (const { totalDebt: stratDebt } of activeStrategies) {
+      if (Number(formatUnits(BigInt(stratDebt), decimals)) * price > 0) {
+        strategyCount++;
+      }
+    }
+
+    amount +=
+      (Number(formatUnits(BigInt(withdrawable), decimals)) -
+        Number(formatUnits(BigInt(totalDebt), decimals))) *
+      price;
+  }
+
+  if (amount <= 0) return null;
+
+  return { amount, color: assignColor(strategyCount), label };
+};

--- a/web/src/pages/analytics/utils.ts
+++ b/web/src/pages/analytics/utils.ts
@@ -86,9 +86,8 @@ export const toYieldItems = function ({
   return items;
 };
 
-// Returns the reserve buffer amount and label, or null if the buffer is zero or negative.
-// The buffer is the idle amount not deployed to any strategy, used for instant withdrawal liquidity.
-// Color is intentionally omitted — callers assign it based on their rendering context.
+// Returns the reserve buffer amount in USD (idle funds not deployed to any strategy).
+// Returns 0 when there is no buffer. Color is intentionally omitted — callers assign it.
 export const toReserveBufferAmount = function ({
   treasuryTokens = [],
   whitelistedTokens = [],
@@ -114,5 +113,5 @@ export const toReserveBufferAmount = function ({
       price;
   }
 
-  return amount > 0 ? amount : null;
+  return Math.max(0, amount);
 };

--- a/web/test/pages/analytics/utils.test.ts
+++ b/web/test/pages/analytics/utils.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  toReserveBufferItem,
+  assignColor,
+  toReserveBufferAmount,
   toTvlItems,
   toYieldItems,
 } from "../../../src/pages/analytics/utils";
@@ -33,14 +34,24 @@ const usdcToken = {
 };
 
 describe("pages/analytics/utils", function () {
-  describe("toReserveBufferItem", function () {
+  describe("assignColor", function () {
+    it("returns the color at the given index", function () {
+      expect(assignColor(0)).toBe("bg-blue-400");
+      expect(assignColor(1)).toBe("bg-emerald-400");
+    });
+
+    it("wraps around when index exceeds palette length", function () {
+      expect(assignColor(8)).toBe("bg-blue-400");
+    });
+  });
+
+  describe("toReserveBufferAmount", function () {
     it("returns null when treasuryTokens is empty", function () {
-      expect(toReserveBufferItem({ label: "Reserve buffer" })).toBeNull();
+      expect(toReserveBufferAmount({})).toBeNull();
     });
 
     it("returns null when withdrawable equals totalDebt", function () {
-      const result = toReserveBufferItem({
-        label: "Reserve buffer",
+      const result = toReserveBufferAmount({
         treasuryTokens: [
           {
             activeStrategies: [],
@@ -57,8 +68,7 @@ describe("pages/analytics/utils", function () {
     });
 
     it("returns null when buffer is negative", function () {
-      const result = toReserveBufferItem({
-        label: "Reserve buffer",
+      const result = toReserveBufferAmount({
         treasuryTokens: [
           {
             activeStrategies: [],
@@ -76,8 +86,7 @@ describe("pages/analytics/utils", function () {
 
     it("computes correct amount for a single token", function () {
       // withdrawable: 1000 USDT, totalDebt: 900 USDT → buffer: 100 USDT @ $1 = $100
-      const result = toReserveBufferItem({
-        label: "Reserve buffer",
+      const result = toReserveBufferAmount({
         treasuryTokens: [
           {
             activeStrategies: [],
@@ -90,13 +99,12 @@ describe("pages/analytics/utils", function () {
         whitelistedTokens: [usdtToken],
       });
 
-      expect(result?.amount).toBeCloseTo(100);
+      expect(result).toBeCloseTo(100);
     });
 
     it("sums buffer across multiple tokens", function () {
       // USDT buffer: $100, USDC buffer: $50 → total: $150
-      const result = toReserveBufferItem({
-        label: "Reserve buffer",
+      const result = toReserveBufferAmount({
         treasuryTokens: [
           {
             activeStrategies: [],
@@ -116,13 +124,12 @@ describe("pages/analytics/utils", function () {
         whitelistedTokens: [usdtToken, usdcToken],
       });
 
-      expect(result?.amount).toBeCloseTo(150);
+      expect(result).toBeCloseTo(150);
     });
 
     it("uses decimals from whitelistedTokens", function () {
       // 1 token with 18 decimals @ $1 → buffer: $1
-      const result = toReserveBufferItem({
-        label: "Reserve buffer",
+      const result = toReserveBufferAmount({
         treasuryTokens: [
           {
             activeStrategies: [],
@@ -135,12 +142,11 @@ describe("pages/analytics/utils", function () {
         whitelistedTokens: [{ ...usdtToken, decimals: 18 as const }],
       });
 
-      expect(result?.amount).toBeCloseTo(1);
+      expect(result).toBeCloseTo(1);
     });
 
     it("falls back to 18 decimals for unknown tokens", function () {
-      const result = toReserveBufferItem({
-        label: "Reserve buffer",
+      const result = toReserveBufferAmount({
         treasuryTokens: [
           {
             activeStrategies: [],
@@ -153,61 +159,7 @@ describe("pages/analytics/utils", function () {
         whitelistedTokens: [],
       });
 
-      expect(result?.amount).toBeCloseTo(1);
-    });
-
-    it("returns the provided label", function () {
-      const result = toReserveBufferItem({
-        label: "Reserve buffer",
-        treasuryTokens: [
-          {
-            activeStrategies: [],
-            latestPrice: ONE_USD_PRICE,
-            tokenAddress: USDT_ADDRESS,
-            totalDebt: "0",
-            withdrawable: "1000000000",
-          },
-        ],
-        whitelistedTokens: [usdtToken],
-      });
-
-      expect(result?.label).toBe("Reserve buffer");
-    });
-
-    it("assigns color based on active strategy count", function () {
-      // 0 active strategies → index 0 → bg-blue-400
-      const noStrategies = toReserveBufferItem({
-        label: "Buffer",
-        treasuryTokens: [
-          {
-            activeStrategies: [],
-            latestPrice: ONE_USD_PRICE,
-            tokenAddress: USDT_ADDRESS,
-            totalDebt: "0",
-            withdrawable: "1000000000",
-          },
-        ],
-        whitelistedTokens: [usdtToken],
-      });
-
-      expect(noStrategies?.color).toBe("bg-blue-400");
-
-      // 1 active strategy → index 1 → bg-emerald-400
-      const oneStrategy = toReserveBufferItem({
-        label: "Buffer",
-        treasuryTokens: [
-          {
-            activeStrategies: [{ name: "Strategy A", totalDebt: "500000000" }],
-            latestPrice: ONE_USD_PRICE,
-            tokenAddress: USDT_ADDRESS,
-            totalDebt: "500000000",
-            withdrawable: "1000000000",
-          },
-        ],
-        whitelistedTokens: [usdtToken],
-      });
-
-      expect(oneStrategy?.color).toBe("bg-emerald-400");
+      expect(result).toBeCloseTo(1);
     });
   });
 

--- a/web/test/pages/analytics/utils.test.ts
+++ b/web/test/pages/analytics/utils.test.ts
@@ -6,23 +6,29 @@ import {
   toYieldItems,
 } from "../../../src/pages/analytics/utils";
 
-const USDT_ADDRESS = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
-const USDC_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const USDT_ADDRESS =
+  "0xdAC17F958D2ee523a2206206994597C13D831ec7" as `0x${string}`;
+const USDC_ADDRESS =
+  "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as `0x${string}`;
 
 // $1.00 expressed with 8 decimals
 const ONE_USD_PRICE = "100000000";
 
 const usdtToken = {
   address: USDT_ADDRESS,
+  chainId: 1,
   decimals: 6,
-  logoURI: undefined,
+  logoURI: "",
+  name: "Tether USD",
   symbol: "USDT",
 };
 
 const usdcToken = {
   address: USDC_ADDRESS,
+  chainId: 1,
   decimals: 6,
-  logoURI: undefined,
+  logoURI: "",
+  name: "USD Coin",
   symbol: "USDC",
 };
 
@@ -126,7 +132,7 @@ describe("pages/analytics/utils", function () {
             withdrawable: "1000000000000000000",
           },
         ],
-        whitelistedTokens: [{ ...usdtToken, decimals: 18 }],
+        whitelistedTokens: [{ ...usdtToken, decimals: 18 as const }],
       });
 
       expect(result?.amount).toBeCloseTo(1);

--- a/web/test/pages/analytics/utils.test.ts
+++ b/web/test/pages/analytics/utils.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  toReserveBufferItem,
+  toTvlItems,
+  toYieldItems,
+} from "../../../src/pages/analytics/utils";
+
+const USDT_ADDRESS = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+const USDC_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+
+// $1.00 expressed with 8 decimals
+const ONE_USD_PRICE = "100000000";
+
+const usdtToken = {
+  address: USDT_ADDRESS,
+  decimals: 6,
+  logoURI: undefined,
+  symbol: "USDT",
+};
+
+const usdcToken = {
+  address: USDC_ADDRESS,
+  decimals: 6,
+  logoURI: undefined,
+  symbol: "USDC",
+};
+
+describe("pages/analytics/utils", function () {
+  describe("toReserveBufferItem", function () {
+    it("returns null when treasuryTokens is empty", function () {
+      expect(toReserveBufferItem({ label: "Reserve buffer" })).toBeNull();
+    });
+
+    it("returns null when withdrawable equals totalDebt", function () {
+      const result = toReserveBufferItem({
+        label: "Reserve buffer",
+        treasuryTokens: [
+          {
+            activeStrategies: [],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDT_ADDRESS,
+            totalDebt: "1000000000",
+            withdrawable: "1000000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken],
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when buffer is negative", function () {
+      const result = toReserveBufferItem({
+        label: "Reserve buffer",
+        treasuryTokens: [
+          {
+            activeStrategies: [],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDT_ADDRESS,
+            totalDebt: "1100000000",
+            withdrawable: "1000000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken],
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("computes correct amount for a single token", function () {
+      // withdrawable: 1000 USDT, totalDebt: 900 USDT → buffer: 100 USDT @ $1 = $100
+      const result = toReserveBufferItem({
+        label: "Reserve buffer",
+        treasuryTokens: [
+          {
+            activeStrategies: [],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDT_ADDRESS,
+            totalDebt: "900000000",
+            withdrawable: "1000000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken],
+      });
+
+      expect(result?.amount).toBeCloseTo(100);
+    });
+
+    it("sums buffer across multiple tokens", function () {
+      // USDT buffer: $100, USDC buffer: $50 → total: $150
+      const result = toReserveBufferItem({
+        label: "Reserve buffer",
+        treasuryTokens: [
+          {
+            activeStrategies: [],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDT_ADDRESS,
+            totalDebt: "900000000",
+            withdrawable: "1000000000",
+          },
+          {
+            activeStrategies: [],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDC_ADDRESS,
+            totalDebt: "50000000",
+            withdrawable: "100000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken, usdcToken],
+      });
+
+      expect(result?.amount).toBeCloseTo(150);
+    });
+
+    it("uses decimals from whitelistedTokens", function () {
+      // 1 token with 18 decimals @ $1 → buffer: $1
+      const result = toReserveBufferItem({
+        label: "Reserve buffer",
+        treasuryTokens: [
+          {
+            activeStrategies: [],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDT_ADDRESS,
+            totalDebt: "0",
+            withdrawable: "1000000000000000000",
+          },
+        ],
+        whitelistedTokens: [{ ...usdtToken, decimals: 18 }],
+      });
+
+      expect(result?.amount).toBeCloseTo(1);
+    });
+
+    it("falls back to 18 decimals for unknown tokens", function () {
+      const result = toReserveBufferItem({
+        label: "Reserve buffer",
+        treasuryTokens: [
+          {
+            activeStrategies: [],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: "0xunknown",
+            totalDebt: "0",
+            withdrawable: "1000000000000000000",
+          },
+        ],
+        whitelistedTokens: [],
+      });
+
+      expect(result?.amount).toBeCloseTo(1);
+    });
+
+    it("returns the provided label", function () {
+      const result = toReserveBufferItem({
+        label: "Reserve buffer",
+        treasuryTokens: [
+          {
+            activeStrategies: [],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDT_ADDRESS,
+            totalDebt: "0",
+            withdrawable: "1000000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken],
+      });
+
+      expect(result?.label).toBe("Reserve buffer");
+    });
+
+    it("assigns color based on active strategy count", function () {
+      // 0 active strategies → index 0 → bg-blue-400
+      const noStrategies = toReserveBufferItem({
+        label: "Buffer",
+        treasuryTokens: [
+          {
+            activeStrategies: [],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDT_ADDRESS,
+            totalDebt: "0",
+            withdrawable: "1000000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken],
+      });
+
+      expect(noStrategies?.color).toBe("bg-blue-400");
+
+      // 1 active strategy → index 1 → bg-emerald-400
+      const oneStrategy = toReserveBufferItem({
+        label: "Buffer",
+        treasuryTokens: [
+          {
+            activeStrategies: [{ name: "Strategy A", totalDebt: "500000000" }],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDT_ADDRESS,
+            totalDebt: "500000000",
+            withdrawable: "1000000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken],
+      });
+
+      expect(oneStrategy?.color).toBe("bg-emerald-400");
+    });
+  });
+
+  describe("toTvlItems", function () {
+    it("returns empty array when no treasury tokens", function () {
+      expect(toTvlItems({})).toEqual([]);
+    });
+
+    it("computes correct USD amount per token", function () {
+      // 1000 USDT (6 decimals) @ $1 = $1000
+      const items = toTvlItems({
+        treasuryTokens: [
+          {
+            activeStrategies: [],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDT_ADDRESS,
+            totalDebt: "0",
+            withdrawable: "1000000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken],
+      });
+
+      expect(items).toHaveLength(1);
+      expect(items[0]?.amount).toBeCloseTo(1000);
+      expect(items[0]?.label).toBe("USDT");
+    });
+
+    it("falls back to token address prefix when token is unknown", function () {
+      const items = toTvlItems({
+        treasuryTokens: [
+          {
+            activeStrategies: [],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: "0xABCDEF123456",
+            totalDebt: "0",
+            withdrawable: "1000000000000000000",
+          },
+        ],
+        whitelistedTokens: [],
+      });
+
+      expect(items[0]?.label).toBe("0xABCD");
+    });
+  });
+
+  describe("toYieldItems", function () {
+    it("returns empty array when no treasury tokens", function () {
+      expect(toYieldItems({})).toEqual([]);
+    });
+
+    it("excludes strategies with zero amount", function () {
+      const items = toYieldItems({
+        treasuryTokens: [
+          {
+            activeStrategies: [
+              { name: "Zero Strategy", totalDebt: "0" },
+              { name: "Active Strategy", totalDebt: "500000000" },
+            ],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDT_ADDRESS,
+            totalDebt: "500000000",
+            withdrawable: "500000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken],
+      });
+
+      expect(items).toHaveLength(1);
+      expect(items[0]?.label).toBe("Active Strategy");
+    });
+
+    it("flattens strategies across multiple tokens", function () {
+      const items = toYieldItems({
+        treasuryTokens: [
+          {
+            activeStrategies: [
+              { name: "USDT Strategy", totalDebt: "500000000" },
+            ],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDT_ADDRESS,
+            totalDebt: "500000000",
+            withdrawable: "500000000",
+          },
+          {
+            activeStrategies: [
+              { name: "USDC Strategy", totalDebt: "200000000" },
+            ],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDC_ADDRESS,
+            totalDebt: "200000000",
+            withdrawable: "200000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken, usdcToken],
+      });
+
+      expect(items).toHaveLength(2);
+      expect(items[0]?.label).toBe("USDT Strategy");
+      expect(items[1]?.label).toBe("USDC Strategy");
+    });
+
+    it("computes correct USD amount per strategy", function () {
+      // 500 USDT (6 decimals) @ $1 = $500
+      const items = toYieldItems({
+        treasuryTokens: [
+          {
+            activeStrategies: [{ name: "Strategy", totalDebt: "500000000" }],
+            latestPrice: ONE_USD_PRICE,
+            tokenAddress: USDT_ADDRESS,
+            totalDebt: "500000000",
+            withdrawable: "500000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken],
+      });
+
+      expect(items[0]?.amount).toBeCloseTo(500);
+    });
+  });
+});

--- a/web/test/pages/analytics/utils.test.ts
+++ b/web/test/pages/analytics/utils.test.ts
@@ -46,11 +46,11 @@ describe("pages/analytics/utils", function () {
   });
 
   describe("toReserveBufferAmount", function () {
-    it("returns null when treasuryTokens is empty", function () {
-      expect(toReserveBufferAmount({})).toBeNull();
+    it("returns 0 when treasuryTokens is empty", function () {
+      expect(toReserveBufferAmount({})).toBe(0);
     });
 
-    it("returns null when withdrawable equals totalDebt", function () {
+    it("returns 0 when withdrawable equals totalDebt", function () {
       const result = toReserveBufferAmount({
         treasuryTokens: [
           {
@@ -64,10 +64,10 @@ describe("pages/analytics/utils", function () {
         whitelistedTokens: [usdtToken],
       });
 
-      expect(result).toBeNull();
+      expect(result).toBe(0);
     });
 
-    it("returns null when buffer is negative", function () {
+    it("returns 0 when buffer is negative", function () {
       const result = toReserveBufferAmount({
         treasuryTokens: [
           {
@@ -81,7 +81,7 @@ describe("pages/analytics/utils", function () {
         whitelistedTokens: [usdtToken],
       });
 
-      expect(result).toBeNull();
+      expect(result).toBe(0);
     });
 
     it("computes correct amount for a single token", function () {


### PR DESCRIPTION
### Description

This PR shows the idle treasury funds not deployed to any strategy as a last row in the yield allocation table. The buffer is computed as withdrawable minus totalDebt per token, converted to USD, and colored using the existing palette sequence.

### Screenshots

<img width="1152" height="596" alt="Captura de Tela 2026-03-24 às 16 14 45" src="https://github.com/user-attachments/assets/9f15ac61-493d-4fc9-a377-713e39e33cf7" />


### Related issue(s)

Closes #238 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
