### PR TITLE
landing: add KV binding to production env

### DIFF
--- a/landing/wrangler.jsonc
+++ b/landing/wrangler.jsonc
@@ -18,6 +18,12 @@
       "vars": {
         "ORIGIN": "https://vetro.org",
       },
+      "kv_namespaces": [
+        {
+          "binding": "KV",
+          "id": "fc3dcb6070824b3cbf4b945767006661", // Not sensitive information
+        },
+      ],
     },
   },
   "kv_namespaces": [


### PR DESCRIPTION
### Description

The `KV` binding was not inherited by the `production` environment, causing a 503 response in production.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
