### PR TITLE
Add mint/redeem fee scripts + update setup

### DIFF
--- a/packages/gateway/src/abi/gatewayAbi.ts
+++ b/packages/gateway/src/abi/gatewayAbi.ts
@@ -14,6 +14,13 @@ export const gatewayAbi = [
     type: "function",
   },
   {
+    inputs: [],
+    name: "owner",
+    outputs: [{ type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
     inputs: [{ name: "token_", type: "address" }],
     name: "redeemFee",
     outputs: [{ type: "uint256" }],
@@ -119,6 +126,26 @@ export const gatewayAbi = [
   {
     inputs: [{ name: "peggedTokenAmount_", type: "uint256" }],
     name: "requestRedeem",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { name: "token_", type: "address" },
+      { name: "newMintFee_", type: "uint256" },
+    ],
+    name: "updateMintFee",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { name: "token_", type: "address" },
+      { name: "newRedeemFee_", type: "uint256" },
+    ],
+    name: "updateRedeemFee",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",

--- a/web/README.md
+++ b/web/README.md
@@ -45,3 +45,39 @@ Options:
 | ------------ | ----- | --------------------------- | ----------------------- |
 | `--address`  | `-a`  | Address to check (required) | —                       |
 | `--fork-url` | `-f`  | Anvil RPC URL               | `http://127.0.0.1:8545` |
+
+### Update Mint Fee
+
+Update the mint fee for a token on the Gateway contract using a local Anvil fork. Impersonates the contract admin to grant the maintainer role and set the new fee.
+
+**Usage:**
+
+```bash
+node web/scripts/updateMintFee.ts --token 0xTokenAddress --fee 100
+```
+
+Options:
+
+| Flag        | Short | Description                           | Default                 |
+| ----------- | ----- | ------------------------------------- | ----------------------- |
+| `--token`   | `-t`  | Token address (required)              | —                       |
+| `--fee`     | `-f`  | New mint fee in BPS, 0–500 (required) | —                       |
+| `--rpc-url` | `-r`  | Anvil RPC URL                         | `http://127.0.0.1:8545` |
+
+### Update Redeem Fee
+
+Update the redeem fee for a token on the Gateway contract using a local Anvil fork. Impersonates the contract admin to grant the maintainer role and set the new fee.
+
+**Usage:**
+
+```bash
+node web/scripts/updateRedeemFee.ts --token 0xTokenAddress --fee 100
+```
+
+Options:
+
+| Flag        | Short | Description                             | Default                 |
+| ----------- | ----- | --------------------------------------- | ----------------------- |
+| `--token`   | `-t`  | Token address (required)                | —                       |
+| `--fee`     | `-f`  | New redeem fee in BPS, 0–500 (required) | —                       |
+| `--rpc-url` | `-r`  | Anvil RPC URL                           | `http://127.0.0.1:8545` |

--- a/web/scripts/setup.ts
+++ b/web/scripts/setup.ts
@@ -2,7 +2,6 @@ import { parseArgs } from "node:util";
 import {
   createPublicClient,
   createTestClient,
-  erc20Abi,
   encodePacked,
   formatEther,
   http,
@@ -12,7 +11,9 @@ import {
   parseEther,
   toHex,
 } from "viem";
+import { getBalance, setBalance, setStorageAt } from "viem/actions";
 import { mainnet } from "viem/chains";
+import { balanceOf } from "viem-erc20/actions";
 
 import { knownTokens } from "../src/utils/tokenList.ts";
 
@@ -62,19 +63,17 @@ const testClient = createTestClient({
 });
 
 // Fund 1 ETH for gas
-const ethBalanceBefore = await publicClient.getBalance({ address });
-await testClient.setBalance({ address, value: parseEther("1") });
-const ethBalanceAfter = await publicClient.getBalance({ address });
+const ethBalanceBefore = await getBalance(publicClient, { address });
+await setBalance(testClient, { address, value: parseEther("1") });
+const ethBalanceAfter = await getBalance(publicClient, { address });
 console.log(
   `ETH: ${formatEther(ethBalanceBefore)} -> ${formatEther(ethBalanceAfter)}`,
 );
 
 for (const token of tokens) {
-  const balanceBefore = await publicClient.readContract({
-    abi: erc20Abi,
+  const balanceBefore = await balanceOf(publicClient, {
+    account: address,
     address: token.address,
-    args: [address],
-    functionName: "balanceOf",
   });
 
   const value = amount * 10n ** BigInt(token.decimals);
@@ -87,17 +86,15 @@ for (const token of tokens) {
     ),
   );
 
-  await testClient.setStorageAt({
+  await setStorageAt(testClient, {
     address: token.address,
     index: storageKey,
     value: pad(toHex(value)),
   });
 
-  const balanceAfter = await publicClient.readContract({
-    abi: erc20Abi,
+  const balanceAfter = await balanceOf(publicClient, {
+    account: address,
     address: token.address,
-    args: [address],
-    functionName: "balanceOf",
   });
 
   console.log(

--- a/web/scripts/updateMintFee.ts
+++ b/web/scripts/updateMintFee.ts
@@ -1,0 +1,127 @@
+import { parseArgs } from "node:util";
+import {
+  createPublicClient,
+  createTestClient,
+  http,
+  isAddress,
+  keccak256,
+  parseEther,
+  toHex,
+} from "viem";
+import {
+  impersonateAccount,
+  readContract,
+  setBalance,
+  waitForTransactionReceipt,
+  writeContract,
+} from "viem/actions";
+import { mainnet } from "viem/chains";
+
+import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
+import { getGatewayAddress } from "../../packages/gateway/src/getGatewayAddress.ts";
+
+const gateway = getGatewayAddress(mainnet.id);
+
+const grantRoleAbi = [
+  {
+    inputs: [
+      { name: "role", type: "bytes32" },
+      { name: "account", type: "address" },
+    ],
+    name: "grantRole",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
+
+const { values } = parseArgs({
+  options: {
+    fee: { short: "f", type: "string" },
+    "rpc-url": { default: "http://127.0.0.1:8545", short: "r", type: "string" },
+    token: { short: "t", type: "string" },
+  },
+  strict: true,
+});
+
+const token = values.token;
+if (!token || !isAddress(token, { strict: false })) {
+  console.error("Invalid --token. Must be a valid address.");
+  process.exit(1);
+}
+
+const fee = Number(values.fee);
+if (!values.fee || !Number.isInteger(fee) || fee < 0 || fee > 500) {
+  console.error("Invalid --fee. Must be an integer between 0 and 500 (BPS).");
+  process.exit(1);
+}
+
+const transport = http(values["rpc-url"]);
+
+const publicClient = createPublicClient({
+  chain: mainnet,
+  transport,
+});
+
+const testClient = createTestClient({
+  chain: mainnet,
+  mode: "anvil",
+  transport,
+});
+
+const [admin, treasury] = await Promise.all([
+  readContract(publicClient, {
+    abi: gatewayAbi,
+    address: gateway,
+    functionName: "owner",
+  }),
+  readContract(publicClient, {
+    abi: gatewayAbi,
+    address: gateway,
+    functionName: "treasury",
+  }),
+]);
+
+await impersonateAccount(testClient, { address: admin });
+await setBalance(testClient, { address: admin, value: parseEther("1") });
+
+const MAINTAINER_ROLE = keccak256(toHex("MAINTAINER_ROLE"));
+
+const grantRoleHash = await writeContract(testClient, {
+  abi: grantRoleAbi,
+  account: admin,
+  address: treasury,
+  args: [MAINTAINER_ROLE, admin],
+  functionName: "grantRole",
+});
+
+await waitForTransactionReceipt(publicClient, { hash: grantRoleHash });
+
+console.log(`Admin: ${admin}`);
+console.log(`Gateway: ${gateway}`);
+console.log(`Token: ${token}`);
+
+const currentFee = await readContract(publicClient, {
+  abi: gatewayAbi,
+  address: gateway,
+  args: [token],
+  functionName: "mintFee",
+});
+
+console.log(`Current mint fee: ${currentFee} BPS`);
+console.log(`New mint fee: ${fee} BPS`);
+
+const hash = await writeContract(testClient, {
+  abi: gatewayAbi,
+  account: admin,
+  address: gateway,
+  args: [token, BigInt(fee)],
+  functionName: "updateMintFee",
+});
+
+console.log(`Transaction hash: ${hash}`);
+
+const receipt = await waitForTransactionReceipt(publicClient, { hash });
+
+console.log(`Transaction confirmed in block ${receipt.blockNumber}`);
+console.log(`Mint fee updated: ${currentFee} -> ${fee} BPS`);

--- a/web/scripts/updateRedeemFee.ts
+++ b/web/scripts/updateRedeemFee.ts
@@ -1,0 +1,127 @@
+import { parseArgs } from "node:util";
+import {
+  createPublicClient,
+  createTestClient,
+  http,
+  isAddress,
+  keccak256,
+  parseEther,
+  toHex,
+} from "viem";
+import {
+  impersonateAccount,
+  readContract,
+  setBalance,
+  waitForTransactionReceipt,
+  writeContract,
+} from "viem/actions";
+import { mainnet } from "viem/chains";
+
+import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
+import { getGatewayAddress } from "../../packages/gateway/src/getGatewayAddress.ts";
+
+const gateway = getGatewayAddress(mainnet.id);
+
+const grantRoleAbi = [
+  {
+    inputs: [
+      { name: "role", type: "bytes32" },
+      { name: "account", type: "address" },
+    ],
+    name: "grantRole",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
+
+const { values } = parseArgs({
+  options: {
+    fee: { short: "f", type: "string" },
+    "rpc-url": { default: "http://127.0.0.1:8545", short: "r", type: "string" },
+    token: { short: "t", type: "string" },
+  },
+  strict: true,
+});
+
+const token = values.token;
+if (!token || !isAddress(token, { strict: false })) {
+  console.error("Invalid --token. Must be a valid address.");
+  process.exit(1);
+}
+
+const fee = Number(values.fee);
+if (!values.fee || !Number.isInteger(fee) || fee < 0 || fee > 500) {
+  console.error("Invalid --fee. Must be an integer between 0 and 500 (BPS).");
+  process.exit(1);
+}
+
+const transport = http(values["rpc-url"]);
+
+const publicClient = createPublicClient({
+  chain: mainnet,
+  transport,
+});
+
+const testClient = createTestClient({
+  chain: mainnet,
+  mode: "anvil",
+  transport,
+});
+
+const [admin, treasury] = await Promise.all([
+  readContract(publicClient, {
+    abi: gatewayAbi,
+    address: gateway,
+    functionName: "owner",
+  }),
+  readContract(publicClient, {
+    abi: gatewayAbi,
+    address: gateway,
+    functionName: "treasury",
+  }),
+]);
+
+await impersonateAccount(testClient, { address: admin });
+await setBalance(testClient, { address: admin, value: parseEther("1") });
+
+const MAINTAINER_ROLE = keccak256(toHex("MAINTAINER_ROLE"));
+
+const grantRoleHash = await writeContract(testClient, {
+  abi: grantRoleAbi,
+  account: admin,
+  address: treasury,
+  args: [MAINTAINER_ROLE, admin],
+  functionName: "grantRole",
+});
+
+await waitForTransactionReceipt(publicClient, { hash: grantRoleHash });
+
+console.log(`Admin: ${admin}`);
+console.log(`Gateway: ${gateway}`);
+console.log(`Token: ${token}`);
+
+const currentFee = await readContract(publicClient, {
+  abi: gatewayAbi,
+  address: gateway,
+  args: [token],
+  functionName: "redeemFee",
+});
+
+console.log(`Current redeem fee: ${currentFee} BPS`);
+console.log(`New redeem fee: ${fee} BPS`);
+
+const hash = await writeContract(testClient, {
+  abi: gatewayAbi,
+  account: admin,
+  address: gateway,
+  args: [token, BigInt(fee)],
+  functionName: "updateRedeemFee",
+});
+
+console.log(`Transaction hash: ${hash}`);
+
+const receipt = await waitForTransactionReceipt(publicClient, { hash });
+
+console.log(`Transaction confirmed in block ${receipt.blockNumber}`);
+console.log(`Redeem fee updated: ${currentFee} -> ${fee} BPS`);


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds 2 useful scripts: One for updating the MintFee for the swap page, another one for updating the RedeemFee. These are meant to be run in the local fork.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Example usage 

<img width="1486" height="210" alt="image" src="https://github.com/user-attachments/assets/8da75e17-7aca-4201-a299-a8dae828086c" />


### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
