### PR TITLE
Add Oracle tooltip for Borrow drawers

### DIFF
--- a/web/src/components/borrow/borrowForm.tsx
+++ b/web/src/components/borrow/borrowForm.tsx
@@ -8,6 +8,7 @@ import { RenderCryptoValue } from "components/base/cryptoValue";
 import { RenderFiatValue } from "components/base/fiatValue";
 import { MaxButton } from "components/base/maxButton";
 import { Toast } from "components/base/toast";
+import { OracleLabel } from "components/borrow/oracleLabel";
 import { NetworkFees } from "components/networkFees";
 import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
 import { TokenInput } from "components/tokenInput";
@@ -360,7 +361,10 @@ export function BorrowForm({
             openConnectModal={openConnectModal}
           />
         </div>
-        <NetworkFees networkFee={networkFee} />
+        <NetworkFees
+          label={<OracleLabel oracle={market.oracle} />}
+          networkFee={networkFee}
+        />
         <div className="border-t border-gray-200 px-4 py-1">
           <BorrowingReview
             borrowApy={market.borrowApy}

--- a/web/src/components/borrow/borrowMoreForm.tsx
+++ b/web/src/components/borrow/borrowMoreForm.tsx
@@ -9,6 +9,7 @@ import {
   VerticalStepper,
   stepStatus,
 } from "components/base/verticalStepper";
+import { OracleLabel } from "components/borrow/oracleLabel";
 import { hasSufficientGas } from "components/borrow/utils";
 import { NetworkFees } from "components/networkFees";
 import { TokenInput } from "components/tokenInput";
@@ -370,7 +371,10 @@ export function BorrowMoreForm({ market, onClose }: Props) {
             sufficientGas={sufficientGas}
           />
         </div>
-        <NetworkFees networkFee={networkFee} />
+        <NetworkFees
+          label={<OracleLabel oracle={market.oracle} />}
+          networkFee={networkFee}
+        />
         <div className="border-t border-gray-200 px-6 py-2">
           <PositionReview
             borrowApy={market.borrowApy}

--- a/web/src/components/borrow/oracleLabel.tsx
+++ b/web/src/components/borrow/oracleLabel.tsx
@@ -11,9 +11,7 @@ export function OracleLabel({ oracle }: Props) {
 
   return (
     <span className="flex items-center gap-x-1">
-      <span className="text-b-medium text-gray-500">
-        {t("pages.borrow.oracle")}
-      </span>
+      <span className="text-b-medium text-gray-500">{t("common.oracle")}</span>
       <OracleTooltip oracle={oracle} useParentContainer />
     </span>
   );

--- a/web/src/components/borrow/oracleLabel.tsx
+++ b/web/src/components/borrow/oracleLabel.tsx
@@ -1,0 +1,20 @@
+import { OracleTooltip } from "components/oracleTooltip";
+import { useTranslation } from "react-i18next";
+import type { Address } from "viem";
+
+type Props = {
+  oracle: Address;
+};
+
+export function OracleLabel({ oracle }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <span className="flex items-center gap-x-1">
+      <span className="text-b-medium text-gray-500">
+        {t("pages.borrow.oracle")}
+      </span>
+      <OracleTooltip oracle={oracle} useParentContainer />
+    </span>
+  );
+}

--- a/web/src/components/borrow/repayLoanForm.tsx
+++ b/web/src/components/borrow/repayLoanForm.tsx
@@ -11,6 +11,7 @@ import {
   VerticalStepper,
   stepStatus,
 } from "components/base/verticalStepper";
+import { OracleLabel } from "components/borrow/oracleLabel";
 import { hasSufficientGas } from "components/borrow/utils";
 import { NetworkFees } from "components/networkFees";
 import { TokenInput } from "components/tokenInput";
@@ -396,7 +397,10 @@ export function RepayLoanForm({ market, onClose }: Props) {
             sufficientGas={sufficientGas}
           />
         </div>
-        <NetworkFees networkFee={networkFee} />
+        <NetworkFees
+          label={<OracleLabel oracle={market.oracle} />}
+          networkFee={networkFee}
+        />
         <div className="border-t border-gray-200 px-6 py-2">
           <PositionReview
             borrowApy={market.borrowApy}

--- a/web/src/components/borrow/supplyCollateralForm.tsx
+++ b/web/src/components/borrow/supplyCollateralForm.tsx
@@ -11,6 +11,7 @@ import {
   VerticalStepper,
   stepStatus,
 } from "components/base/verticalStepper";
+import { OracleLabel } from "components/borrow/oracleLabel";
 import { hasSufficientGas } from "components/borrow/utils";
 import { NetworkFees } from "components/networkFees";
 import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
@@ -402,7 +403,10 @@ export function SupplyCollateralForm({ market, onClose }: Props) {
             sufficientGas={sufficientGas}
           />
         </div>
-        <NetworkFees networkFee={networkFee} />
+        <NetworkFees
+          label={<OracleLabel oracle={market.oracle} />}
+          networkFee={networkFee}
+        />
         <div className="border-t border-gray-200 px-6 py-2">
           <PositionReview
             borrowApy={market.borrowApy}

--- a/web/src/components/borrow/withdrawCollateralForm.tsx
+++ b/web/src/components/borrow/withdrawCollateralForm.tsx
@@ -9,6 +9,7 @@ import {
   VerticalStepper,
   stepStatus,
 } from "components/base/verticalStepper";
+import { OracleLabel } from "components/borrow/oracleLabel";
 import { hasSufficientGas } from "components/borrow/utils";
 import { NetworkFees } from "components/networkFees";
 import { TokenInput } from "components/tokenInput";
@@ -334,7 +335,10 @@ export function WithdrawCollateralForm({ market, onClose }: Props) {
             sufficientGas={sufficientGas}
           />
         </div>
-        <NetworkFees networkFee={networkFee} />
+        <NetworkFees
+          label={<OracleLabel oracle={market.oracle} />}
+          networkFee={networkFee}
+        />
         <div className="border-t border-gray-200 px-6 py-2">
           <PositionReview
             borrowApy={market.borrowApy}

--- a/web/src/components/oracleTooltip.tsx
+++ b/web/src/components/oracleTooltip.tsx
@@ -72,7 +72,7 @@ export function OracleTooltip({
 
   const variantConfig = {
     chainlink: { label: "Chainlink", logo: <ChainlinkLogo /> },
-    oracle: { label: t("pages.borrow.oracle"), logo: <OracleLogo /> },
+    oracle: { label: t("common.oracle"), logo: <OracleLogo /> },
   };
 
   const { label, logo } = variantConfig[variant];

--- a/web/src/components/oracleTooltip.tsx
+++ b/web/src/components/oracleTooltip.tsx
@@ -2,6 +2,7 @@ import { ExternalLink } from "components/base/externalLink";
 import { InfoIcon } from "components/icons/infoIcon";
 import { Tooltip } from "components/tooltip";
 import { useMainnet } from "hooks/useMainnet";
+import { useTranslation } from "react-i18next";
 import { formatEvmAddress } from "utils/format";
 import type { Address } from "viem";
 
@@ -52,15 +53,12 @@ const OracleLogo = () => (
   </svg>
 );
 
-const variantConfig = {
-  chainlink: { label: "Chainlink", logo: <ChainlinkLogo /> },
-  oracle: { label: "Oracle", logo: <OracleLogo /> },
-} as const;
+type Variant = "chainlink" | "oracle";
 
 type Props = {
   oracle: Address;
   useParentContainer?: boolean;
-  variant?: keyof typeof variantConfig;
+  variant?: Variant;
 };
 
 export function OracleTooltip({
@@ -69,7 +67,14 @@ export function OracleTooltip({
   variant = "chainlink",
 }: Props) {
   const chain = useMainnet();
+  const { t } = useTranslation();
   const explorerBaseUrl = chain.blockExplorers!.default.url;
+
+  const variantConfig = {
+    chainlink: { label: "Chainlink", logo: <ChainlinkLogo /> },
+    oracle: { label: t("pages.borrow.oracle"), logo: <OracleLogo /> },
+  };
+
   const { label, logo } = variantConfig[variant];
 
   return (

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -79,6 +79,7 @@
       "max-lltv": "Max {{value}}",
       "no-positions-description": "Deposit collateral to borrow {{symbol}} and put your assets to work.",
       "no-positions-title": "No active borrow position yet",
+      "oracle": "Oracle",
       "per-day": "/ day",
       "period-1-month": "1 month",
       "period-1-week": "1 week",

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -2,7 +2,8 @@
   "common": {
     "approve-10x": "Approve 10x",
     "approve-10x-tooltip": "Approves up to 10× your transaction amount, reducing future approval steps. You can revoke it anytime.",
-    "network-fee": "Network Fee"
+    "network-fee": "Network Fee",
+    "oracle": "Oracle"
   },
   "language": {
     "switch-to": "Switch to Spanish"
@@ -79,7 +80,6 @@
       "max-lltv": "Max {{value}}",
       "no-positions-description": "Deposit collateral to borrow {{symbol}} and put your assets to work.",
       "no-positions-title": "No active borrow position yet",
-      "oracle": "Oracle",
       "per-day": "/ day",
       "period-1-month": "1 month",
       "period-1-week": "1 week",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -79,6 +79,7 @@
       "max-lltv": "Max {{value}}",
       "no-positions-description": "Deposite garantía para pedir prestado {{symbol}} y poner sus activos a trabajar.",
       "no-positions-title": "Aún no hay posiciones de préstamos activos",
+      "oracle": "Oráculo",
       "per-day": "/ día",
       "period-1-month": "1 mes",
       "period-1-week": "1 semana",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -2,7 +2,8 @@
   "common": {
     "approve-10x": "Aprobar 10x",
     "approve-10x-tooltip": "Apruebe hasta 10× el monto de su transacción, reduciendo futuros pasos de aprobación. Puede revocarlo en cualquier momento.",
-    "network-fee": "Tarifa de Red"
+    "network-fee": "Tarifa de Red",
+    "oracle": "Oráculo"
   },
   "language": {
     "switch-to": "Cambiar a Inglés"
@@ -79,7 +80,6 @@
       "max-lltv": "Max {{value}}",
       "no-positions-description": "Deposite garantía para pedir prestado {{symbol}} y poner sus activos a trabajar.",
       "no-positions-title": "Aún no hay posiciones de préstamos activos",
-      "oracle": "Oráculo",
       "per-day": "/ día",
       "period-1-month": "1 mes",
       "period-1-week": "1 semana",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds the Oracle link in the Borrow drawers for each action. Note that the proper alignment will be done as part of #165

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Market Details page

https://github.com/user-attachments/assets/e8eb28e1-621f-4e63-9573-fd83c6c70028

Supply More collateral

<img width="453" height="428" alt="image" src="https://github.com/user-attachments/assets/d8e87722-9727-4d3a-b8a3-53b2b33dfac8" />

Withdraw Collateral

<img width="462" height="452" alt="image" src="https://github.com/user-attachments/assets/d948161e-e596-4d6f-89e4-a7e71dfc6b38" />

Borrow more

<img width="226" height="211" alt="image" src="https://github.com/user-attachments/assets/f37ba133-b12c-4034-ba03-ddb9947b8853" />

Repay Loan

<img width="452" height="451" alt="image" src="https://github.com/user-attachments/assets/4a1149bb-9b54-45c6-85fd-0342331d2fb6" />



### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #157

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
