### PR TITLE
Apply hover effect to nav bar items

### DIFF
--- a/web/src/components/base/button/button.css
+++ b/web/src/components/base/button/button.css
@@ -43,15 +43,11 @@
 
 /* Navbar link variants - color/state only */
 .button-nav-secondary {
-  @apply bg-transparent text-gray-500 enabled:hover:text-gray-900;
+  @apply bg-transparent text-gray-500 hover:text-gray-900;
 }
 
 .button-nav-secondary:focus-visible {
   box-shadow: 0 0 0 4px var(--color-gray-300);
-}
-
-.button-nav-secondary:hover {
-  @apply text-gray-900;
 }
 
 .button-nav-primary {

--- a/web/src/components/base/button/button.css
+++ b/web/src/components/base/button/button.css
@@ -50,6 +50,10 @@
   box-shadow: 0 0 0 4px var(--color-gray-300);
 }
 
+.button-nav-secondary:hover {
+  @apply text-gray-900;
+}
+
 .button-nav-primary {
   @apply bg-blue-50 text-blue-500;
 }


### PR DESCRIPTION
### Description

The hover effect was not applied because the `enabled` selector only applies to form controls, not links. Removing that selector allows the effect to be applied to links too. Given `button-nav-secondary` is only applied to links, this change seems safe to me.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/89de78ba-e6f5-464d-91bd-f11f31bad809

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #126

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
