### PR TITLE
Prompt users to add tokens to wallet after transactions

### DIFF
--- a/patches/@hemilabs__wallet-watch-asset@1.0.2.patch
+++ b/patches/@hemilabs__wallet-watch-asset@1.0.2.patch
@@ -1,0 +1,20 @@
+diff --git a/src/index.js b/src/index.js
+index fc229490136ba643be385a65bdafd88cd8015a5e..661e1dc577ccd137021e406e0fcd43bf12ba4677 100644
+--- a/src/index.js
++++ b/src/index.js
+@@ -28,10 +28,11 @@
+ async function watchAsset(provider, account, token, storage) {
+   const { address, chainId, decimals, logoURI, symbol } = token;
+ 
+-  // The only wallet known so far with EIP-747 support is MetaMask.
+-  if (!provider.isMetaMask) {
+-    throw new Error("Wallet not supported");
+-  }
++  // Patched: disabled MetaMask-only check so wallet_watchAsset works with
++  // any EIP-747 compatible wallet (e.g. wagmi's WalletClient).
++  // if (!provider.isMetaMask) {
++  //   throw new Error("Wallet not supported");
++  // }
+ 
+   const storageKey = `watchedAssets:${account}`;
+   const watchedAssets = storage?.getItem(storageKey) || "";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@hemilabs/wallet-watch-asset@1.0.2':
+    hash: 933b0ee20c3f95b39d12cd9f25e1175fef9353a7ef2d91378cafd55f2efec0fc
+    path: patches/@hemilabs__wallet-watch-asset@1.0.2.patch
+
 importers:
 
   .:
@@ -213,10 +218,10 @@ importers:
     dependencies:
       '@hemilabs/react-hooks':
         specifier: 1.5.0
-        version: 1.5.0(@hemilabs/wallet-watch-asset@1.0.2)(@tanstack/react-query@5.90.19(react@19.2.3))(react@19.2.3)(viem-erc20@2.1.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.19)(@tanstack/react-query@5.90.19(react@19.2.3))(@types/react@19.2.9)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))
+        version: 1.5.0(@hemilabs/wallet-watch-asset@1.0.2(patch_hash=933b0ee20c3f95b39d12cd9f25e1175fef9353a7ef2d91378cafd55f2efec0fc))(@tanstack/react-query@5.90.19(react@19.2.3))(react@19.2.3)(viem-erc20@2.1.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.19)(@tanstack/react-query@5.90.19(react@19.2.3))(@types/react@19.2.9)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))
       '@hemilabs/wallet-watch-asset':
         specifier: 1.0.2
-        version: 1.0.2
+        version: 1.0.2(patch_hash=933b0ee20c3f95b39d12cd9f25e1175fef9353a7ef2d91378cafd55f2efec0fc)
       '@morpho-org/blue-sdk':
         specifier: 5.17.0
         version: 5.17.0(@morpho-org/morpho-ts@2.5.0)
@@ -9133,16 +9138,16 @@ snapshots:
     dependencies:
       assemblyscript: 0.27.31
 
-  '@hemilabs/react-hooks@1.5.0(@hemilabs/wallet-watch-asset@1.0.2)(@tanstack/react-query@5.90.19(react@19.2.3))(react@19.2.3)(viem-erc20@2.1.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.19)(@tanstack/react-query@5.90.19(react@19.2.3))(@types/react@19.2.9)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))':
+  '@hemilabs/react-hooks@1.5.0(@hemilabs/wallet-watch-asset@1.0.2(patch_hash=933b0ee20c3f95b39d12cd9f25e1175fef9353a7ef2d91378cafd55f2efec0fc))(@tanstack/react-query@5.90.19(react@19.2.3))(react@19.2.3)(viem-erc20@2.1.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.19)(@tanstack/react-query@5.90.19(react@19.2.3))(@types/react@19.2.9)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))':
     dependencies:
-      '@hemilabs/wallet-watch-asset': 1.0.2
+      '@hemilabs/wallet-watch-asset': 1.0.2(patch_hash=933b0ee20c3f95b39d12cd9f25e1175fef9353a7ef2d91378cafd55f2efec0fc)
       '@tanstack/react-query': 5.90.19(react@19.2.3)
       react: 19.2.3
       viem: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       viem-erc20: 2.1.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
       wagmi: 2.19.5(@tanstack/query-core@5.90.19)(@tanstack/react-query@5.90.19(react@19.2.3))(@types/react@19.2.9)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5)
 
-  '@hemilabs/wallet-watch-asset@1.0.2': {}
+  '@hemilabs/wallet-watch-asset@1.0.2(patch_hash=933b0ee20c3f95b39d12cd9f25e1175fef9353a7ef2d91378cafd55f2efec0fc)': {}
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,9 @@ packages:
   - "subgraph"
   - "web"
 
+patchedDependencies:
+  "@hemilabs/wallet-watch-asset@1.0.2": "patches/@hemilabs__wallet-watch-asset@1.0.2.patch"
+
 # https://github.com/microsoft/vscode-eslint/issues/1986#issuecomment-2799868163
 publicHoistPattern:
   - "*eslint*"

--- a/web/src/components/borrow/borrowForm.tsx
+++ b/web/src/components/borrow/borrowForm.tsx
@@ -1,3 +1,4 @@
+import { useAddTokenToWallet } from "@hemilabs/react-hooks/useAddTokenToWallet";
 import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { useNeedsApproval } from "@hemilabs/react-hooks/useNeedsApproval";
 import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
@@ -133,7 +134,6 @@ export function BorrowForm({
   const ethereumChain = useMainnet();
   const { address } = useAccount();
   const { openConnectModal } = useConnectModal();
-
   const [flowStatus, setFlowStatus] = useState<BorrowFlowStatus>("idle");
   const [showToast, setShowToast] = useState(false);
   const [startedWithApproval, setStartedWithApproval] = useState(false);
@@ -143,6 +143,13 @@ export function BorrowForm({
   );
 
   const { collateralToken, loanToken, marketId } = market;
+  const { mutate: watchToken } = useAddTokenToWallet({
+    token: {
+      address: loanToken.address,
+      chainId: loanToken.chainId,
+      extensions: { logoURI: loanToken.logoURI },
+    },
+  });
 
   const collateralAmountBigInt = parseUnits(
     collateralInput,
@@ -237,6 +244,7 @@ export function BorrowForm({
         onCompleted();
         setFlowStatus("borrowed");
         setShowToast(true);
+        watchToken();
       });
       emitter.on("borrow-assets-transaction-reverted", function () {
         onFailed();

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -1,3 +1,4 @@
+import { useAddTokenToWallet } from "@hemilabs/react-hooks/useAddTokenToWallet";
 import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { useNeedsApproval } from "@hemilabs/react-hooks/useNeedsApproval";
 import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
@@ -65,6 +66,13 @@ export function Deposit({
   whitelistedTokens,
 }: Props) {
   const ethereumChain = useMainnet();
+  const { mutate: watchToken } = useAddTokenToWallet({
+    token: {
+      address: toToken.address,
+      chainId: toToken.chainId,
+      extensions: { logoURI: toToken.logoURI },
+    },
+  });
   const { t } = useTranslation();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const handleDrawerClose = useCallback(() => setIsDrawerOpen(false), []);
@@ -144,6 +152,7 @@ export function Deposit({
         onCompleted();
         setFlowStatus("deposited");
         setShowToast(true);
+        watchToken();
       });
       emitter.on("deposit-transaction-reverted", function () {
         onFailed();

--- a/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
@@ -1,3 +1,4 @@
+import { useAddTokenToWallet } from "@hemilabs/react-hooks/useAddTokenToWallet";
 import { useAllowance } from "@hemilabs/react-hooks/useAllowance";
 import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
@@ -16,6 +17,7 @@ import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
 import { useActivityTracking } from "hooks/useActivityTracking";
 import { useMainnet } from "hooks/useMainnet";
 import { useStakeDeposit } from "hooks/useStakeDeposit";
+import { useSvusd } from "hooks/useSvusd";
 import { useVusd } from "hooks/useVusd";
 import { useTotalDepositFees } from "pages/earn/hooks/useTotalDepositFees";
 import { type FormEvent, useCallback } from "react";
@@ -166,7 +168,15 @@ export function StakeDepositForm({
   const chain = useMainnet();
   const { openConnectModal } = useConnectModal();
   const { t } = useTranslation();
+  const { data: svusd } = useSvusd();
   const { data: vusd } = useVusd();
+  const { mutate: watchToken } = useAddTokenToWallet({
+    token: {
+      address: svusd!.address,
+      chainId: chain.id,
+      extensions: { logoURI: svusd!.logoURI },
+    },
+  });
   const stakingVaultAddress = getStakingVaultAddress(chain.id);
 
   const { data: vusdBalance, isError: isVusdBalanceError } = useTokenBalance({
@@ -219,8 +229,9 @@ export function StakeDepositForm({
         description: t("pages.earn.stake.deposit-toast-description"),
         title: t("pages.earn.stake.deposit-toast-title"),
       });
+      watchToken();
     },
-    [onSuccess, t],
+    [onSuccess, t, watchToken],
   );
 
   const depositMutation = useStakeDeposit({


### PR DESCRIPTION
### Description

After a successful swap, earn deposit, or borrow transaction, prompt users via EIP-747 (`wallet_watchAsset`) to add the received token to their wallet:

- **Swap**: prompts to add VUSD after depositing a whitelisted token
- **Earn**: prompts to add sVUSD after staking
- **Borrow**: prompts to add the loan token after opening a position

Uses `useAddTokenToWallet` from `@hemilabs/react-hooks`. Also patches `@hemilabs/wallet-watch-asset` to disable the MetaMask-only guard so it works with any EIP-747 compatible wallet.

### Screenshots

Prompt after swapping

https://github.com/user-attachments/assets/d85c4594-9bed-451b-8419-3e2251a8f9d9

Prompt after depositing on Earn

https://github.com/user-attachments/assets/ea577bba-5eef-413d-8d71-658d386a55dd

Prompt after borrowing

https://github.com/user-attachments/assets/9b031ace-0b10-4553-ad05-eabf527cf32e

After adding:

<img width="1018" height="142" alt="image" src="https://github.com/user-attachments/assets/a7cee181-ad45-4b97-9550-9fb934a324ea" />

<img width="1008" height="164" alt="image" src="https://github.com/user-attachments/assets/f477657f-d5fd-4db8-b4b1-4321b140e3a8" />

(there's no image for sVUSD)

### Related issue(s)

Closes #170

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.