### PR TITLE
Make Vetro logo navigate to the Swap page

### DIFF
--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -14,7 +14,7 @@ import { NavBarLinks } from "./navbar/links";
 import { WalletDrawer } from "./walletDrawer";
 
 const VetroLogo = () => (
-  <I18nLink className="mr-auto flex items-center" to="/swap">
+  <I18nLink className="mr-auto flex items-center" to="/">
     <img alt="Vetro Logo" className="md:hidden" src={vetroLogoMobile} />
     <img alt="Vetro Logo" className="max-md:hidden" src={vetroLogo} />
   </I18nLink>

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -14,9 +14,9 @@ import { NavBarLinks } from "./navbar/links";
 import { WalletDrawer } from "./walletDrawer";
 
 const VetroLogo = () => (
-  <I18nLink to="/swap">
-    <img alt="Vetro Logo" className="mr-auto md:hidden" src={vetroLogoMobile} />
-    <img alt="Vetro Logo" className="mr-auto max-md:hidden" src={vetroLogo} />
+  <I18nLink className="mr-auto flex items-center" to="/swap">
+    <img alt="Vetro Logo" className="md:hidden" src={vetroLogoMobile} />
+    <img alt="Vetro Logo" className="max-md:hidden" src={vetroLogo} />
   </I18nLink>
 );
 

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -5,6 +5,7 @@ import { formatEvmAddress } from "utils/format";
 import { useAccount } from "wagmi";
 
 import { Button, ButtonIcon } from "./base/button";
+import { I18nLink } from "./base/i18nLink";
 import hamburgerIcon from "./icons/hamburger.svg";
 import vetroLogo from "./icons/vetroLogo.svg";
 import vetroLogoMobile from "./icons/vetroLogoMobile.svg";
@@ -13,10 +14,10 @@ import { NavBarLinks } from "./navbar/links";
 import { WalletDrawer } from "./walletDrawer";
 
 const VetroLogo = () => (
-  <>
+  <I18nLink to="/swap">
     <img alt="Vetro Logo" className="mr-auto md:hidden" src={vetroLogoMobile} />
     <img alt="Vetro Logo" className="mr-auto max-md:hidden" src={vetroLogo} />
-  </>
+  </I18nLink>
 );
 
 export function Header() {


### PR DESCRIPTION
### Description

The logo had no click behavior. This PR wraps it with I18nLink which navigates to the default route (/swap) while preserving the current locale prefix.

### Screenshots

https://github.com/user-attachments/assets/545fb3ca-1b4c-478b-8cb1-fd61504cd3aa

### Related issue(s)

Closes #203 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
