### PR TITLE
Validate balances before gas estimations

### DIFF
--- a/web/src/fetchers/fetchDepositGasUnits.ts
+++ b/web/src/fetchers/fetchDepositGasUnits.ts
@@ -1,3 +1,4 @@
+import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
 import type { QueryClient } from "@tanstack/react-query";
 import { getStakingVaultAddress, stakingVaultAbi } from "@vetro/earn";
 import type { Token } from "types";
@@ -10,6 +11,7 @@ import { estimateApprovalGasUnits } from "./estimateApprovalGasUnits";
 /**
  * Estimates gas units for an earn deposit. Returns the total gas units
  * for the whole flow (approval + deposit).
+ * Throws if the amount exceeds the user's token balance.
  */
 export const fetchDepositGasUnits = async function ({
   amount,
@@ -26,7 +28,20 @@ export const fetchDepositGasUnits = async function ({
   queryClient: QueryClient;
   token: Token;
 }) {
-  const stakingVaultAddress = getStakingVaultAddress(client.chain!.id);
+  const chainId = client.chain!.id;
+  const stakingVaultAddress = getStakingVaultAddress(chainId);
+
+  const balance = await queryClient.ensureQueryData(
+    tokenBalanceQueryOptions({
+      account: owner,
+      client,
+      token,
+    }),
+  );
+
+  if (amount > balance) {
+    throw new Error("Insufficient token balance");
+  }
 
   const [approvalGas, depositGas] = await Promise.all([
     estimateApprovalGasUnits({

--- a/web/src/fetchers/fetchMintGasUnits.ts
+++ b/web/src/fetchers/fetchMintGasUnits.ts
@@ -1,3 +1,4 @@
+import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
 import type { QueryClient } from "@tanstack/react-query";
 import { getGatewayAddress } from "@vetro/gateway";
 import { encodeDeposit } from "@vetro/gateway/actions";
@@ -12,6 +13,7 @@ import { estimateApprovalGasUnits } from "./estimateApprovalGasUnits";
  * Estimates gas units for minting. Minting always requires approving the
  * tokens sent to the gateway. Returns the total gas units for the whole flow
  * (approval + deposit).
+ * Throws if the amount exceeds the user's token balance.
  */
 export const fetchMintGasUnits = async function ({
   amount,
@@ -30,7 +32,20 @@ export const fetchMintGasUnits = async function ({
   queryClient: QueryClient;
   token: Token;
 }) {
-  const gatewayAddress = getGatewayAddress(client.chain!.id);
+  const chainId = client.chain!.id;
+  const gatewayAddress = getGatewayAddress(chainId);
+
+  const balance = await queryClient.ensureQueryData(
+    tokenBalanceQueryOptions({
+      account: owner,
+      client,
+      token,
+    }),
+  );
+
+  if (amount > balance) {
+    throw new Error("Insufficient token balance");
+  }
 
   const [approvalGas, mintGas] = await Promise.all([
     estimateApprovalGasUnits({

--- a/web/src/fetchers/fetchRedeemGasUnits.ts
+++ b/web/src/fetchers/fetchRedeemGasUnits.ts
@@ -1,7 +1,9 @@
+import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
 import type { QueryClient } from "@tanstack/react-query";
 import { getGatewayAddress } from "@vetro/gateway";
 import { encodeRedeem } from "@vetro/gateway/actions";
 import { redeemDelayOptions } from "hooks/useRedeemDelay";
+import { treasuryReservesOptions } from "hooks/useTreasuryReserves";
 import type { Token } from "types";
 import { createErc20AllowanceStateOverride } from "utils/erc20StateOverride";
 import type { Address, Client } from "viem";
@@ -14,6 +16,8 @@ import { estimateApprovalGasUnits } from "./estimateApprovalGasUnits";
  * need an ERC-20 approval because tokens are sent directly to the gateway.
  * Two-step redeemers (redeemDelay > 0) skip the approval because their
  * tokens are already locked in the vault.
+ * Throws if the amount exceeds the user's token balance (instant redeem) or
+ * the treasury reserves for the output token (two-step redeem).
  */
 export const fetchRedeemGasUnits = async function ({
   amount,
@@ -34,17 +38,43 @@ export const fetchRedeemGasUnits = async function ({
   token: Token;
   tokenOut: Address;
 }) {
-  const gatewayAddress = getGatewayAddress(client.chain!.id);
+  const chainId = client.chain!.id;
+  const gatewayAddress = getGatewayAddress(chainId);
 
   const redeemDelay = await queryClient.ensureQueryData(
     redeemDelayOptions({
       account: owner,
-      chainId: client.chain!.id,
+      chainId,
       client,
       gatewayAddress,
       queryClient,
     }),
   );
+
+  // For instant redeems (redeemDelay === 0), tokens come from the user's
+  // wallet, so check the balance. For vault redeems (redeemDelay > 0),
+  // tokens are already locked in the contract.
+  if (redeemDelay === 0n) {
+    const balance = await queryClient.ensureQueryData(
+      tokenBalanceQueryOptions({
+        account: owner,
+        client,
+        token: { address: token.address, chainId },
+      }),
+    );
+
+    if (amount > balance) {
+      throw new Error("Insufficient token balance");
+    }
+  } else {
+    const reserves = await queryClient.ensureQueryData(
+      treasuryReservesOptions({ chainId, client, gatewayAddress, queryClient }),
+    );
+    const reserve = reserves.find((r) => r.token.address === tokenOut);
+    if (reserve && minAmountOut > reserve.amount) {
+      throw new Error("Insufficient treasury reserves");
+    }
+  }
 
   const operationGasPromise = estimateGas(client, {
     account: owner,

--- a/web/src/fetchers/fetchRedeemGasUnits.ts
+++ b/web/src/fetchers/fetchRedeemGasUnits.ts
@@ -6,7 +6,7 @@ import { redeemDelayOptions } from "hooks/useRedeemDelay";
 import { treasuryReservesOptions } from "hooks/useTreasuryReserves";
 import type { Token } from "types";
 import { createErc20AllowanceStateOverride } from "utils/erc20StateOverride";
-import type { Address, Client } from "viem";
+import { type Address, type Client, isAddressEqual } from "viem";
 import { estimateGas } from "viem/actions";
 
 import { estimateApprovalGasUnits } from "./estimateApprovalGasUnits";
@@ -70,8 +70,13 @@ export const fetchRedeemGasUnits = async function ({
     const reserves = await queryClient.ensureQueryData(
       treasuryReservesOptions({ chainId, client, gatewayAddress, queryClient }),
     );
-    const reserve = reserves.find((r) => r.token.address === tokenOut);
-    if (reserve && minAmountOut > reserve.amount) {
+    const reserve = reserves.find((r) =>
+      isAddressEqual(r.token.address, tokenOut),
+    );
+    if (!reserve) {
+      throw new Error("Unknown output token");
+    }
+    if (minAmountOut > reserve.amount) {
       throw new Error("Insufficient treasury reserves");
     }
   }

--- a/web/src/fetchers/fetchRequestRedeemGasUnits.ts
+++ b/web/src/fetchers/fetchRequestRedeemGasUnits.ts
@@ -1,3 +1,4 @@
+import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
 import type { QueryClient } from "@tanstack/react-query";
 import { getGatewayAddress } from "@vetro/gateway";
 import { encodeRequestRedeem } from "@vetro/gateway/actions";
@@ -13,6 +14,7 @@ import { estimateApprovalGasUnits } from "./estimateApprovalGasUnits";
  * in the vault, so an ERC-20 approval may be needed before the operation.
  * Returns the total gas units for the whole flow (1 or 2 transactions:
  * optional approval + requestRedeem).
+ * Throws if the amount exceeds the user's token balance.
  */
 export const fetchRequestRedeemGasUnits = async function ({
   amount,
@@ -29,7 +31,20 @@ export const fetchRequestRedeemGasUnits = async function ({
   queryClient: QueryClient;
   token: Token;
 }) {
-  const gatewayAddress = getGatewayAddress(client.chain!.id);
+  const chainId = client.chain!.id;
+  const gatewayAddress = getGatewayAddress(chainId);
+
+  const balance = await queryClient.ensureQueryData(
+    tokenBalanceQueryOptions({
+      account: owner,
+      client,
+      token,
+    }),
+  );
+
+  if (amount > balance) {
+    throw new Error("Insufficient token balance");
+  }
 
   const [approvalGas, operationGas] = await Promise.all([
     estimateApprovalGasUnits({

--- a/web/src/fetchers/fetchWithdrawGasUnits.ts
+++ b/web/src/fetchers/fetchWithdrawGasUnits.ts
@@ -1,3 +1,4 @@
+import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
 import type { QueryClient } from "@tanstack/react-query";
 import { getStakingVaultAddress, stakingVaultAbi } from "@vetro/earn";
 import { canInstantWithdrawOptions } from "pages/earn/hooks/useCanInstantWithdraw";
@@ -8,10 +9,12 @@ import {
   encodeFunctionData,
 } from "viem";
 import { estimateGas } from "viem/actions";
+import { convertToAssets } from "viem-erc4626/actions";
 
 /**
  * Estimates gas units for an earn withdraw. Reads the instant withdraw
  * status from the query cache and builds the appropriate calldata.
+ * Throws if the amount exceeds the user's staked balance.
  */
 export const fetchWithdrawGasUnits = async function ({
   account,
@@ -27,13 +30,33 @@ export const fetchWithdrawGasUnits = async function ({
   const chainId = client.chain!.id;
   const stakingVaultAddress = getStakingVaultAddress(chainId);
 
-  const canInstantWithdraw = await queryClient.ensureQueryData(
-    canInstantWithdrawOptions({
-      account,
-      chainId,
-      client,
-    }),
-  );
+  const [canInstantWithdraw, stakedBalance] = await Promise.all([
+    queryClient.ensureQueryData(
+      canInstantWithdrawOptions({
+        account,
+        chainId,
+        client,
+      }),
+    ),
+    queryClient
+      .ensureQueryData(
+        tokenBalanceQueryOptions({
+          account,
+          client,
+          token: { address: stakingVaultAddress, chainId },
+        }),
+      )
+      .then((shares) =>
+        convertToAssets(client, {
+          address: stakingVaultAddress,
+          shares,
+        }),
+      ),
+  ]);
+
+  if (amount > stakedBalance) {
+    throw new Error("Insufficient staked balance");
+  }
 
   const data = canInstantWithdraw
     ? encodeFunctionData({

--- a/web/src/hooks/useTreasuryReserves.ts
+++ b/web/src/hooks/useTreasuryReserves.ts
@@ -1,7 +1,12 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  queryOptions,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query";
 import { getGatewayAddress } from "@vetro/gateway";
 import { fetchTreasuryReserves } from "fetchers/fetchTreasuryReserves";
-import type { Address, Chain } from "viem";
+import type { Address, Chain, Client } from "viem";
 
 import { useEthereumClient } from "./useEthereumClient";
 import { useMainnet } from "./useMainnet";
@@ -14,23 +19,36 @@ export const treasuryReservesQueryKey = ({
   gatewayAddress: Address;
 }) => ["treasury-reserves", chainId, gatewayAddress];
 
+export const treasuryReservesOptions = ({
+  chainId,
+  client,
+  gatewayAddress,
+  queryClient,
+}: {
+  chainId: Chain["id"];
+  client: Client;
+  gatewayAddress: Address;
+  queryClient: QueryClient;
+}) =>
+  queryOptions({
+    enabled: !!client?.chain,
+    queryFn: () =>
+      fetchTreasuryReserves({ client, gatewayAddress, queryClient }),
+    queryKey: treasuryReservesQueryKey({ chainId, gatewayAddress }),
+  });
+
 export const useTreasuryReserves = function () {
   const ethereumChain = useMainnet();
   const client = useEthereumClient();
   const gatewayAddress = getGatewayAddress(ethereumChain.id);
   const queryClient = useQueryClient();
 
-  return useQuery({
-    enabled: !!client?.chain,
-    queryFn: () =>
-      fetchTreasuryReserves({
-        client: client!,
-        gatewayAddress,
-        queryClient,
-      }),
-    queryKey: treasuryReservesQueryKey({
+  return useQuery(
+    treasuryReservesOptions({
       chainId: ethereumChain.id,
+      client: client!,
       gatewayAddress,
+      queryClient,
     }),
-  });
+  );
 };

--- a/web/test/fetchers/fetchDepositGasUnits.test.ts
+++ b/web/test/fetchers/fetchDepositGasUnits.test.ts
@@ -1,4 +1,4 @@
-import type { QueryClient } from "@tanstack/react-query";
+import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import type { Token } from "types";
 import { type Client, zeroAddress } from "viem";
 import { estimateGas } from "viem/actions";
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { estimateApprovalGasUnits } from "../../src/fetchers/estimateApprovalGasUnits";
 import { fetchDepositGasUnits } from "../../src/fetchers/fetchDepositGasUnits";
+import { createTestQueryClient } from "../utils";
 
 vi.mock("../../src/fetchers/estimateApprovalGasUnits", () => ({
   estimateApprovalGasUnits: vi.fn(),
@@ -24,18 +25,30 @@ vi.mock("utils/erc20StateOverride", () => ({
   createErc20AllowanceStateOverride: vi.fn(),
 }));
 
+const chainId = 1;
+
 describe("fetchDepositGasUnits", function () {
-  const mockClient = { chain: { id: 1 } } as unknown as Client;
+  const mockClient = { chain: { id: chainId } } as unknown as Client;
   const mockOwner = zeroAddress;
-  const mockQueryClient = {} as unknown as QueryClient;
-  // @ts-expect-error - Only address is needed for these tests
+  // @ts-expect-error - Only address and chainId are needed for these tests
   const mockToken = {
     address: zeroAddress,
+    chainId,
   } as Token;
+
+  function createPrepopulatedQueryClient(balance = 1000n) {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      tokenBalanceQueryKey({ address: zeroAddress, chainId }, mockOwner),
+      balance,
+    );
+    return queryClient;
+  }
 
   it("returns sum of approval and deposit gas", async function () {
     const approvalGas = 46000n;
     const depositGas = 120000n;
+    const queryClient = createPrepopulatedQueryClient();
 
     vi.mocked(estimateApprovalGasUnits).mockResolvedValue(approvalGas);
     vi.mocked(estimateGas).mockResolvedValue(depositGas);
@@ -45,7 +58,7 @@ describe("fetchDepositGasUnits", function () {
       approveAmount: 100n,
       client: mockClient,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
       token: mockToken,
     });
 
@@ -54,6 +67,7 @@ describe("fetchDepositGasUnits", function () {
 
   it("returns only deposit gas when no approval needed", async function () {
     const depositGas = 120000n;
+    const queryClient = createPrepopulatedQueryClient();
 
     vi.mocked(estimateApprovalGasUnits).mockResolvedValue(0n);
     vi.mocked(estimateGas).mockResolvedValue(depositGas);
@@ -63,10 +77,27 @@ describe("fetchDepositGasUnits", function () {
       approveAmount: 100n,
       client: mockClient,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
       token: mockToken,
     });
 
     expect(result).toBe(depositGas);
+  });
+
+  it("throws when amount exceeds token balance", async function () {
+    const queryClient = createPrepopulatedQueryClient(50n);
+
+    await expect(
+      fetchDepositGasUnits({
+        amount: 100n,
+        approveAmount: 100n,
+        client: mockClient,
+        owner: mockOwner,
+        queryClient,
+        token: mockToken,
+      }),
+    ).rejects.toThrow("Insufficient token balance");
+
+    expect(estimateGas).not.toHaveBeenCalled();
   });
 });

--- a/web/test/fetchers/fetchMintGasUnits.test.ts
+++ b/web/test/fetchers/fetchMintGasUnits.test.ts
@@ -1,4 +1,4 @@
-import type { QueryClient } from "@tanstack/react-query";
+import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import type { Token } from "types";
 import { zeroAddress, type Client } from "viem";
 import { estimateGas } from "viem/actions";
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { estimateApprovalGasUnits } from "../../src/fetchers/estimateApprovalGasUnits";
 import { fetchMintGasUnits } from "../../src/fetchers/fetchMintGasUnits";
+import { createTestQueryClient } from "../utils";
 
 vi.mock("../../src/fetchers/estimateApprovalGasUnits", () => ({
   estimateApprovalGasUnits: vi.fn(),
@@ -27,19 +28,30 @@ vi.mock("utils/erc20StateOverride", () => ({
   createErc20AllowanceStateOverride: vi.fn(),
 }));
 
+const chainId = 1;
+
 describe("fetchMintGasUnits", function () {
   const mockOwner = zeroAddress;
-  const mockClient = { chain: { id: 1 } } as unknown as Client;
-  // @ts-expect-error - Only address is needed for these tests
+  const mockClient = { chain: { id: chainId } } as unknown as Client;
+  // @ts-expect-error - Only address and chainId are needed for these tests
   const mockToken = {
     address: zeroAddress,
+    chainId,
   } as Token;
 
-  const mockQueryClient = {} as unknown as QueryClient;
+  function createPrepopulatedQueryClient(balance = 1000n) {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      tokenBalanceQueryKey({ address: zeroAddress, chainId }, mockOwner),
+      balance,
+    );
+    return queryClient;
+  }
 
   it("returns sum of approval and mint gas", async function () {
     const approvalGas = 46000n;
     const mintGas = 120000n;
+    const queryClient = createPrepopulatedQueryClient();
 
     vi.mocked(estimateApprovalGasUnits).mockResolvedValue(approvalGas);
     vi.mocked(estimateGas).mockResolvedValue(mintGas);
@@ -50,7 +62,7 @@ describe("fetchMintGasUnits", function () {
       client: mockClient,
       minPeggedTokenOut: 90n,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
       token: mockToken,
     });
 
@@ -59,6 +71,7 @@ describe("fetchMintGasUnits", function () {
 
   it("returns only mint gas when no approval needed", async function () {
     const mintGas = 120000n;
+    const queryClient = createPrepopulatedQueryClient();
 
     vi.mocked(estimateApprovalGasUnits).mockResolvedValue(0n);
     vi.mocked(estimateGas).mockResolvedValue(mintGas);
@@ -69,10 +82,28 @@ describe("fetchMintGasUnits", function () {
       client: mockClient,
       minPeggedTokenOut: 90n,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
       token: mockToken,
     });
 
     expect(result).toBe(mintGas);
+  });
+
+  it("throws when amount exceeds token balance", async function () {
+    const queryClient = createPrepopulatedQueryClient(50n);
+
+    await expect(
+      fetchMintGasUnits({
+        amount: 100n,
+        approveAmount: 100n,
+        client: mockClient,
+        minPeggedTokenOut: 90n,
+        owner: mockOwner,
+        queryClient,
+        token: mockToken,
+      }),
+    ).rejects.toThrow("Insufficient token balance");
+
+    expect(estimateGas).not.toHaveBeenCalled();
   });
 });

--- a/web/test/fetchers/fetchRedeemGasUnits.test.ts
+++ b/web/test/fetchers/fetchRedeemGasUnits.test.ts
@@ -1,4 +1,9 @@
-import type { QueryClient } from "@tanstack/react-query";
+import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
+import { redeemDelayOptions } from "hooks/useRedeemDelay";
+import {
+  treasuryReservesOptions,
+  treasuryReservesQueryKey,
+} from "hooks/useTreasuryReserves";
 import type { Token } from "types";
 import { zeroAddress, type Client } from "viem";
 import { estimateGas } from "viem/actions";
@@ -6,6 +11,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { estimateApprovalGasUnits } from "../../src/fetchers/estimateApprovalGasUnits";
 import { fetchRedeemGasUnits } from "../../src/fetchers/fetchRedeemGasUnits";
+import { createTestQueryClient } from "../utils";
 
 vi.mock("../../src/fetchers/estimateApprovalGasUnits", () => ({
   estimateApprovalGasUnits: vi.fn(),
@@ -22,7 +28,21 @@ vi.mock("@vetro/gateway/actions", () => ({
 vi.mock("hooks/useRedeemDelay", () => ({
   redeemDelayOptions: vi.fn().mockReturnValue({
     queryFn: () => 0n,
+    queryKey: ["redeem-delay"],
   }),
+}));
+
+vi.mock("hooks/useTreasuryReserves", () => ({
+  treasuryReservesOptions: vi.fn(),
+  treasuryReservesQueryKey: vi.fn(
+    ({
+      chainId,
+      gatewayAddress,
+    }: {
+      chainId: number;
+      gatewayAddress: string;
+    }) => ["treasury-reserves", chainId, gatewayAddress],
+  ),
 }));
 
 vi.mock("viem/actions", () => ({
@@ -33,24 +53,49 @@ vi.mock("utils/erc20StateOverride", () => ({
   createErc20AllowanceStateOverride: vi.fn(),
 }));
 
+const chainId = 1;
+
 describe("fetchRedeemGasUnits", function () {
   const mockOwner = zeroAddress;
-  const mockClient = { chain: { id: 1 } } as unknown as Client;
+  const mockClient = { chain: { id: chainId } } as unknown as Client;
   // @ts-expect-error - Only address is needed for these tests
   const mockToken = {
     address: zeroAddress,
   } as Token;
   const mockTokenOut = zeroAddress;
+  const mockReservesQueryKey = treasuryReservesQueryKey({
+    chainId,
+    gatewayAddress: zeroAddress,
+  });
 
-  const mockQueryClient = {
-    ensureQueryData: vi.fn(),
-  } as unknown as QueryClient;
+  function createPrepopulatedQueryClient({
+    balance = 1000n,
+    reserveAmount = 1000n,
+  } = {}) {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      tokenBalanceQueryKey({ address: zeroAddress, chainId }, mockOwner),
+      balance,
+    );
+    queryClient.setQueryData(mockReservesQueryKey, [
+      {
+        amount: reserveAmount,
+        // @ts-expect-error Only address is needed for these tests
+        token: { address: mockTokenOut } as Token,
+      },
+    ]);
+    vi.mocked(treasuryReservesOptions).mockReturnValue({
+      queryFn: vi.fn() as never,
+      queryKey: mockReservesQueryKey as never,
+    });
+    return queryClient;
+  }
 
   it("returns approval + operation gas for whitelisted users", async function () {
     const approvalGas = 46000n;
     const operationGas = 120000n;
+    const queryClient = createPrepopulatedQueryClient();
 
-    vi.mocked(mockQueryClient.ensureQueryData).mockResolvedValue(0n);
     vi.mocked(estimateApprovalGasUnits).mockResolvedValue(approvalGas);
     vi.mocked(estimateGas).mockResolvedValue(operationGas);
 
@@ -60,7 +105,7 @@ describe("fetchRedeemGasUnits", function () {
       client: mockClient,
       minAmountOut: 90n,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
       token: mockToken,
       tokenOut: mockTokenOut,
     });
@@ -70,8 +115,12 @@ describe("fetchRedeemGasUnits", function () {
 
   it("returns only operation gas for two-step redeemers", async function () {
     const operationGas = 120000n;
+    const queryClient = createPrepopulatedQueryClient();
 
-    vi.mocked(mockQueryClient.ensureQueryData).mockResolvedValue(86400n);
+    vi.mocked(redeemDelayOptions).mockReturnValue({
+      queryFn: () => 86400n,
+      queryKey: ["redeem-delay"] as never,
+    });
     vi.mocked(estimateGas).mockResolvedValue(operationGas);
 
     const result = await fetchRedeemGasUnits({
@@ -80,7 +129,7 @@ describe("fetchRedeemGasUnits", function () {
       client: mockClient,
       minAmountOut: 90n,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
       token: mockToken,
       tokenOut: mockTokenOut,
     });
@@ -90,8 +139,12 @@ describe("fetchRedeemGasUnits", function () {
 
   it("returns only operation gas when whitelisted but no approval needed", async function () {
     const operationGas = 120000n;
+    const queryClient = createPrepopulatedQueryClient();
 
-    vi.mocked(mockQueryClient.ensureQueryData).mockResolvedValue(0n);
+    vi.mocked(redeemDelayOptions).mockReturnValue({
+      queryFn: () => 0n,
+      queryKey: ["redeem-delay"] as never,
+    });
     vi.mocked(estimateApprovalGasUnits).mockResolvedValue(0n);
     vi.mocked(estimateGas).mockResolvedValue(operationGas);
 
@@ -101,11 +154,61 @@ describe("fetchRedeemGasUnits", function () {
       client: mockClient,
       minAmountOut: 90n,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
       token: mockToken,
       tokenOut: mockTokenOut,
     });
 
     expect(result).toBe(operationGas);
+  });
+
+  it("throws when amount exceeds token balance for instant redeem", async function () {
+    const queryClient = createPrepopulatedQueryClient({ balance: 50n });
+
+    vi.mocked(redeemDelayOptions).mockReturnValue({
+      queryFn: () => 0n,
+      queryKey: ["redeem-delay"] as never,
+    });
+
+    await expect(
+      fetchRedeemGasUnits({
+        amount: 100n,
+        approveAmount: 100n,
+        client: mockClient,
+        minAmountOut: 90n,
+        owner: mockOwner,
+        queryClient,
+        token: mockToken,
+        tokenOut: mockTokenOut,
+      }),
+    ).rejects.toThrow("Insufficient token balance");
+
+    expect(estimateGas).not.toHaveBeenCalled();
+  });
+
+  it("throws when treasury reserves are insufficient for two-step redeem", async function () {
+    const queryClient = createPrepopulatedQueryClient({
+      reserveAmount: 50n,
+    });
+
+    vi.mocked(redeemDelayOptions).mockReturnValue({
+      queryFn: () => 86400n,
+      queryKey: ["redeem-delay"] as never,
+    });
+
+    await expect(
+      fetchRedeemGasUnits({
+        amount: 100n,
+        approveAmount: 100n,
+        client: mockClient,
+        minAmountOut: 90n,
+        owner: mockOwner,
+        queryClient,
+        token: mockToken,
+        tokenOut: mockTokenOut,
+      }),
+    ).rejects.toThrow("Insufficient treasury reserves");
+
+    expect(estimateGas).not.toHaveBeenCalled();
   });
 });

--- a/web/test/fetchers/fetchRequestRedeemGasUnits.test.ts
+++ b/web/test/fetchers/fetchRequestRedeemGasUnits.test.ts
@@ -1,4 +1,4 @@
-import type { QueryClient } from "@tanstack/react-query";
+import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import type { Token } from "types";
 import { zeroAddress, type Client } from "viem";
 import { estimateGas } from "viem/actions";
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { estimateApprovalGasUnits } from "../../src/fetchers/estimateApprovalGasUnits";
 import { fetchRequestRedeemGasUnits } from "../../src/fetchers/fetchRequestRedeemGasUnits";
+import { createTestQueryClient } from "../utils";
 
 vi.mock("../../src/fetchers/estimateApprovalGasUnits", () => ({
   estimateApprovalGasUnits: vi.fn(),
@@ -27,19 +28,30 @@ vi.mock("utils/erc20StateOverride", () => ({
   createErc20AllowanceStateOverride: vi.fn(),
 }));
 
+const chainId = 1;
+
 describe("fetchRequestRedeemGasUnits", function () {
   const mockOwner = zeroAddress;
-  const mockClient = { chain: { id: 1 } } as unknown as Client;
-  // @ts-expect-error We just need the token address
+  const mockClient = { chain: { id: chainId } } as unknown as Client;
+  // @ts-expect-error We just need the token address and chainId
   const mockToken = {
     address: zeroAddress,
+    chainId,
   } as Token;
 
-  const mockQueryClient = {} as unknown as QueryClient;
+  function createPrepopulatedQueryClient(balance = 1000n) {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      tokenBalanceQueryKey({ address: zeroAddress, chainId }, mockOwner),
+      balance,
+    );
+    return queryClient;
+  }
 
   it("returns sum of approval and operation gas", async function () {
     const approvalGas = 46000n;
     const operationGas = 120000n;
+    const queryClient = createPrepopulatedQueryClient();
 
     vi.mocked(estimateApprovalGasUnits).mockResolvedValue(approvalGas);
     vi.mocked(estimateGas).mockResolvedValue(operationGas);
@@ -49,7 +61,7 @@ describe("fetchRequestRedeemGasUnits", function () {
       approveAmount: 100n,
       client: mockClient,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
       token: mockToken,
     });
 
@@ -58,6 +70,7 @@ describe("fetchRequestRedeemGasUnits", function () {
 
   it("returns only operation gas when no approval needed", async function () {
     const operationGas = 120000n;
+    const queryClient = createPrepopulatedQueryClient();
 
     vi.mocked(estimateApprovalGasUnits).mockResolvedValue(0n);
     vi.mocked(estimateGas).mockResolvedValue(operationGas);
@@ -67,10 +80,27 @@ describe("fetchRequestRedeemGasUnits", function () {
       approveAmount: 100n,
       client: mockClient,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
       token: mockToken,
     });
 
     expect(result).toBe(operationGas);
+  });
+
+  it("throws when amount exceeds token balance", async function () {
+    const queryClient = createPrepopulatedQueryClient(50n);
+
+    await expect(
+      fetchRequestRedeemGasUnits({
+        amount: 100n,
+        approveAmount: 100n,
+        client: mockClient,
+        owner: mockOwner,
+        queryClient,
+        token: mockToken,
+      }),
+    ).rejects.toThrow("Insufficient token balance");
+
+    expect(estimateGas).not.toHaveBeenCalled();
   });
 });

--- a/web/test/fetchers/fetchWithdrawGasUnits.test.ts
+++ b/web/test/fetchers/fetchWithdrawGasUnits.test.ts
@@ -1,9 +1,11 @@
-import type { QueryClient } from "@tanstack/react-query";
+import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import { type Client, zeroAddress } from "viem";
 import { estimateGas } from "viem/actions";
+import { convertToAssets } from "viem-erc4626/actions";
 import { describe, expect, it, vi } from "vitest";
 
 import { fetchWithdrawGasUnits } from "../../src/fetchers/fetchWithdrawGasUnits";
+import { createTestQueryClient } from "../utils";
 
 vi.mock("@vetro/earn", async (importOriginal) => ({
   ...(await importOriginal()),
@@ -12,6 +14,7 @@ vi.mock("@vetro/earn", async (importOriginal) => ({
 
 vi.mock("pages/earn/hooks/useCanInstantWithdraw", () => ({
   canInstantWithdrawOptions: vi.fn().mockReturnValue({
+    queryFn: () => true,
     queryKey: ["can-instant-withdraw"],
   }),
 }));
@@ -20,16 +23,32 @@ vi.mock("viem/actions", () => ({
   estimateGas: vi.fn(),
 }));
 
+vi.mock("viem-erc4626/actions", () => ({
+  convertToAssets: vi.fn(),
+}));
+
+const chainId = 1;
+
 describe("fetchWithdrawGasUnits", function () {
   const mockAccount = zeroAddress;
-  const mockClient = { chain: { id: 1 } } as unknown as Client;
+  const mockClient = { chain: { id: chainId } } as unknown as Client;
+
+  function createPrepopulatedQueryClient({
+    shares = 1000n,
+    stakedBalance = 1000n,
+  } = {}) {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      tokenBalanceQueryKey({ address: zeroAddress, chainId }, mockAccount),
+      shares,
+    );
+    vi.mocked(convertToAssets).mockResolvedValue(stakedBalance);
+    return queryClient;
+  }
 
   it("returns gas estimate for instant withdraw", async function () {
     const withdrawGas = 95000n;
-
-    const mockQueryClient = {
-      ensureQueryData: vi.fn().mockResolvedValue(true),
-    } as unknown as QueryClient;
+    const queryClient = createPrepopulatedQueryClient();
 
     vi.mocked(estimateGas).mockResolvedValue(withdrawGas);
 
@@ -37,7 +56,7 @@ describe("fetchWithdrawGasUnits", function () {
       account: mockAccount,
       amount: 100n,
       client: mockClient,
-      queryClient: mockQueryClient,
+      queryClient,
     });
 
     expect(result).toBe(withdrawGas);
@@ -45,10 +64,14 @@ describe("fetchWithdrawGasUnits", function () {
 
   it("returns gas estimate for request withdraw", async function () {
     const requestGas = 80000n;
+    const queryClient = createPrepopulatedQueryClient();
 
-    const mockQueryClient = {
-      ensureQueryData: vi.fn().mockResolvedValue(false),
-    } as unknown as QueryClient;
+    const { canInstantWithdrawOptions } =
+      await import("pages/earn/hooks/useCanInstantWithdraw");
+    vi.mocked(canInstantWithdrawOptions).mockReturnValue({
+      queryFn: () => false,
+      queryKey: ["can-instant-withdraw"] as never,
+    });
 
     vi.mocked(estimateGas).mockResolvedValue(requestGas);
 
@@ -56,9 +79,27 @@ describe("fetchWithdrawGasUnits", function () {
       account: mockAccount,
       amount: 100n,
       client: mockClient,
-      queryClient: mockQueryClient,
+      queryClient,
     });
 
     expect(result).toBe(requestGas);
+  });
+
+  it("throws when amount exceeds staked balance", async function () {
+    const queryClient = createPrepopulatedQueryClient({
+      shares: 50n,
+      stakedBalance: 50n,
+    });
+
+    await expect(
+      fetchWithdrawGasUnits({
+        account: mockAccount,
+        amount: 100n,
+        client: mockClient,
+        queryClient,
+      }),
+    ).rejects.toThrow("Insufficient staked balance");
+
+    expect(estimateGas).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Description

Add balance validation checks to gas estimation fetchers so they fail early with clear error messages instead of letting the RPC call fail with an obscure revert.

- **Deposit, Mint, RequestRedeem**: Check the user's token balance before estimating gas. Throw `"Insufficient token balance"` if the amount exceeds the balance.
- **Withdraw**: Check the user's staked balance before estimating gas. Throw `"Insufficient staked balance"` if the amount exceeds it.
- **Redeem**: For instant redeems (`redeemDelay === 0`), check the user's token balance. For two-step redeems (`redeemDelay > 0`), check the treasury reserves for the output token.
- Extract `treasuryReservesOptions` from `useTreasuryReserves` hook so it can be reused with `queryClient.ensureQueryData` outside React components.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Closes #255 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.