### PR TITLE
Show fees section after user has typed in inputs

### DIFF
--- a/web/src/components/borrow/borrowForm.tsx
+++ b/web/src/components/borrow/borrowForm.tsx
@@ -362,7 +362,9 @@ export function BorrowForm({
             openConnectModal={openConnectModal}
           />
         </div>
-        <FormSection>
+        <FormSection
+          show={borrowAmountBigInt !== 0n && collateralAmountBigInt !== 0n}
+        >
           <FormSectionItem>
             <NetworkFees
               label={<OracleLabel oracle={market.oracle} />}

--- a/web/src/components/borrow/borrowMoreForm.tsx
+++ b/web/src/components/borrow/borrowMoreForm.tsx
@@ -11,6 +11,7 @@ import {
 } from "components/base/verticalStepper";
 import { OracleLabel } from "components/borrow/oracleLabel";
 import { hasSufficientGas } from "components/borrow/utils";
+import { CollapsibleSection } from "components/collapsibleSection";
 import { DrawerFeesContainer } from "components/feesContainer";
 import { NetworkFees } from "components/networkFees";
 import { TokenInput } from "components/tokenInput";
@@ -372,12 +373,14 @@ export function BorrowMoreForm({ market, onClose }: Props) {
             sufficientGas={sufficientGas}
           />
         </div>
-        <DrawerFeesContainer>
-          <NetworkFees
-            label={<OracleLabel oracle={market.oracle} />}
-            networkFee={networkFee}
-          />
-        </DrawerFeesContainer>
+        <CollapsibleSection show={borrowAmountBigInt !== 0n}>
+          <DrawerFeesContainer>
+            <NetworkFees
+              label={<OracleLabel oracle={market.oracle} />}
+              networkFee={networkFee}
+            />
+          </DrawerFeesContainer>
+        </CollapsibleSection>
         <DrawerFeesContainer>
           <PositionReview
             borrowApy={market.borrowApy}

--- a/web/src/components/borrow/repayLoanForm.tsx
+++ b/web/src/components/borrow/repayLoanForm.tsx
@@ -13,6 +13,7 @@ import {
 } from "components/base/verticalStepper";
 import { OracleLabel } from "components/borrow/oracleLabel";
 import { hasSufficientGas } from "components/borrow/utils";
+import { CollapsibleSection } from "components/collapsibleSection";
 import { DrawerFeesContainer } from "components/feesContainer";
 import { NetworkFees } from "components/networkFees";
 import { TokenInput } from "components/tokenInput";
@@ -398,12 +399,14 @@ export function RepayLoanForm({ market, onClose }: Props) {
             sufficientGas={sufficientGas}
           />
         </div>
-        <DrawerFeesContainer>
-          <NetworkFees
-            label={<OracleLabel oracle={market.oracle} />}
-            networkFee={networkFee}
-          />
-        </DrawerFeesContainer>
+        <CollapsibleSection show={repayAmountBigInt !== 0n}>
+          <DrawerFeesContainer>
+            <NetworkFees
+              label={<OracleLabel oracle={market.oracle} />}
+              networkFee={networkFee}
+            />
+          </DrawerFeesContainer>
+        </CollapsibleSection>
         <DrawerFeesContainer>
           <PositionReview
             borrowApy={market.borrowApy}

--- a/web/src/components/borrow/supplyCollateralForm.tsx
+++ b/web/src/components/borrow/supplyCollateralForm.tsx
@@ -13,6 +13,7 @@ import {
 } from "components/base/verticalStepper";
 import { OracleLabel } from "components/borrow/oracleLabel";
 import { hasSufficientGas } from "components/borrow/utils";
+import { CollapsibleSection } from "components/collapsibleSection";
 import { DrawerFeesContainer } from "components/feesContainer";
 import { NetworkFees } from "components/networkFees";
 import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
@@ -404,12 +405,14 @@ export function SupplyCollateralForm({ market, onClose }: Props) {
             sufficientGas={sufficientGas}
           />
         </div>
-        <DrawerFeesContainer>
-          <NetworkFees
-            label={<OracleLabel oracle={market.oracle} />}
-            networkFee={networkFee}
-          />
-        </DrawerFeesContainer>
+        <CollapsibleSection show={collateralAmountBigInt !== 0n}>
+          <DrawerFeesContainer>
+            <NetworkFees
+              label={<OracleLabel oracle={market.oracle} />}
+              networkFee={networkFee}
+            />
+          </DrawerFeesContainer>
+        </CollapsibleSection>
         <DrawerFeesContainer>
           <PositionReview
             borrowApy={market.borrowApy}

--- a/web/src/components/borrow/withdrawCollateralForm.tsx
+++ b/web/src/components/borrow/withdrawCollateralForm.tsx
@@ -11,6 +11,7 @@ import {
 } from "components/base/verticalStepper";
 import { OracleLabel } from "components/borrow/oracleLabel";
 import { hasSufficientGas } from "components/borrow/utils";
+import { CollapsibleSection } from "components/collapsibleSection";
 import { DrawerFeesContainer } from "components/feesContainer";
 import { NetworkFees } from "components/networkFees";
 import { TokenInput } from "components/tokenInput";
@@ -336,12 +337,14 @@ export function WithdrawCollateralForm({ market, onClose }: Props) {
             sufficientGas={sufficientGas}
           />
         </div>
-        <DrawerFeesContainer>
-          <NetworkFees
-            label={<OracleLabel oracle={market.oracle} />}
-            networkFee={networkFee}
-          />
-        </DrawerFeesContainer>
+        <CollapsibleSection show={collateralAmountBigInt !== 0n}>
+          <DrawerFeesContainer>
+            <NetworkFees
+              label={<OracleLabel oracle={market.oracle} />}
+              networkFee={networkFee}
+            />
+          </DrawerFeesContainer>
+        </CollapsibleSection>
         <DrawerFeesContainer>
           <PositionReview
             borrowApy={market.borrowApy}

--- a/web/src/components/collapsibleSection.tsx
+++ b/web/src/components/collapsibleSection.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+export const CollapsibleSection = ({
+  children,
+  className = "",
+  show,
+}: {
+  children: ReactNode;
+  className?: string;
+  show: boolean;
+}) => (
+  <div
+    className={`grid transition-[grid-template-rows] duration-200 ease-out ${show ? "grid-rows-[1fr]" : "grid-rows-[0fr]"} ${className}`}
+  >
+    <div className="overflow-hidden">{children}</div>
+  </div>
+);

--- a/web/src/components/collapsibleSection.tsx
+++ b/web/src/components/collapsibleSection.tsx
@@ -12,6 +12,8 @@ export const CollapsibleSection = ({
   <div
     className={`grid transition-[grid-template-rows] duration-200 ease-out ${show ? "grid-rows-[1fr]" : "grid-rows-[0fr]"} ${className}`}
   >
-    <div className="overflow-hidden">{children}</div>
+    <div aria-hidden={!show} className="overflow-hidden" inert={!show}>
+      {children}
+    </div>
   </div>
 );

--- a/web/src/components/feesContainer.tsx
+++ b/web/src/components/feesContainer.tsx
@@ -2,6 +2,7 @@ import { Children, type ReactElement, type ReactNode, useState } from "react";
 import Skeleton from "react-loading-skeleton";
 
 import { ChevronIcon } from "./base/chevronIcon";
+import { CollapsibleSection } from "./collapsibleSection";
 import type { FeeDetailsProps } from "./feeDetails";
 import feesSvg from "./icons/fees.svg";
 import gasSvg from "./icons/gas.svg";
@@ -86,8 +87,16 @@ export const DrawerFeesContainer = ({ children }: { children: ReactNode }) => (
   <div className="w-full border-b border-gray-200 px-6">{children}</div>
 );
 
-export const FormSection = ({ children }: { children: ReactNode }) => (
-  <div className="w-full md:max-w-md">{children}</div>
+export const FormSection = ({
+  children,
+  show,
+}: {
+  children: ReactNode;
+  show: boolean;
+}) => (
+  <CollapsibleSection className="w-full md:max-w-md" show={show}>
+    {children}
+  </CollapsibleSection>
 );
 
 export const FormSectionItem = ({ children }: { children: ReactNode }) => (

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -255,7 +255,7 @@ export function Deposit({
           token={fromToken}
         />
       </Form>
-      <FormSection>
+      <FormSection show={amountBigInt !== 0n}>
         <FormSectionItem>
           <ApproveSection active={approve10x} onToggle={onToggleApprove10x} />
         </FormSectionItem>

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -256,7 +256,7 @@ export function OneStepRedeem({
           token={fromToken}
         />
       </Form>
-      <FormSection>
+      <FormSection show={amountBigInt !== 0n}>
         <FormSectionItem>
           <ApproveSection active={approve10x} onToggle={onToggleApprove10x} />
         </FormSectionItem>

--- a/web/src/components/swapForm/swapFormSkeleton.tsx
+++ b/web/src/components/swapForm/swapFormSkeleton.tsx
@@ -54,7 +54,7 @@ export function SwapFormSkeleton() {
           </div>
         </div>
       </div>
-      <FormSection>
+      <FormSection show={false}>
         <FormSectionItem>
           <ApproveSection active={false} />
         </FormSectionItem>

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -249,7 +249,7 @@ export function TwoStepRedeem({
           </Button>
         </div>
       </Form>
-      <FormSection>
+      <FormSection show={amountBigInt !== 0n}>
         <FormSectionItem>
           <ApproveSection active={approve10x} onToggle={onToggleApprove10x} />
         </FormSectionItem>

--- a/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
@@ -6,6 +6,7 @@ import { getStakingVaultAddress } from "@vetro-protocol/earn";
 import { ApproveSection } from "components/approveSection";
 import { RenderFiatValue } from "components/base/fiatValue";
 import { VerticalStepper, stepStatus } from "components/base/verticalStepper";
+import { CollapsibleSection } from "components/collapsibleSection";
 import { DrawerFeesContainer } from "components/feesContainer";
 import { NetworkFees } from "components/networkFees";
 import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
@@ -304,19 +305,21 @@ export function StakeDepositForm({
           pendingText={pendingText}
         />
       </div>
-      <DrawerFeesContainer>
-        <ApproveSection active={approve10x} onToggle={onApprove10xToggle} />
-      </DrawerFeesContainer>
-      <div className="border-b border-gray-200">
-        <NetworkFees
-          label={t("pages.earn.stake.fees-label", {
-            amount: inputValue,
-            token: vusd.symbol,
-          })}
-          networkFee={depositFeesQuery}
-          sectionClassName="px-6"
-        />
-      </div>
+      <CollapsibleSection show={amountBigInt !== 0n}>
+        <DrawerFeesContainer>
+          <ApproveSection active={approve10x} onToggle={onApprove10xToggle} />
+        </DrawerFeesContainer>
+        <div className="border-b border-gray-200">
+          <NetworkFees
+            label={t("pages.earn.stake.fees-label", {
+              amount: inputValue,
+              token: vusd.symbol,
+            })}
+            networkFee={depositFeesQuery}
+            sectionClassName="px-6"
+          />
+        </div>
+      </CollapsibleSection>
       <DepositProgress
         approvalCompleted={approvalCompleted}
         depositStep={depositStep}

--- a/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
@@ -2,6 +2,7 @@ import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { RenderFiatValue } from "components/base/fiatValue";
 import { VerticalStepper, stepStatus } from "components/base/verticalStepper";
+import { CollapsibleSection } from "components/collapsibleSection";
 import { NetworkFees } from "components/networkFees";
 import { SetMaxStakedBalance } from "components/setMaxStakedBalance";
 import { TokenInput } from "components/tokenInput";
@@ -298,16 +299,18 @@ export function StakeWithdrawForm({
           }
         />
       </div>
-      <div className="border-b border-gray-200">
-        <NetworkFees
-          label={t("pages.earn.stake.withdrawing-fees-label", {
-            amount: inputValue,
-            token: vusd.symbol,
-          })}
-          networkFee={withdrawFeesQuery}
-          sectionClassName="px-6"
-        />
-      </div>
+      <CollapsibleSection show={amountBigInt !== 0n}>
+        <div className="border-b border-gray-200">
+          <NetworkFees
+            label={t("pages.earn.stake.withdrawing-fees-label", {
+              amount: inputValue,
+              token: vusd.symbol,
+            })}
+            networkFee={withdrawFeesQuery}
+            sectionClassName="px-6"
+          />
+        </div>
+      </CollapsibleSection>
       <div className="mt-auto flex flex-col gap-2 px-6">
         <p className="text-xs font-medium tracking-wide text-gray-500">
           {t("pages.earn.stake.withdraw-progress")}

--- a/web/stories/collapsibleSection.stories.tsx
+++ b/web/stories/collapsibleSection.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+import { CollapsibleSection } from "../src/components/collapsibleSection";
+
+const meta: Meta<typeof CollapsibleSection> = {
+  argTypes: {
+    children: {
+      control: false,
+    },
+    show: {
+      control: "boolean",
+    },
+  },
+  component: CollapsibleSection,
+  title: "Components/CollapsibleSection",
+};
+
+export default meta;
+type Story = StoryObj<typeof CollapsibleSection>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <div className="rounded border border-gray-200 bg-gray-50 p-4">
+        <p className="text-sm text-gray-700">
+          This content animates in and out. Toggle the <strong>show</strong>{" "}
+          control to see the transition.
+        </p>
+      </div>
+    ),
+    show: true,
+  },
+};
+
+export const Interactive: Story = {
+  render: function Component() {
+    const [show, setShow] = useState(false);
+
+    return (
+      <div className="flex w-80 flex-col gap-4">
+        <input
+          className="rounded border border-gray-300 px-3 py-2 text-sm"
+          onChange={(e) => setShow(e.target.value !== "")}
+          placeholder="Type something to reveal content..."
+          type="text"
+        />
+        <CollapsibleSection show={show}>
+          <div className="flex flex-col gap-2 rounded border border-gray-200 bg-gray-50 p-4">
+            <p className="text-sm font-semibold text-gray-900">Fees</p>
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-500">Network Fee</span>
+              <span className="text-gray-900">$0.0001</span>
+            </div>
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-500">Protocol Fee</span>
+              <span className="text-gray-900">0.003%</span>
+            </div>
+          </div>
+        </CollapsibleSection>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The fees are now in a collapsible section that appears when the user types in the input

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/ef2df1c4-57e0-4dad-8fc0-e639f90842fd

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #130

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
