### PR TITLE
Update withdraw stepper copy and rename i18n key

### DIFF
--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -239,7 +239,8 @@
         "requesting": "Requesting...",
         "withdraw": "Withdraw",
         "withdraw-coming-soon": "Withdraw coming soon",
-        "withdraw-step-1-description": "Submit a withdrawal request to begin the exit process. Your funds remain staked at this stage.",
+        "withdraw-progress": "Withdraw progress",
+        "withdraw-step-1-description": "Start the withdrawal process. Your funds will be locked in a cooldown and will no longer earn yield.",
         "withdraw-step-1-title": "Request withdrawal",
         "withdraw-step-2-description": "A {{count}}-day cooldown period begins. During this time, your funds are locked and no yield is earned.",
         "withdraw-step-2-title": "Start {{count}}-day cooldown",
@@ -247,7 +248,6 @@
         "withdraw-step-3-title": "Withdraw funds",
         "withdraw-toast-description": "Your {{count}}-day cooldown has started.",
         "withdraw-toast-title": "Withdrawal request confirmed",
-        "withdrawals-progress": "Withdrawals progress",
         "withdrawing-fees-label": "Withdrawing {{amount}} {{token}}",
         "you-will-stake": "You will stake",
         "you-will-withdraw": "You will withdraw"

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -241,7 +241,8 @@
         "requesting": "Solicitando...",
         "withdraw": "Retirar",
         "withdraw-coming-soon": "Retiro próximamente",
-        "withdraw-step-1-description": "Envíe una solicitud de retiro para iniciar el proceso de salida. Sus fondos permanecen en stake en esta etapa.",
+        "withdraw-progress": "Progreso de retiro",
+        "withdraw-step-1-description": "Inicie el proceso de retiro. Sus fondos estarán bloqueados en un período de espera y ya no generarán rendimiento.",
         "withdraw-step-1-title": "Solicitar retiro",
         "withdraw-step-2-description_one": "Comienza un período de espera de {{count}} día. Durante este tiempo, sus fondos están bloqueados y no se generan rendimientos.",
         "withdraw-step-2-description_other": "Comienza un período de espera de {{count}} días. Durante este tiempo, sus fondos están bloqueados y no se generan rendimientos.",
@@ -252,7 +253,6 @@
         "withdraw-toast-description_one": "Su período de espera de {{count}} día ha comenzado.",
         "withdraw-toast-description_other": "Su período de espera de {{count}} días ha comenzado.",
         "withdraw-toast-title": "Solicitud de retiro confirmada",
-        "withdrawals-progress": "Progreso de retiros",
         "withdrawing-fees-label": "Retirando {{amount}} {{token}}",
         "you-will-stake": "Usted va a hacer stake de",
         "you-will-withdraw": "Usted va a retirar"

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -241,7 +241,7 @@
         "requesting": "Solicitando...",
         "withdraw": "Retirar",
         "withdraw-coming-soon": "Retiro próximamente",
-        "withdraw-progress": "Progreso de retiro",
+        "withdraw-progress": "Progreso del retiro",
         "withdraw-step-1-description": "Inicie el proceso de retiro. Sus fondos estarán bloqueados en un período de espera y ya no generarán rendimiento.",
         "withdraw-step-1-title": "Solicitar retiro",
         "withdraw-step-2-description_one": "Comienza un período de espera de {{count}} día. Durante este tiempo, sus fondos están bloqueados y no se generan rendimientos.",

--- a/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
@@ -311,7 +311,7 @@ export function StakeWithdrawForm({
 
       <div className="mt-auto flex flex-col gap-2 px-6">
         <p className="text-xs font-medium tracking-wide text-gray-500">
-          {t("pages.earn.stake.withdrawals-progress")}
+          {t("pages.earn.stake.withdraw-progress")}
         </p>
         <div className="border-t border-gray-200">
           <VerticalStepper steps={steps} />


### PR DESCRIPTION
### Description

This PR clarifies step 1 description to say funds are locked in a cooldown and no longer earn yield. Also rename the i18n key from `withdrawals-progress` to `withdraw-progress` to match the new label "Withdraw progress".

### Screenshots

https://github.com/user-attachments/assets/172dac3d-d081-4f4f-b99e-e6346c0fef89

### Related issue(s)

Closes #63 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
