### PR TITLE
Add staked and exit queue cards to analytics

### DIFF
--- a/web/src/hooks/useAnalyticsTotals.ts
+++ b/web/src/hooks/useAnalyticsTotals.ts
@@ -6,6 +6,7 @@ const apiUrl = import.meta.env.VITE_VETRO_API_URL;
 
 type AnalyticsTotals = {
   vusdMinted: string;
+  vusdStaked: string;
 };
 
 export const useAnalyticsTotals = () =>

--- a/web/src/hooks/useAnalyticsTotals.ts
+++ b/web/src/hooks/useAnalyticsTotals.ts
@@ -17,4 +17,5 @@ export const useAnalyticsTotals = () =>
     queryKey: ["analytics-totals"],
     refetchInterval: 5 * 60 * 1000, // 5 minutes
     retry: 2,
+    staleTime: 5 * 60 * 1000, // 5 minutes
   });

--- a/web/src/hooks/useVariableStakeExitQueue.ts
+++ b/web/src/hooks/useVariableStakeExitQueue.ts
@@ -1,0 +1,46 @@
+import { useQuery } from "@tanstack/react-query";
+import { getStakingVaultAddress } from "@vetro/earn";
+import fetch from "fetch-plus-plus";
+import { useEthereumClient } from "hooks/useEthereumClient";
+import { useMainnet } from "hooks/useMainnet";
+import { isValidUrl } from "utils/url";
+import type { Address } from "viem";
+import { convertToAssets } from "viem-erc4626/actions";
+
+const apiUrl = import.meta.env.VITE_VETRO_API_URL;
+
+type ExitQueue = {
+  openTickets: number;
+  shares: string;
+};
+
+const exitQueueQueryKey = ({
+  chainId,
+  stakingVaultAddress,
+}: {
+  chainId: number;
+  stakingVaultAddress: Address;
+}) => ["variable-stake-exit-queue", chainId, stakingVaultAddress];
+
+export function useVariableStakeExitQueue() {
+  const chain = useMainnet();
+  const client = useEthereumClient();
+  const stakingVaultAddress = getStakingVaultAddress(chain.id);
+
+  return useQuery({
+    enabled: apiUrl !== undefined && isValidUrl(apiUrl) && !!client,
+    async queryFn() {
+      const { openTickets, shares } = await (fetch(
+        `${apiUrl}/variable-stake/exit-queue`,
+      ) as Promise<ExitQueue>);
+      const vusdInCooldown = await convertToAssets(client!, {
+        address: stakingVaultAddress,
+        shares: BigInt(shares),
+      });
+      return { openTickets, vusdInCooldown };
+    },
+    queryKey: exitQueueQueryKey({ chainId: chain.id, stakingVaultAddress }),
+    refetchInterval: 5 * 60 * 1000, // 5 minutes
+    retry: 2,
+  });
+}

--- a/web/src/hooks/useVariableStakeExitQueue.ts
+++ b/web/src/hooks/useVariableStakeExitQueue.ts
@@ -42,5 +42,6 @@ export function useVariableStakeExitQueue() {
     queryKey: exitQueueQueryKey({ chainId: chain.id, stakingVaultAddress }),
     refetchInterval: 5 * 60 * 1000, // 5 minutes
     retry: 2,
+    staleTime: 5 * 60 * 1000, // 5 minutes
   });
 }

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -11,7 +11,9 @@
   },
   "pages": {
     "analytics": {
+      "exit-queue-label": "Total VUSD on withdrawn cooldown",
       "reserve-buffer-label": "Reserve buffer",
+      "staked-label": "Total VUSD staked",
       "title": "Monitor protocol analytics",
       "tvl-label": "Total Value Locked (TVL)",
       "yield-label": "Yield allocation",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -11,7 +11,9 @@
   },
   "pages": {
     "analytics": {
+      "exit-queue-label": "Total VUSD en período de espera de retiro",
       "reserve-buffer-label": "Reserva de liquidez",
+      "staked-label": "Total VUSD depositado",
       "title": "Monitorear analíticas del protocolo",
       "tvl-label": "Valor Total Bloqueado (TVL)",
       "yield-label": "Asignación de yield",

--- a/web/src/pages/analytics/components/allocationCard/index.tsx
+++ b/web/src/pages/analytics/components/allocationCard/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   icon: ReactNode;
   isError: boolean;
   isLoading: boolean;
-  items: AllocationItem[];
+  items?: AllocationItem[];
   label: string;
   value: string;
 };
@@ -43,20 +43,24 @@ export const AllocationCard = function ({
           <h3 className="text-h3 text-gray-900">{renderValue()}</h3>
         </div>
       </div>
-      <AllocationChart
-        hoveredLabel={hoveredLabel}
-        isError={isError}
-        isLoading={isLoading}
-        items={items}
-        onHover={setHoveredLabel}
-      />
-      <AllocationLegend
-        hoveredLabel={hoveredLabel}
-        isError={isError}
-        isLoading={isLoading}
-        items={items}
-        onHover={setHoveredLabel}
-      />
+      {items !== undefined && (
+        <>
+          <AllocationChart
+            hoveredLabel={hoveredLabel}
+            isError={isError}
+            isLoading={isLoading}
+            items={items}
+            onHover={setHoveredLabel}
+          />
+          <AllocationLegend
+            hoveredLabel={hoveredLabel}
+            isError={isError}
+            isLoading={isLoading}
+            items={items}
+            onHover={setHoveredLabel}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/web/src/pages/analytics/icons/exitQueueIcon.tsx
+++ b/web/src/pages/analytics/icons/exitQueueIcon.tsx
@@ -1,0 +1,8 @@
+export const ExitQueueIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none">
+    <path
+      fill="#416BFF"
+      d="M8.75 6h-1.5V3.56L6.03 4.78a.75.75 0 0 1-1.06-1.06l2.5-2.5a.75.75 0 0 1 1.06 0l2.5 2.5a.75.75 0 1 1-1.06 1.06L8.75 3.56V6H11a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h2.25v5.25a.75.75 0 1 0 1.5 0V6Z"
+    />
+  </svg>
+);

--- a/web/src/pages/analytics/icons/stakingIcon.tsx
+++ b/web/src/pages/analytics/icons/stakingIcon.tsx
@@ -1,0 +1,8 @@
+export const StakingIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none">
+    <path
+      fill="#416BFF"
+      d="M8 1a.75.75 0 0 1 .75.75V5h-1.5V1.75A.75.75 0 0 1 8 1Zm-.75 4v4.44L6.03 8.22a.75.75 0 0 0-1.06 1.06l2.5 2.5a.75.75 0 0 0 1.06 0l2.5-2.5a.75.75 0 1 0-1.06-1.06L8.75 9.44V5H11a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h2.25Z"
+    />
+  </svg>
+);

--- a/web/src/pages/analytics/index.tsx
+++ b/web/src/pages/analytics/index.tsx
@@ -1,6 +1,8 @@
 import { PageTitle } from "components/base/pageTitle";
+import { StripedDivider } from "components/stripedDivider";
 import { useAnalyticsTotals } from "hooks/useAnalyticsTotals";
 import { useAnalyticsTreasury } from "hooks/useAnalyticsTreasury";
+import { useVariableStakeExitQueue } from "hooks/useVariableStakeExitQueue";
 import { useVusd } from "hooks/useVusd";
 import { useWhitelistedTokens } from "hooks/useWhitelistedTokens";
 import { useTranslation } from "react-i18next";
@@ -9,7 +11,9 @@ import { formatUnits } from "viem";
 
 import { AllocationCard } from "./components/allocationCard";
 import { DatabaseIcon } from "./icons/databaseIcon";
+import { ExitQueueIcon } from "./icons/exitQueueIcon";
 import { PieChartIcon } from "./icons/pieChartIcon";
+import { StakingIcon } from "./icons/stakingIcon";
 import {
   assignColor,
   toReserveBufferAmount,
@@ -29,6 +33,11 @@ export const Analytics = function () {
     isError: isTotalsError,
     isLoading: isTotalsLoading,
   } = useAnalyticsTotals();
+  const {
+    data: exitQueue,
+    isError: isExitQueueError,
+    isLoading: isExitQueueLoading,
+  } = useVariableStakeExitQueue();
   const { data: vusd } = useVusd();
   const {
     data: whitelistedTokens,
@@ -40,8 +49,19 @@ export const Analytics = function () {
   const isTokensError = isTreasuryError || isWhitelistedTokensError;
   const tokens = { treasuryTokens: treasury, whitelistedTokens };
 
-  const tvlValue = totals
-    ? formatUsd(Number(formatUnits(BigInt(totals.vusdMinted), vusd.decimals)))
+  const [tvlValue, stakedValue] = totals
+    ? [
+        formatUsd(
+          Number(formatUnits(BigInt(totals.vusdMinted), vusd.decimals)),
+        ),
+        formatUsd(
+          Number(formatUnits(BigInt(totals.vusdStaked), vusd.decimals)),
+        ),
+      ]
+    : ["", ""];
+
+  const exitQueueValue = exitQueue
+    ? formatUsd(Number(formatUnits(exitQueue.vusdInCooldown, vusd.decimals)))
     : "";
 
   const yieldItems = toYieldItems(tokens);
@@ -61,7 +81,7 @@ export const Analytics = function () {
   return (
     <div className="flex flex-col">
       <PageTitle value={t("pages.analytics.title")} />
-      <div className="flex flex-col border-t border-gray-200 md:flex-row md:divide-x md:divide-gray-200">
+      <div className="flex flex-col border-t border-gray-200 bg-gray-100 md:flex-row md:divide-x md:divide-gray-200">
         <AllocationCard
           icon={<DatabaseIcon />}
           isError={isTokensError || isTotalsError}
@@ -77,6 +97,25 @@ export const Analytics = function () {
           items={bufferItem ? [...yieldItems, bufferItem] : yieldItems}
           label={t("pages.analytics.yield-label")}
           value={yieldValue}
+        />
+      </div>
+      <div className="bg-gray-100">
+        <StripedDivider />
+      </div>
+      <div className="flex flex-col border-y border-gray-200 bg-gray-100 md:flex-row md:divide-x md:divide-gray-200">
+        <AllocationCard
+          icon={<StakingIcon />}
+          isError={isTotalsError}
+          isLoading={isTotalsLoading}
+          label={t("pages.analytics.staked-label")}
+          value={stakedValue}
+        />
+        <AllocationCard
+          icon={<ExitQueueIcon />}
+          isError={isExitQueueError}
+          isLoading={isExitQueueLoading}
+          label={t("pages.analytics.exit-queue-label")}
+          value={exitQueueValue}
         />
       </div>
     </div>


### PR DESCRIPTION
### Description

This PR adds two new stat cards below the existing allocation cards on the analytics page.. "Total VUSD staked" and "Total VUSD on withdrawn cooldown".

- Add `vusdStaked` field to `AnalyticsTotals` type
- Create `useVariableStakeExitQueue` hook that fetches open tickets and converts vault shares to VUSD assets via `convertToAssets`
- Refactor `AllocationCard` to make `items` optional so the component can render as a simple stat card without chart/legend
- Add staking and exit queue SVG icons
- Add EN/ES translation keys


### Screenshots

https://github.com/user-attachments/assets/8772745d-af73-4359-b452-eb4dfed718d8

### Related issue(s)

Closes #248

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
