### PR TITLE
Use oracle price for whitelisted treasury tokens

### DIFF
--- a/web/src/components/base/fiatValue.tsx
+++ b/web/src/components/base/fiatValue.tsx
@@ -1,5 +1,5 @@
 import { type QueryStatus } from "@tanstack/react-query";
-import { useTokenPrices } from "hooks/useTokenPrices";
+import { usePrices } from "hooks/usePrices";
 import { type ComponentProps } from "react";
 import Skeleton from "react-loading-skeleton";
 import type { Token } from "types";
@@ -20,9 +20,7 @@ const RenderFiatValueUnsafe = function ({
   token: Token;
   value: bigint | undefined;
 }) {
-  const { data: pricesData, status: pricesStatus } = useTokenPrices({
-    retryOnMount: false,
-  });
+  const { data: pricesData, status: pricesStatus } = usePrices();
 
   if (value !== undefined && pricesData !== undefined) {
     const stringBalance = formatUnits(value, token.decimals);

--- a/web/src/components/borrow/positionsTable.tsx
+++ b/web/src/components/borrow/positionsTable.tsx
@@ -8,8 +8,8 @@ import {
   type PositionData,
   usePositionsData,
 } from "hooks/borrow/usePositionsData";
+import { usePrices } from "hooks/usePrices";
 import { useScrollToHash } from "hooks/useScrollToHash";
-import { useTokenPrices } from "hooks/useTokenPrices";
 import { lazy, Suspense, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { isPositionAtRisk } from "utils/borrowPosition";
@@ -66,7 +66,7 @@ export function PositionsTable({ marketIds }: Props) {
     useMarketsData(marketIds);
   const { data: positionsData, isLoading: isPositionsLoading } =
     usePositionsData(marketIds);
-  const { data: prices } = useTokenPrices();
+  const { data: prices } = usePrices();
   const [{ borrowAction, marketId: actionMarketId }, setBorrowAction] =
     useBorrowAction();
 

--- a/web/src/fetchers/fetchOraclePrices.ts
+++ b/web/src/fetchers/fetchOraclePrices.ts
@@ -1,0 +1,70 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { getGatewayAddress } from "@vetro-protocol/gateway";
+import { tokenConfigOptions } from "hooks/useTokenConfig";
+import { whitelistedTokensOptions } from "hooks/useWhitelistedTokens";
+import { type Client, formatUnits } from "viem";
+import { readContract } from "viem/actions";
+
+const aggregatorV3Abi = [
+  {
+    inputs: [],
+    name: "decimals",
+    outputs: [{ internalType: "uint8", name: "", type: "uint8" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "latestAnswer",
+    outputs: [{ internalType: "int256", name: "", type: "int256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export const fetchOraclePrices = async function ({
+  client,
+  queryClient,
+}: {
+  client: Client;
+  queryClient: QueryClient;
+}) {
+  const chainId = client.chain!.id;
+  const gatewayAddress = getGatewayAddress(chainId);
+
+  const whitelistedTokens = await queryClient.ensureQueryData(
+    whitelistedTokensOptions({ client, queryClient }),
+  );
+
+  const entries = await Promise.all(
+    whitelistedTokens.map(async function (token) {
+      const { oracle } = await queryClient.ensureQueryData(
+        tokenConfigOptions({
+          chainId,
+          client,
+          gatewayAddress,
+          queryClient,
+          token: token.address,
+        }),
+      );
+
+      const [latestAnswer, decimals] = await Promise.all([
+        readContract(client, {
+          abi: aggregatorV3Abi,
+          address: oracle,
+          functionName: "latestAnswer",
+        }),
+        readContract(client, {
+          abi: aggregatorV3Abi,
+          address: oracle,
+          functionName: "decimals",
+        }),
+      ]);
+
+      const key = (token.extensions?.priceSymbol ?? token.symbol).toUpperCase();
+      return [key, formatUnits(latestAnswer, decimals)] as const;
+    }),
+  );
+
+  return Object.fromEntries(entries) as Record<string, string>;
+};

--- a/web/src/fetchers/fetchTotalMintFees.ts
+++ b/web/src/fetchers/fetchTotalMintFees.ts
@@ -3,8 +3,8 @@ import type { QueryClient } from "@tanstack/react-query";
 import { getGatewayAddress } from "@vetro-protocol/gateway";
 import { parseEthPrice } from "hooks/useEthPrice";
 import { mintFeeOptions } from "hooks/useMintFee";
+import { pricesOptions } from "hooks/usePrices";
 import { mintGasUnitsOptions } from "hooks/useSwapMintFees";
-import { tokenPricesOptions } from "hooks/useTokenPrices";
 import { config } from "providers/web3Provider";
 import type { Token } from "types";
 import { applyBps, weiToUsd } from "utils/fees";
@@ -68,7 +68,7 @@ export const fetchTotalMintFees = async function ({
         }),
       )
       .then((protocolFeeBps) => applyBps(amount, protocolFeeBps)),
-    queryClient.ensureQueryData(tokenPricesOptions()),
+    queryClient.ensureQueryData(pricesOptions({ client, queryClient })),
   ]);
 
   const ethPrice = parseEthPrice(prices);

--- a/web/src/fetchers/fetchTotalRedeemFees.ts
+++ b/web/src/fetchers/fetchTotalRedeemFees.ts
@@ -2,9 +2,9 @@ import { estimateFeesQueryOptions } from "@hemilabs/react-hooks/useEstimateFees"
 import type { QueryClient } from "@tanstack/react-query";
 import { getGatewayAddress } from "@vetro-protocol/gateway";
 import { parseEthPrice } from "hooks/useEthPrice";
+import { pricesOptions } from "hooks/usePrices";
 import { redeemFeeOptions } from "hooks/useRedeemFee";
 import { redeemGasUnitsOptions } from "hooks/useSwapRedeemFees";
-import { tokenPricesOptions } from "hooks/useTokenPrices";
 import { config } from "providers/web3Provider";
 import type { Token } from "types";
 import { applyBps, weiToUsd } from "utils/fees";
@@ -73,7 +73,7 @@ export const fetchTotalRedeemFees = async function ({
         }),
       )
       .then((protocolFeeBps) => applyBps(amount, protocolFeeBps)),
-    queryClient.ensureQueryData(tokenPricesOptions()),
+    queryClient.ensureQueryData(pricesOptions({ client, queryClient })),
   ]);
 
   const ethPrice = parseEthPrice(prices);

--- a/web/src/hooks/borrow/useBorrowReview.ts
+++ b/web/src/hooks/borrow/useBorrowReview.ts
@@ -10,7 +10,7 @@ import {
 import { getTokenPrice } from "utils/token";
 import { parseUnits } from "viem";
 
-import { useTokenPrices } from "../useTokenPrices";
+import { usePrices } from "../usePrices";
 
 type ReviewValues = {
   dailyInterestCost: number | null;
@@ -45,7 +45,7 @@ export const useBorrowReview = function ({
   loanToken,
   morphoMarket,
 }: Params): ReviewValues {
-  const { data: prices } = useTokenPrices();
+  const { data: prices } = usePrices();
 
   if (!morphoMarket) {
     return nullReview;

--- a/web/src/hooks/borrow/usePositionReview.ts
+++ b/web/src/hooks/borrow/usePositionReview.ts
@@ -9,7 +9,7 @@ import {
 import { getTokenPrice, parseTokenUnits } from "utils/token";
 import { formatUnits } from "viem";
 
-import { useTokenPrices } from "../useTokenPrices";
+import { usePrices } from "../usePrices";
 
 type Position = {
   borrowShares: bigint;
@@ -86,7 +86,7 @@ export const usePositionReview = function ({
   loanToken,
   position,
 }: Params): { current: PositionMetrics; updated: PositionMetrics | null } {
-  const { data: prices } = useTokenPrices();
+  const { data: prices } = usePrices();
 
   if (!position) {
     return { current: nullMetrics, updated: null };

--- a/web/src/hooks/useOraclePrices.ts
+++ b/web/src/hooks/useOraclePrices.ts
@@ -1,0 +1,18 @@
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { fetchOraclePrices } from "fetchers/fetchOraclePrices";
+import type { Client } from "viem";
+
+export const oraclePricesOptions = ({
+  client,
+  queryClient,
+}: {
+  client: Client | undefined;
+  queryClient: QueryClient;
+}) =>
+  queryOptions({
+    enabled: !!client && !!client.chain,
+    queryFn: () => fetchOraclePrices({ client: client!, queryClient }),
+    queryKey: ["oracle-prices", client?.chain?.id],
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });

--- a/web/src/hooks/usePrices.ts
+++ b/web/src/hooks/usePrices.ts
@@ -1,0 +1,46 @@
+import {
+  type QueryClient,
+  queryOptions,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import type { Client } from "viem";
+
+import { useEthereumClient } from "./useEthereumClient";
+import { oraclePricesOptions } from "./useOraclePrices";
+import { tokenPricesOptions } from "./useTokenPrices";
+
+export const pricesOptions = ({
+  client,
+  queryClient,
+}: {
+  client: Client | undefined;
+  queryClient: QueryClient;
+}) =>
+  queryOptions({
+    enabled: !!client && !!client.chain,
+    async queryFn() {
+      const [portalPrices, oraclePrices] = await Promise.all([
+        queryClient.ensureQueryData(tokenPricesOptions()),
+        queryClient.ensureQueryData(
+          oraclePricesOptions({ client, queryClient }),
+        ),
+      ]);
+      return { ...portalPrices, ...oraclePrices };
+    },
+    queryKey: ["prices", client?.chain?.id],
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+
+export const usePrices = function () {
+  const client = useEthereumClient();
+  const queryClient = useQueryClient();
+
+  return useQuery(
+    pricesOptions({
+      client,
+      queryClient,
+    }),
+  );
+};

--- a/web/src/hooks/useTokenConfig.ts
+++ b/web/src/hooks/useTokenConfig.ts
@@ -12,7 +12,7 @@ import { useEthereumClient } from "./useEthereumClient";
 import { useMainnet } from "./useMainnet";
 import { treasuryAddressOptions } from "./useTreasuryAddress";
 
-const tokenConfigOptions = ({
+export const tokenConfigOptions = ({
   chainId,
   client,
   gatewayAddress,
@@ -31,24 +31,24 @@ const tokenConfigOptions = ({
       const treasuryAddress = await queryClient.fetchQuery(
         treasuryAddressOptions({ chainId, client, gatewayAddress }),
       );
-      return getTokenConfig(client!, { address: treasuryAddress, token });
+      const [
+        vault,
+        oracle,
+        stalePeriod,
+        depositActive,
+        withdrawActive,
+        decimals,
+      ] = await getTokenConfig(client!, { address: treasuryAddress, token });
+      return {
+        decimals,
+        depositActive,
+        oracle,
+        stalePeriod,
+        vault,
+        withdrawActive,
+      };
     },
     queryKey: ["token-config", chainId, gatewayAddress, token],
-    select: ([
-      vault,
-      oracle,
-      stalePeriod,
-      depositActive,
-      withdrawActive,
-      decimals,
-    ]) => ({
-      decimals,
-      depositActive,
-      oracle,
-      stalePeriod,
-      vault,
-      withdrawActive,
-    }),
   });
 
 export const useTokenConfig = function (token: Address) {

--- a/web/test/fetchers/fetchOraclePrices.test.ts
+++ b/web/test/fetchers/fetchOraclePrices.test.ts
@@ -1,0 +1,160 @@
+import { tokenConfigOptions } from "hooks/useTokenConfig";
+import { whitelistedTokensOptions } from "hooks/useWhitelistedTokens";
+import type { Token } from "types";
+import { type Address, type Client, zeroAddress } from "viem";
+import { readContract } from "viem/actions";
+import { describe, expect, it, vi } from "vitest";
+
+import { fetchOraclePrices } from "../../src/fetchers/fetchOraclePrices";
+import { createTestQueryClient } from "../utils";
+
+vi.mock("@vetro-protocol/gateway", () => ({
+  getGatewayAddress: vi.fn().mockReturnValue(zeroAddress),
+}));
+
+vi.mock("hooks/useTokenConfig", () => ({
+  tokenConfigOptions: vi.fn().mockReturnValue({
+    queryFn: () => ({ oracle: zeroAddress }),
+    queryKey: ["token-config"],
+  }),
+}));
+
+vi.mock("hooks/useWhitelistedTokens", () => ({
+  whitelistedTokensOptions: vi.fn().mockReturnValue({
+    queryFn: () => [],
+    queryKey: ["whitelisted-tokens"],
+  }),
+}));
+
+vi.mock("viem/actions", () => ({
+  readContract: vi.fn(),
+}));
+
+const oracleAddress = "0x1111111111111111111111111111111111111111" as Address;
+
+const createMockToken = (
+  symbol: string,
+  address: Address,
+  priceSymbol?: string,
+): Token => ({
+  address,
+  chainId: 1,
+  decimals: 18,
+  extensions: priceSymbol ? { priceSymbol } : undefined,
+  logoURI: "",
+  name: symbol,
+  symbol,
+});
+
+describe("fetchOraclePrices", function () {
+  const mockClient = { chain: { id: 1 } } as unknown as Client;
+
+  it("returns oracle prices for whitelisted tokens", async function () {
+    const usdc = createMockToken(
+      "USDC",
+      "0x2222222222222222222222222222222222222222",
+    );
+    const queryClient = createTestQueryClient();
+
+    vi.mocked(whitelistedTokensOptions).mockReturnValue({
+      queryFn: () => [usdc],
+      queryKey: ["whitelisted-tokens"],
+    } as never);
+    vi.mocked(tokenConfigOptions).mockReturnValue({
+      queryFn: () => ({ oracle: oracleAddress }),
+      queryKey: ["token-config"],
+    } as never);
+    vi.mocked(readContract)
+      // latestAnswer
+      .mockResolvedValueOnce(100000000n)
+      // decimals
+      .mockResolvedValueOnce(8);
+
+    const result = await fetchOraclePrices({
+      client: mockClient,
+      queryClient,
+    });
+
+    expect(result).toEqual({ USDC: "1" });
+  });
+
+  it("uses priceSymbol from token extensions when available", async function () {
+    const hemiBtc = createMockToken(
+      "hemiBTC",
+      "0x3333333333333333333333333333333333333333",
+      "BTC",
+    );
+    const queryClient = createTestQueryClient();
+
+    vi.mocked(whitelistedTokensOptions).mockReturnValue({
+      queryFn: () => [hemiBtc],
+      queryKey: ["whitelisted-tokens"],
+    } as never);
+    vi.mocked(tokenConfigOptions).mockReturnValue({
+      queryFn: () => ({ oracle: oracleAddress }),
+      queryKey: ["token-config"],
+    } as never);
+    // BTC price: $60,000 with 8 decimals
+    vi.mocked(readContract)
+      .mockResolvedValueOnce(6000000000000n)
+      .mockResolvedValueOnce(8);
+
+    const result = await fetchOraclePrices({
+      client: mockClient,
+      queryClient,
+    });
+
+    expect(result).toEqual({ BTC: "60000" });
+  });
+
+  it("returns prices for multiple tokens", async function () {
+    const usdc = createMockToken(
+      "USDC",
+      "0x2222222222222222222222222222222222222222",
+    );
+    const wbtc = createMockToken(
+      "WBTC",
+      "0x3333333333333333333333333333333333333333",
+    );
+    const queryClient = createTestQueryClient();
+
+    vi.mocked(whitelistedTokensOptions).mockReturnValue({
+      queryFn: () => [usdc, wbtc],
+      queryKey: ["whitelisted-tokens"],
+    } as never);
+    vi.mocked(tokenConfigOptions).mockReturnValue({
+      queryFn: () => ({ oracle: oracleAddress }),
+      queryKey: ["token-config"],
+    } as never);
+    vi.mocked(readContract)
+      // USDC: latestAnswer, decimals
+      .mockResolvedValueOnce(100000000n)
+      .mockResolvedValueOnce(8)
+      // WBTC: latestAnswer, decimals
+      .mockResolvedValueOnce(6000000000000n)
+      .mockResolvedValueOnce(8);
+
+    const result = await fetchOraclePrices({
+      client: mockClient,
+      queryClient,
+    });
+
+    expect(result).toEqual({ USDC: "1", WBTC: "60000" });
+  });
+
+  it("returns empty object when no whitelisted tokens", async function () {
+    const queryClient = createTestQueryClient();
+
+    vi.mocked(whitelistedTokensOptions).mockReturnValue({
+      queryFn: () => [],
+      queryKey: ["whitelisted-tokens"],
+    } as never);
+
+    const result = await fetchOraclePrices({
+      client: mockClient,
+      queryClient,
+    });
+
+    expect(result).toEqual({});
+  });
+});

--- a/web/test/fetchers/fetchTotalMintFees.test.ts
+++ b/web/test/fetchers/fetchTotalMintFees.test.ts
@@ -1,14 +1,19 @@
-import type { QueryClient } from "@tanstack/react-query";
+import { estimateFeesQueryOptions } from "@hemilabs/react-hooks/useEstimateFees";
+import { mintFeeOptions } from "hooks/useMintFee";
+import { pricesOptions } from "hooks/usePrices";
+import { mintGasUnitsOptions } from "hooks/useSwapMintFees";
 import type { Token } from "types";
 import { zeroAddress, type Client } from "viem";
 import { sepolia } from "viem/chains";
 import { describe, expect, it, vi } from "vitest";
 
 import { fetchTotalMintFees } from "../../src/fetchers/fetchTotalMintFees";
+import { createTestQueryClient } from "../utils";
 
 vi.mock("@hemilabs/react-hooks/useEstimateFees", () => ({
   estimateFeesQueryOptions: vi.fn().mockReturnValue({
     queryFn: () => 0n,
+    queryKey: ["estimate-fees"],
   }),
 }));
 
@@ -19,18 +24,21 @@ vi.mock("@vetro-protocol/gateway", () => ({
 vi.mock("hooks/useMintFee", () => ({
   mintFeeOptions: vi.fn().mockReturnValue({
     queryFn: () => 0n,
+    queryKey: ["mint-fee"],
+  }),
+}));
+
+vi.mock("hooks/usePrices", () => ({
+  pricesOptions: vi.fn().mockReturnValue({
+    queryFn: () => ({}),
+    queryKey: ["prices"],
   }),
 }));
 
 vi.mock("hooks/useSwapMintFees", () => ({
   mintGasUnitsOptions: vi.fn().mockReturnValue({
     queryFn: () => 100000n,
-  }),
-}));
-
-vi.mock("hooks/useTokenPrices", () => ({
-  tokenPricesOptions: vi.fn().mockReturnValue({
-    queryFn: () => ({}),
+    queryKey: ["mint-gas-units"],
   }),
 }));
 
@@ -48,12 +56,7 @@ describe("fetchTotalMintFees", function () {
     symbol: "USDC",
   } as Token;
 
-  const mockQueryClient = {
-    ensureQueryData: vi.fn(),
-  } as unknown as QueryClient;
-
   it("returns correct total fee in USD", async function () {
-    const gasUnits = 100000n;
     // 0.001 ETH in wei
     const networkFeeWei = 1000000000000000n;
     // 100 bps = 1%
@@ -61,15 +64,24 @@ describe("fetchTotalMintFees", function () {
     // amount is 1 USDC (6 decimals)
     const amount = 1000000n;
 
-    vi.mocked(mockQueryClient.ensureQueryData)
-      // mintGasUnitsOptions
-      .mockResolvedValueOnce(gasUnits)
-      // estimateFeesQueryOptions
-      .mockResolvedValueOnce(networkFeeWei)
-      // mintFeeOptions
-      .mockResolvedValueOnce(protocolFeeBps)
-      // tokenPricesOptions
-      .mockResolvedValueOnce({ ETH: "2000", USDC: "1" });
+    const queryClient = createTestQueryClient();
+
+    vi.mocked(mintGasUnitsOptions).mockReturnValue({
+      queryFn: () => 100000n,
+      queryKey: ["mint-gas-units"],
+    } as never);
+    vi.mocked(estimateFeesQueryOptions).mockReturnValue({
+      queryFn: () => networkFeeWei,
+      queryKey: ["estimate-fees"],
+    } as never);
+    vi.mocked(mintFeeOptions).mockReturnValue({
+      queryFn: () => protocolFeeBps,
+      queryKey: ["mint-fee"],
+    } as never);
+    vi.mocked(pricesOptions).mockReturnValue({
+      queryFn: () => ({ ETH: "2000", USDC: "1" }),
+      queryKey: ["prices"],
+    } as never);
 
     const result = await fetchTotalMintFees({
       amount,
@@ -79,7 +91,7 @@ describe("fetchTotalMintFees", function () {
       fromToken: mockToken,
       minPeggedTokenOut: 0n,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
     });
 
     // network: 0.001 ETH * 2000 = $2
@@ -89,15 +101,24 @@ describe("fetchTotalMintFees", function () {
   });
 
   it("returns zero when both fees are zero", async function () {
-    vi.mocked(mockQueryClient.ensureQueryData)
-      // mintGasUnitsOptions
-      .mockResolvedValueOnce(100000n)
-      // estimateFeesQueryOptions
-      .mockResolvedValueOnce(0n)
-      // mintFeeOptions
-      .mockResolvedValueOnce(0n)
-      // tokenPricesOptions
-      .mockResolvedValueOnce({ ETH: "2000", USDC: "1" });
+    const queryClient = createTestQueryClient();
+
+    vi.mocked(mintGasUnitsOptions).mockReturnValue({
+      queryFn: () => 100000n,
+      queryKey: ["mint-gas-units"],
+    } as never);
+    vi.mocked(estimateFeesQueryOptions).mockReturnValue({
+      queryFn: () => 0n,
+      queryKey: ["estimate-fees"],
+    } as never);
+    vi.mocked(mintFeeOptions).mockReturnValue({
+      queryFn: () => 0n,
+      queryKey: ["mint-fee"],
+    } as never);
+    vi.mocked(pricesOptions).mockReturnValue({
+      queryFn: () => ({ ETH: "2000", USDC: "1" }),
+      queryKey: ["prices"],
+    } as never);
 
     const result = await fetchTotalMintFees({
       amount: 1000000n,
@@ -107,26 +128,35 @@ describe("fetchTotalMintFees", function () {
       fromToken: mockToken,
       minPeggedTokenOut: 0n,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
     });
 
     expect(result).toBe(0);
   });
 
-  it("handles undefined network fee", async function () {
+  it("handles zero network fee", async function () {
     // 100 bps = 1%
     const protocolFeeBps = 100n;
     const amount = 1000000n;
 
-    vi.mocked(mockQueryClient.ensureQueryData)
-      // mintGasUnitsOptions
-      .mockResolvedValueOnce(100000n)
-      // estimateFeesQueryOptions
-      .mockResolvedValueOnce(undefined)
-      // mintFeeOptions
-      .mockResolvedValueOnce(protocolFeeBps)
-      // tokenPricesOptions
-      .mockResolvedValueOnce({ ETH: "2000", USDC: "1" });
+    const queryClient = createTestQueryClient();
+
+    vi.mocked(mintGasUnitsOptions).mockReturnValue({
+      queryFn: () => 100000n,
+      queryKey: ["mint-gas-units"],
+    } as never);
+    vi.mocked(estimateFeesQueryOptions).mockReturnValue({
+      queryFn: () => 0n,
+      queryKey: ["estimate-fees"],
+    } as never);
+    vi.mocked(mintFeeOptions).mockReturnValue({
+      queryFn: () => protocolFeeBps,
+      queryKey: ["mint-fee"],
+    } as never);
+    vi.mocked(pricesOptions).mockReturnValue({
+      queryFn: () => ({ ETH: "2000", USDC: "1" }),
+      queryKey: ["prices"],
+    } as never);
 
     const result = await fetchTotalMintFees({
       amount,
@@ -136,10 +166,10 @@ describe("fetchTotalMintFees", function () {
       fromToken: mockToken,
       minPeggedTokenOut: 0n,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
     });
 
-    // network: 0 (undefined → 0n)
+    // network: 0
     // protocol: 1% of 1 USDC = $0.01
     expect(result).toBeCloseTo(0.01);
   });

--- a/web/test/fetchers/fetchTotalRedeemFees.test.ts
+++ b/web/test/fetchers/fetchTotalRedeemFees.test.ts
@@ -1,14 +1,19 @@
-import type { QueryClient } from "@tanstack/react-query";
+import { estimateFeesQueryOptions } from "@hemilabs/react-hooks/useEstimateFees";
+import { pricesOptions } from "hooks/usePrices";
+import { redeemFeeOptions } from "hooks/useRedeemFee";
+import { redeemGasUnitsOptions } from "hooks/useSwapRedeemFees";
 import type { Token } from "types";
 import { zeroAddress, type Client } from "viem";
 import { sepolia } from "viem/chains";
 import { describe, expect, it, vi } from "vitest";
 
 import { fetchTotalRedeemFees } from "../../src/fetchers/fetchTotalRedeemFees";
+import { createTestQueryClient } from "../utils";
 
 vi.mock("@hemilabs/react-hooks/useEstimateFees", () => ({
   estimateFeesQueryOptions: vi.fn().mockReturnValue({
     queryFn: () => 0n,
+    queryKey: ["estimate-fees"],
   }),
 }));
 
@@ -16,21 +21,24 @@ vi.mock("@vetro-protocol/gateway", () => ({
   getGatewayAddress: vi.fn().mockReturnValue(zeroAddress),
 }));
 
+vi.mock("hooks/usePrices", () => ({
+  pricesOptions: vi.fn().mockReturnValue({
+    queryFn: () => ({}),
+    queryKey: ["prices"],
+  }),
+}));
+
 vi.mock("hooks/useRedeemFee", () => ({
   redeemFeeOptions: vi.fn().mockReturnValue({
     queryFn: () => 0n,
+    queryKey: ["redeem-fee"],
   }),
 }));
 
 vi.mock("hooks/useSwapRedeemFees", () => ({
   redeemGasUnitsOptions: vi.fn().mockReturnValue({
     queryFn: () => 100000n,
-  }),
-}));
-
-vi.mock("hooks/useTokenPrices", () => ({
-  tokenPricesOptions: vi.fn().mockReturnValue({
-    queryFn: () => ({}),
+    queryKey: ["redeem-gas-units"],
   }),
 }));
 
@@ -49,12 +57,7 @@ describe("fetchTotalRedeemFees", function () {
   } as Token;
   const mockTokenOut = zeroAddress;
 
-  const mockQueryClient = {
-    ensureQueryData: vi.fn(),
-  } as unknown as QueryClient;
-
   it("returns correct total fee in USD", async function () {
-    const gasUnits = 100000n;
     // 0.001 ETH in wei
     const networkFeeWei = 1000000000000000n;
     // 100 bps = 1%
@@ -62,15 +65,24 @@ describe("fetchTotalRedeemFees", function () {
     // amount is 1 USDC (6 decimals)
     const amount = 1000000n;
 
-    vi.mocked(mockQueryClient.ensureQueryData)
-      // redeemGasUnitsOptions
-      .mockResolvedValueOnce(gasUnits)
-      // redeemFeeOptions
-      .mockResolvedValueOnce(protocolFeeBps)
-      // tokenPricesOptions
-      .mockResolvedValueOnce({ ETH: "2000", USDC: "1" })
-      // estimateFeesQueryOptions (chained after gasUnits resolves)
-      .mockResolvedValueOnce(networkFeeWei);
+    const queryClient = createTestQueryClient();
+
+    vi.mocked(redeemGasUnitsOptions).mockReturnValue({
+      queryFn: () => 100000n,
+      queryKey: ["redeem-gas-units"],
+    } as never);
+    vi.mocked(estimateFeesQueryOptions).mockReturnValue({
+      queryFn: () => networkFeeWei,
+      queryKey: ["estimate-fees"],
+    } as never);
+    vi.mocked(redeemFeeOptions).mockReturnValue({
+      queryFn: () => protocolFeeBps,
+      queryKey: ["redeem-fee"],
+    } as never);
+    vi.mocked(pricesOptions).mockReturnValue({
+      queryFn: () => ({ ETH: "2000", USDC: "1" }),
+      queryKey: ["prices"],
+    } as never);
 
     const result = await fetchTotalRedeemFees({
       amount,
@@ -80,7 +92,7 @@ describe("fetchTotalRedeemFees", function () {
       fromToken: mockToken,
       minAmountOut: 0n,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
       tokenOut: mockTokenOut,
     });
 
@@ -91,15 +103,24 @@ describe("fetchTotalRedeemFees", function () {
   });
 
   it("returns zero when both fees are zero", async function () {
-    vi.mocked(mockQueryClient.ensureQueryData)
-      // redeemGasUnitsOptions
-      .mockResolvedValueOnce(100000n)
-      // redeemFeeOptions
-      .mockResolvedValueOnce(0n)
-      // tokenPricesOptions
-      .mockResolvedValueOnce({ ETH: "2000", USDC: "1" })
-      // estimateFeesQueryOptions
-      .mockResolvedValueOnce(0n);
+    const queryClient = createTestQueryClient();
+
+    vi.mocked(redeemGasUnitsOptions).mockReturnValue({
+      queryFn: () => 100000n,
+      queryKey: ["redeem-gas-units"],
+    } as never);
+    vi.mocked(estimateFeesQueryOptions).mockReturnValue({
+      queryFn: () => 0n,
+      queryKey: ["estimate-fees"],
+    } as never);
+    vi.mocked(redeemFeeOptions).mockReturnValue({
+      queryFn: () => 0n,
+      queryKey: ["redeem-fee"],
+    } as never);
+    vi.mocked(pricesOptions).mockReturnValue({
+      queryFn: () => ({ ETH: "2000", USDC: "1" }),
+      queryKey: ["prices"],
+    } as never);
 
     const result = await fetchTotalRedeemFees({
       amount: 1000000n,
@@ -109,27 +130,36 @@ describe("fetchTotalRedeemFees", function () {
       fromToken: mockToken,
       minAmountOut: 0n,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
       tokenOut: mockTokenOut,
     });
 
     expect(result).toBe(0);
   });
 
-  it("handles undefined network fee", async function () {
+  it("handles zero network fee", async function () {
     // 100 bps = 1%
     const protocolFeeBps = 100n;
     const amount = 1000000n;
 
-    vi.mocked(mockQueryClient.ensureQueryData)
-      // redeemGasUnitsOptions
-      .mockResolvedValueOnce(100000n)
-      // redeemFeeOptions
-      .mockResolvedValueOnce(protocolFeeBps)
-      // tokenPricesOptions
-      .mockResolvedValueOnce({ ETH: "2000", USDC: "1" })
-      // estimateFeesQueryOptions
-      .mockResolvedValueOnce(undefined);
+    const queryClient = createTestQueryClient();
+
+    vi.mocked(redeemGasUnitsOptions).mockReturnValue({
+      queryFn: () => 100000n,
+      queryKey: ["redeem-gas-units"],
+    } as never);
+    vi.mocked(estimateFeesQueryOptions).mockReturnValue({
+      queryFn: () => 0n,
+      queryKey: ["estimate-fees"],
+    } as never);
+    vi.mocked(redeemFeeOptions).mockReturnValue({
+      queryFn: () => protocolFeeBps,
+      queryKey: ["redeem-fee"],
+    } as never);
+    vi.mocked(pricesOptions).mockReturnValue({
+      queryFn: () => ({ ETH: "2000", USDC: "1" }),
+      queryKey: ["prices"],
+    } as never);
 
     const result = await fetchTotalRedeemFees({
       amount,
@@ -139,11 +169,11 @@ describe("fetchTotalRedeemFees", function () {
       fromToken: mockToken,
       minAmountOut: 0n,
       owner: mockOwner,
-      queryClient: mockQueryClient,
+      queryClient,
       tokenOut: mockTokenOut,
     });
 
-    // network: 0 (undefined → 0n)
+    // network: 0
     // protocol: 1% of 1 USDC = $0.01
     expect(result).toBeCloseTo(0.01);
   });


### PR DESCRIPTION
### Description

Whitelisted treasury tokens now get their price from Chainlink oracles
(`tokenConfig.oracle.latestAnswer()`) instead of the Portal API. Non-whitelisted
tokens (e.g., ETH for gas fees) continue using the Portal API. Oracle prices
override Portal prices via a merged `usePrices` hook with `pricesOptions`.

Key changes:
- New `fetchOraclePrices` fetcher — reads oracle address from `tokenConfig`, calls `latestAnswer()` + `decimals()` on the Chainlink aggregator
- New `useOraclePrices` hook with `oraclePricesOptions` — wraps the fetcher with React Query
- New `usePrices` hook with `pricesOptions` — merges Portal API + oracle prices (oracle wins)
- `useTokenConfig` — moved `select` into `queryFn` so `ensureQueryData` returns the object shape
- Consumers (`fiatValue`, `useBorrowReview`, `usePositionReview`, `positionsTable`) switched from `useTokenPrices` to `usePrices`
- `fetchTotalMintFees` / `fetchTotalRedeemFees` use `pricesOptions` instead of `tokenPricesOptions`
- Fee tests refactored to use `createTestQueryClient()` with mocked `queryOptions`

### Screenshots

N/A — no UI changes, only the data source for prices changed.

### Related issue(s)

Closes #295

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.