### PR TITLE
Fix background gradient + rename input.css

### DIFF
--- a/landing/README.md
+++ b/landing/README.md
@@ -13,8 +13,8 @@ pnpm dev:css    # watches for CSS changes and rebuilds (run in a separate termin
 
 Tailwind CSS is pre-compiled using the Tailwind CLI to avoid runtime dependencies and simplify deployment. The compiled file (`public/style.css`) is committed to the repository.
 
-If you modify `src/input.css` or change any Tailwind classes in `public/index.html`, you must rebuild and commit the output:
+If you modify `src/index.css` or change any Tailwind classes in `public/index.html`, you must rebuild and commit the output:
 
 ```sh
-pnpm build:css  # compiles src/input.css -> public/style.css
+pnpm build:css  # compiles src/index.css -> public/style.css
 ```

--- a/landing/README.md
+++ b/landing/README.md
@@ -11,9 +11,7 @@ pnpm dev:css    # watches for CSS changes and rebuilds (run in a separate termin
 
 ## CSS build
 
-Tailwind CSS is pre-compiled using the Tailwind CLI to avoid runtime dependencies and simplify deployment. The compiled file (`public/style.css`) is committed to the repository.
-
-If you modify `src/index.css` or change any Tailwind classes in `public/index.html`, you must rebuild and commit the output:
+Tailwind CSS is pre-compiled using the Tailwind CLI. The compiled output (`public/style.css`) is gitignored and built during deployment.
 
 ```sh
 pnpm build:css  # compiles src/index.css -> public/style.css

--- a/landing/package.json
+++ b/landing/package.json
@@ -2,10 +2,10 @@
   "name": "@vetro-protocol/landing",
   "version": "1.0.0",
   "scripts": {
-    "build:css": "tailwindcss -i src/input.css -o public/style.css --minify",
+    "build:css": "tailwindcss -i src/index.css -o public/style.css --minify",
     "deps:check": "knip",
     "dev": "pnpm build:css && wrangler dev",
-    "dev:css": "tailwindcss -i src/input.css -o public/style.css --watch",
+    "dev:css": "tailwindcss -i src/index.css -o public/style.css --watch",
     "types": "wrangler types",
     "types:check": "pnpm types && tsc"
   },

--- a/landing/public/index.html
+++ b/landing/public/index.html
@@ -18,16 +18,7 @@
   </head>
   <body>
     <main
-      class="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-6 pb-40"
-      style="
-        background:
-          linear-gradient(
-            0deg,
-            rgba(33, 59, 230, 0.08) 0%,
-            rgba(33, 59, 230, 0.08) 100%
-          ),
-          #fff;
-      "
+      class="bg-page relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-6 pb-40"
     >
       <!-- Logo -->
       <img

--- a/landing/src/index.css
+++ b/landing/src/index.css
@@ -14,3 +14,13 @@ body {
   margin: 0;
   font-family: var(--font-geist);
 }
+
+.bg-page {
+  background:
+    linear-gradient(
+      0deg,
+      rgba(33, 59, 230, 0.08) 0%,
+      rgba(33, 59, 230, 0.08) 100%
+    ),
+    #fff;
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR fixes the background gradient which seems to be broken on Cloudflare. Acccording to Claude, 

> This is almost certainly caused by the multiline inline style attribute. Cloudflare's HTML minification (or Auto Minify feature in Wrangler/Pages) can mangle the whitespace inside multi-line inline styles, breaking the CSS value. The browser then ignores the malformed property — but toggling in DevTools re-parses it correctly.

I also renamed `input.css` to `index.css`

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
