### PR TITLE
Add APR chart error handling

### DIFF
--- a/web/src/components/borrow/historicApr.tsx
+++ b/web/src/components/borrow/historicApr.tsx
@@ -1,3 +1,4 @@
+import { Button } from "components/base/button";
 import { SegmentedControl } from "components/base/segmentedControl";
 import {
   type AprHistoryEntry,
@@ -44,12 +45,79 @@ const AreaGradient = () => (
 
 const periods = aprHistoryPeriods;
 
+const periodDurations: Record<AprHistoryPeriod, number> = {
+  "1m": 30 * 24 * 60 * 60 * 1000,
+  "1w": 7 * 24 * 60 * 60 * 1000,
+  "1y": 365 * 24 * 60 * 60 * 1000,
+  "3m": 90 * 24 * 60 * 60 * 1000,
+};
+
+const chartPadding = { bottom: 30, left: 40, right: 16, top: 10 };
+
+const xAxisStyle = {
+  axis: { stroke: "transparent" },
+  tickLabels: { fill: "#6B7280", fontSize: 11 },
+};
+
+const yAxisStyle = {
+  ...xAxisStyle,
+  grid: { stroke: "#E5E7EB", strokeDasharray: "4,4" },
+};
+
+const getPlaceholderXTicks = function (period: AprHistoryPeriod) {
+  const now = Date.now();
+  const duration = periodDurations[period];
+  return Array.from(
+    { length: 4 },
+    (_, i) => now - duration + (i * duration) / 3,
+  );
+};
+
+const EmptyChart = ({
+  locale,
+  period,
+}: {
+  locale: string;
+  period: AprHistoryPeriod;
+}) => (
+  <VictoryChart height={200} padding={chartPadding}>
+    <VictoryAxis
+      style={xAxisStyle}
+      tickFormat={(tick: number) => formatShortDate(tick / 1000, locale)}
+      tickValues={getPlaceholderXTicks(period)}
+    />
+    <VictoryAxis
+      dependentAxis
+      style={yAxisStyle}
+      tickFormat={formatPercentage}
+      tickValues={[0, 2, 4, 6]}
+    />
+  </VictoryChart>
+);
+
 const periodLabelKeys = {
   "1m": "pages.borrow.period-1-month",
   "1w": "pages.borrow.period-1-week",
   "1y": "pages.borrow.period-1-year",
   "3m": "pages.borrow.period-3-month",
 } as const;
+
+const ArrowPathIcon = () => (
+  <svg
+    fill="none"
+    height="12"
+    viewBox="0 0 14 12"
+    width="14"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      clipRule="evenodd"
+      d="M7 1.5C6.22882 1.5 5.46288 1.52209 4.70278 1.56567C4.14144 1.59785 3.69253 2.03441 3.64471 2.59448C3.63865 2.66548 3.63278 2.73653 3.62709 2.80763C3.59408 3.22053 3.2326 3.52848 2.8197 3.49547C2.40681 3.46246 2.09885 3.10098 2.13186 2.68808C2.13776 2.6143 2.14386 2.54056 2.15015 2.46689C2.26145 1.16319 3.31079 0.143005 4.61693 0.068126C5.4056 0.0229129 6.20017 0 7 0C7.79983 0 8.59439 0.0229102 9.38307 0.0681211C10.6892 0.142996 11.7385 1.16318 11.8498 2.46687C11.9064 3.12917 11.9472 3.79592 11.9719 4.46672L12.7197 3.7189C13.0126 3.42601 13.4874 3.42601 13.7803 3.7189C14.0732 4.01179 14.0732 4.48667 13.7803 4.77956L11.7796 6.78032C11.4867 7.07322 11.0118 7.07322 10.7189 6.78032L8.71967 4.78109C8.42678 4.48819 8.42678 4.01332 8.71967 3.72043C9.01256 3.42753 9.48744 3.42753 9.78033 3.72043L10.4685 4.40864C10.4444 3.80023 10.4066 3.19541 10.3553 2.59447C10.3075 2.03439 9.85856 1.59784 9.29722 1.56566C8.53712 1.52209 7.77118 1.5 7 1.5ZM2.22043 5.2192C2.51333 4.9263 2.9882 4.9263 3.28109 5.2192L5.28186 7.21996C5.57475 7.51285 5.57475 7.98773 5.28186 8.28062C4.98896 8.57351 4.51409 8.57351 4.2212 8.28062L3.53144 7.59086C3.55554 8.19944 3.5934 8.80442 3.64472 9.40552C3.69253 9.9656 4.14144 10.4022 4.70278 10.4343C5.46288 10.4779 6.22882 10.5 7 10.5C7.77118 10.5 8.53712 10.4779 9.29722 10.4343C9.85856 10.4022 10.3075 9.96559 10.3553 9.40552C10.3615 9.3329 10.3675 9.26023 10.3733 9.18749C10.4063 8.77459 10.7677 8.46659 11.1806 8.49956C11.5935 8.53252 11.9015 8.89396 11.8685 9.30686C11.8625 9.38233 11.8563 9.45775 11.8499 9.53311C11.7386 10.8368 10.6892 11.857 9.38307 11.9319C8.5944 11.9771 7.79983 12 7 12C6.20017 12 5.4056 11.9771 4.61693 11.9319C3.31079 11.857 2.26145 10.8368 2.15015 9.53312C2.0936 8.87067 2.0528 8.20378 2.02813 7.53282L1.28033 8.28062C0.987437 8.57351 0.512563 8.57351 0.21967 8.28062C-0.0732233 7.98773 -0.0732233 7.51285 0.21967 7.21996L2.22043 5.2192Z"
+      fill="#416BFF"
+      fillRule="evenodd"
+    />
+  </svg>
+);
 
 const ClockRevertIcon = () => (
   <svg
@@ -107,8 +175,7 @@ function ChartTooltipLabel({
 export function HistoricApr({ marketId }: Props) {
   const { i18n, t } = useTranslation();
   const [period, setPeriod] = useState<AprHistoryPeriod>("1w");
-  // TODO add error state https://github.com/vetro-protocol/vetro-monorepo/issues/241
-  const { data: chartData } = useAprHistory(marketId, period);
+  const { data: chartData, isError, refetch } = useAprHistory(marketId, period);
 
   return (
     <div className="px-3 py-6 xl:px-14">
@@ -124,6 +191,8 @@ export function HistoricApr({ marketId }: Props) {
             t("pages.borrow.avg", {
               percentage: formatPercentage(getAverage(chartData)),
             })
+          ) : isError ? (
+            "-"
           ) : (
             <Skeleton width={80} />
           )}
@@ -139,8 +208,30 @@ export function HistoricApr({ marketId }: Props) {
           variant="pill"
         />
       </div>
-      <div className="mt-10">
-        {chartData !== undefined ? (
+      <div className="relative mt-10">
+        {isError && chartData === undefined ? (
+          <>
+            <div className="opacity-32">
+              <EmptyChart locale={i18n.language} period={period} />
+            </div>
+            <div
+              className="absolute flex items-center justify-center"
+              style={{
+                bottom: chartPadding.bottom,
+                left: chartPadding.left,
+                right: chartPadding.right,
+                top: chartPadding.top,
+              }}
+            >
+              <Button onClick={() => refetch()} size="xSmall" variant="primary">
+                <span className="opacity-72">
+                  <ArrowPathIcon />
+                </span>
+                {t("pages.borrow.reload-chart")}
+              </Button>
+            </div>
+          </>
+        ) : chartData !== undefined ? (
           <VictoryChart
             containerComponent={
               <VictoryVoronoiContainer
@@ -167,16 +258,10 @@ export function HistoricApr({ marketId }: Props) {
               />
             }
             height={200}
-            padding={{ bottom: 30, left: 40, right: 16, top: 10 }}
+            padding={chartPadding}
           >
             <VictoryAxis
-              style={{
-                axis: { stroke: "transparent" },
-                tickLabels: {
-                  fill: "#6B7280",
-                  fontSize: 11,
-                },
-              }}
+              style={xAxisStyle}
               tickCount={4}
               tickFormat={(tick: number) =>
                 formatShortDate(tick / 1000, i18n.language)
@@ -184,17 +269,7 @@ export function HistoricApr({ marketId }: Props) {
             />
             <VictoryAxis
               dependentAxis
-              style={{
-                axis: { stroke: "transparent" },
-                grid: {
-                  stroke: "#E5E7EB",
-                  strokeDasharray: "4,4",
-                },
-                tickLabels: {
-                  fill: "#6B7280",
-                  fontSize: 11,
-                },
-              }}
+              style={yAxisStyle}
               tickFormat={formatPercentage}
             />
             <AreaGradient />
@@ -221,7 +296,14 @@ export function HistoricApr({ marketId }: Props) {
             />
           </VictoryChart>
         ) : (
-          <Skeleton height={200} />
+          <>
+            <div className="invisible">
+              <EmptyChart locale={i18n.language} period={period} />
+            </div>
+            <div className="absolute inset-0">
+              <Skeleton height="100%" />
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -99,6 +99,7 @@
         "supply-collateral-title": "Supply collateral",
         "title": "Borrow in progress"
       },
+      "reload-chart": "Reload chart",
       "repay-loan": "Repay loan",
       "repay-loan-progress": {
         "approve-description": "Approve the loan token spending",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -99,6 +99,7 @@
         "supply-collateral-title": "Depositar garantía",
         "title": "Préstamo en progreso"
       },
+      "reload-chart": "Recargar gráfico",
       "repay-loan": "Pagar préstamo",
       "repay-loan-progress": {
         "approve-description": "Apruebe el gasto del token de préstamo",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds an "Reload chart" empty state for the APR borrow chart

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

desktop

https://github.com/user-attachments/assets/827c4faf-1bcd-4ae7-a4d8-04290464f396

mobile

https://github.com/user-attachments/assets/24c0eef3-53c6-44ba-a5eb-fd510a4c8d6d

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #241

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
