### PR TITLE
Add redeem delay toggle script

### DIFF
--- a/packages/gateway/src/abi/gatewayAbi.ts
+++ b/packages/gateway/src/abi/gatewayAbi.ts
@@ -73,6 +73,13 @@ export const gatewayAbi = [
     type: "function",
   },
   {
+    inputs: [{ name: "account_", type: "address" }],
+    name: "removeFromInstantRedeemWhitelist",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
     inputs: [
       { name: "tokenIn_", type: "address" },
       { name: "amountIn_", type: "uint256" },
@@ -131,6 +138,13 @@ export const gatewayAbi = [
     type: "function",
   },
   {
+    inputs: [{ name: "enabled_", type: "bool" }],
+    name: "setWithdrawalDelayEnabled",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
     inputs: [
       { name: "token_", type: "address" },
       { name: "newMintFee_", type: "uint256" },
@@ -146,6 +160,13 @@ export const gatewayAbi = [
       { name: "newRedeemFee_", type: "uint256" },
     ],
     name: "updateRedeemFee",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ name: "newDelay_", type: "uint256" }],
+    name: "updateWithdrawalDelay",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",

--- a/web/README.md
+++ b/web/README.md
@@ -81,3 +81,23 @@ Options:
 | `--token`   | `-t`  | Token address (required)                | —                       |
 | `--fee`     | `-f`  | New redeem fee in BPS, 0–500 (required) | —                       |
 | `--rpc-url` | `-r`  | Anvil RPC URL                           | `http://127.0.0.1:8545` |
+
+### Redeem Delay
+
+Toggle the withdrawal delay for an address on the Gateway contract using a local Anvil fork. Impersonates the contract owner to enable/disable the delay and manage the instant redeem whitelist.
+
+**Usage:**
+
+```bash
+node web/scripts/redeemDelay.ts --address 0xYourAddress --delay
+node web/scripts/redeemDelay.ts --address 0xYourAddress --no-delay
+```
+
+Options:
+
+| Flag         | Short | Description                              | Default                 |
+| ------------ | ----- | ---------------------------------------- | ----------------------- |
+| `--address`  | `-a`  | Target address (required)                | —                       |
+| `--delay`    |       | Enable withdrawal delay for the address  | —                       |
+| `--no-delay` |       | Disable withdrawal delay for the address | —                       |
+| `--fork-url` | `-f`  | Anvil RPC URL                            | `http://127.0.0.1:8545` |

--- a/web/scripts/redeemDelay.ts
+++ b/web/scripts/redeemDelay.ts
@@ -35,7 +35,7 @@ const forkUrl = values["fork-url"] ?? "http://127.0.0.1:8545";
 
 if (!values.address || !isAddress(values.address, { strict: false })) {
   console.error(
-    "Address is invalid. Usage: node web/scripts/delay.ts --address 0xYourAddress --delay|--no-delay",
+    "Address is invalid. Usage: node web/scripts/redeemDelay.ts --address 0xYourAddress --delay|--no-delay",
   );
   process.exit(1);
 }
@@ -84,73 +84,75 @@ const [owner, delayEnabledBefore] = await Promise.all([
 await impersonateAccount(testClient, { address: owner });
 await setBalance(testClient, { address: owner, value: parseEther("1") });
 
-if (enableDelay) {
-  if (!delayEnabledBefore) {
-    const hash = await writeContract(testClient, {
-      abi: gatewayAbi,
-      account: owner,
-      address: gateway,
-      args: [true],
-      functionName: "setWithdrawalDelayEnabled",
-    });
-    await waitForTransactionReceipt(publicClient, { hash });
+try {
+  if (enableDelay) {
+    if (!delayEnabledBefore) {
+      const hash = await writeContract(testClient, {
+        abi: gatewayAbi,
+        account: owner,
+        address: gateway,
+        args: [true],
+        functionName: "setWithdrawalDelayEnabled",
+      });
+      await waitForTransactionReceipt(publicClient, { hash });
+    }
+
+    const [, isWhitelisted] = await Promise.all([
+      writeContract(testClient, {
+        abi: gatewayAbi,
+        account: owner,
+        address: gateway,
+        args: [WITHDRAWAL_DELAY_SECONDS],
+        functionName: "updateWithdrawalDelay",
+      }).then((hash) => waitForTransactionReceipt(publicClient, { hash })),
+      readContract(publicClient, {
+        abi: gatewayAbi,
+        address: gateway,
+        args: [address],
+        functionName: "isInstantRedeemWhitelisted",
+      }),
+    ]);
+
+    if (isWhitelisted) {
+      const hash = await writeContract(testClient, {
+        abi: gatewayAbi,
+        account: owner,
+        address: gateway,
+        args: [address],
+        functionName: "removeFromInstantRedeemWhitelist",
+      });
+      await waitForTransactionReceipt(publicClient, { hash });
+    }
+  } else {
+    if (delayEnabledBefore) {
+      const hash = await writeContract(testClient, {
+        abi: gatewayAbi,
+        account: owner,
+        address: gateway,
+        args: [false],
+        functionName: "setWithdrawalDelayEnabled",
+      });
+      await waitForTransactionReceipt(publicClient, { hash });
+    }
   }
 
-  const [, isWhitelisted] = await Promise.all([
-    writeContract(testClient, {
-      abi: gatewayAbi,
-      account: owner,
-      address: gateway,
-      args: [WITHDRAWAL_DELAY_SECONDS],
-      functionName: "updateWithdrawalDelay",
-    }).then((hash) => waitForTransactionReceipt(publicClient, { hash })),
+  const [delayEnabledAfter, withdrawalDelay] = await Promise.all([
     readContract(publicClient, {
       abi: gatewayAbi,
       address: gateway,
-      args: [address],
-      functionName: "isInstantRedeemWhitelisted",
+      functionName: "withdrawalDelayEnabled",
+    }),
+    readContract(publicClient, {
+      abi: gatewayAbi,
+      address: gateway,
+      functionName: "withdrawalDelay",
     }),
   ]);
 
-  if (isWhitelisted) {
-    const hash = await writeContract(testClient, {
-      abi: gatewayAbi,
-      account: owner,
-      address: gateway,
-      args: [address],
-      functionName: "removeFromInstantRedeemWhitelist",
-    });
-    await waitForTransactionReceipt(publicClient, { hash });
-  }
-} else {
-  if (delayEnabledBefore) {
-    const hash = await writeContract(testClient, {
-      abi: gatewayAbi,
-      account: owner,
-      address: gateway,
-      args: [false],
-      functionName: "setWithdrawalDelayEnabled",
-    });
-    await waitForTransactionReceipt(publicClient, { hash });
-  }
+  console.log(
+    `withdrawalDelayEnabled: ${delayEnabledBefore} -> ${delayEnabledAfter}`,
+  );
+  console.log(`withdrawalDelay: ${withdrawalDelay}s`);
+} finally {
+  await stopImpersonatingAccount(testClient, { address: owner });
 }
-
-const [delayEnabledAfter, withdrawalDelay] = await Promise.all([
-  readContract(publicClient, {
-    abi: gatewayAbi,
-    address: gateway,
-    functionName: "withdrawalDelayEnabled",
-  }),
-  readContract(publicClient, {
-    abi: gatewayAbi,
-    address: gateway,
-    functionName: "withdrawalDelay",
-  }),
-]);
-
-console.log(
-  `withdrawalDelayEnabled: ${delayEnabledBefore} -> ${delayEnabledAfter}`,
-);
-console.log(`withdrawalDelay: ${withdrawalDelay}s`);
-
-await stopImpersonatingAccount(testClient, { address: owner });

--- a/web/scripts/redeemDelay.ts
+++ b/web/scripts/redeemDelay.ts
@@ -1,0 +1,156 @@
+import { parseArgs } from "node:util";
+import {
+  createPublicClient,
+  createTestClient,
+  http,
+  isAddress,
+  parseEther,
+} from "viem";
+import {
+  impersonateAccount,
+  readContract,
+  setBalance,
+  stopImpersonatingAccount,
+  waitForTransactionReceipt,
+  writeContract,
+} from "viem/actions";
+import { mainnet } from "viem/chains";
+
+import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
+import { getGatewayAddress } from "../../packages/gateway/src/getGatewayAddress.ts";
+
+const gateway = getGatewayAddress(mainnet.id);
+
+const { values } = parseArgs({
+  options: {
+    address: { short: "a", type: "string" },
+    delay: { type: "boolean" },
+    "fork-url": { short: "f", type: "string" },
+    "no-delay": { type: "boolean" },
+  },
+  strict: true,
+});
+
+const forkUrl = values["fork-url"] ?? "http://127.0.0.1:8545";
+
+if (!values.address || !isAddress(values.address, { strict: false })) {
+  console.error(
+    "Address is invalid. Usage: node web/scripts/delay.ts --address 0xYourAddress --delay|--no-delay",
+  );
+  process.exit(1);
+}
+
+if (!values.delay && !values["no-delay"]) {
+  console.error("Exactly one of --delay or --no-delay must be provided.");
+  process.exit(1);
+}
+
+if (values.delay && values["no-delay"]) {
+  console.error("Exactly one of --delay or --no-delay must be provided.");
+  process.exit(1);
+}
+
+const { address } = values;
+const enableDelay = Boolean(values.delay);
+
+const WITHDRAWAL_DELAY_SECONDS = 72n;
+
+const transport = http(forkUrl);
+
+const publicClient = createPublicClient({
+  chain: mainnet,
+  transport,
+});
+
+const testClient = createTestClient({
+  chain: mainnet,
+  mode: "anvil",
+  transport,
+});
+
+const [owner, delayEnabledBefore] = await Promise.all([
+  readContract(publicClient, {
+    abi: gatewayAbi,
+    address: gateway,
+    functionName: "owner",
+  }),
+  readContract(publicClient, {
+    abi: gatewayAbi,
+    address: gateway,
+    functionName: "withdrawalDelayEnabled",
+  }),
+]);
+
+await impersonateAccount(testClient, { address: owner });
+await setBalance(testClient, { address: owner, value: parseEther("1") });
+
+if (enableDelay) {
+  if (!delayEnabledBefore) {
+    const hash = await writeContract(testClient, {
+      abi: gatewayAbi,
+      account: owner,
+      address: gateway,
+      args: [true],
+      functionName: "setWithdrawalDelayEnabled",
+    });
+    await waitForTransactionReceipt(publicClient, { hash });
+  }
+
+  const [, isWhitelisted] = await Promise.all([
+    writeContract(testClient, {
+      abi: gatewayAbi,
+      account: owner,
+      address: gateway,
+      args: [WITHDRAWAL_DELAY_SECONDS],
+      functionName: "updateWithdrawalDelay",
+    }).then((hash) => waitForTransactionReceipt(publicClient, { hash })),
+    readContract(publicClient, {
+      abi: gatewayAbi,
+      address: gateway,
+      args: [address],
+      functionName: "isInstantRedeemWhitelisted",
+    }),
+  ]);
+
+  if (isWhitelisted) {
+    const hash = await writeContract(testClient, {
+      abi: gatewayAbi,
+      account: owner,
+      address: gateway,
+      args: [address],
+      functionName: "removeFromInstantRedeemWhitelist",
+    });
+    await waitForTransactionReceipt(publicClient, { hash });
+  }
+} else {
+  if (delayEnabledBefore) {
+    const hash = await writeContract(testClient, {
+      abi: gatewayAbi,
+      account: owner,
+      address: gateway,
+      args: [false],
+      functionName: "setWithdrawalDelayEnabled",
+    });
+    await waitForTransactionReceipt(publicClient, { hash });
+  }
+}
+
+const [delayEnabledAfter, withdrawalDelay] = await Promise.all([
+  readContract(publicClient, {
+    abi: gatewayAbi,
+    address: gateway,
+    functionName: "withdrawalDelayEnabled",
+  }),
+  readContract(publicClient, {
+    abi: gatewayAbi,
+    address: gateway,
+    functionName: "withdrawalDelay",
+  }),
+]);
+
+console.log(
+  `withdrawalDelayEnabled: ${delayEnabledBefore} -> ${delayEnabledAfter}`,
+);
+console.log(`withdrawalDelay: ${withdrawalDelay}s`);
+
+await stopImpersonatingAccount(testClient, { address: owner });


### PR DESCRIPTION
### Description

Add a local development script (`web/scripts/redeemDelay.ts`) to toggle the withdrawal delay for an address on the Gateway contract via a local Anvil fork. The script impersonates the contract owner to enable/disable the delay and manage the instant redeem whitelist.

Also adds the required ABI entries to `gatewayAbi.ts` and documents the script in the README.

### Screenshots

N/A — no UI changes.

### Related issue(s)

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.