### PR TITLE
Enable pnpm's minimum-release-age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+minimum-release-age=10080
 save-exact=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-minimum-release-age=10080
 save-exact=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+minimumReleaseAge: 10080 # 7 days in minutes
+minimumReleaseAgeExclude:
+  - "@hemilabs/*"
+  - "@vetro-protocol/*"
+
 packages:
   - "api"
   - "packages/*"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ minimumReleaseAge: 10080 # 7 days in minutes
 minimumReleaseAgeExclude:
   - "@hemilabs/*"
   - "@vetro-protocol/*"
+  - "viem-erc20"
+  - "viem-erc4626"
 
 packages:
   - "api"


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This is supported since `pnpm@10.16.0`. Enable the setting to 7 days (in minutes).

https://github.com/pnpm/pnpm/releases/tag/v10.16.0

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
