### PR TITLE
Fix fiat value skeleton alignment in swap form

### DIFF
--- a/web/src/components/swapForm/redeemSkeleton.tsx
+++ b/web/src/components/swapForm/redeemSkeleton.tsx
@@ -28,7 +28,9 @@ export function RedeemSkeleton({ fromToken }: Props) {
                 <Balance label={t("pages.swap.form.balance")} value="-" />
               }
               disabled
-              fiatValue={<Skeleton className="ml-2" height={14} width={32} />}
+              fiatValue={
+                <Skeleton className="h-full" containerClassName="w-8" />
+              }
               label={t("pages.swap.form.you-are-swapping")}
               tokenSelector={<TokenSelectorReadOnly {...fromToken} />}
               value="0"
@@ -45,7 +47,9 @@ export function RedeemSkeleton({ fromToken }: Props) {
                 <Balance label={t("pages.swap.form.balance")} value="-" />
               }
               disabled
-              fiatValue={<Skeleton className="ml-2" height={14} width={32} />}
+              fiatValue={
+                <Skeleton className="h-full" containerClassName="w-8" />
+              }
               label={t("pages.swap.form.you-will-receive")}
               tokenSelector={<TokenSelectorSkeleton />}
               value="0"

--- a/web/src/components/swapForm/swapFormSkeleton.tsx
+++ b/web/src/components/swapForm/swapFormSkeleton.tsx
@@ -23,7 +23,9 @@ export function SwapFormSkeleton() {
                 <Balance label={t("pages.swap.form.balance")} value="-" />
               }
               disabled
-              fiatValue={<Skeleton className="ml-2" height={14} width={32} />}
+              fiatValue={
+                <Skeleton className="h-full" containerClassName="w-8" />
+              }
               label={t("pages.swap.form.you-are-swapping")}
               tokenSelector={<TokenSelectorSkeleton />}
               value="0"
@@ -40,7 +42,9 @@ export function SwapFormSkeleton() {
                 <Balance label={t("pages.swap.form.balance")} value="-" />
               }
               disabled
-              fiatValue={<Skeleton className="ml-2" height={14} width={32} />}
+              fiatValue={
+                <Skeleton className="h-full" containerClassName="w-8" />
+              }
               label={t("pages.swap.form.you-will-receive")}
               tokenSelector={<TokenSelectorSkeleton />}
               value="0"

--- a/web/src/components/tokenInput/index.tsx
+++ b/web/src/components/tokenInput/index.tsx
@@ -38,7 +38,9 @@ export const TokenInput = ({
       <div className="shrink-0">{tokenSelector}</div>
     </div>
     <div className="mt-2 flex items-center justify-between">
-      <span className="text-xsm text-gray-500">${fiatValue}</span>
+      <span className="text-xsm inline-flex items-center gap-x-1 text-gray-500">
+        ${fiatValue}
+      </span>
       {balance || maxButton ? (
         <div className="text-xsm flex items-center gap-1">
           {balance}


### PR DESCRIPTION
### Description

The fiat value skeleton (`$` + loading bar) in the swap form was rendering incorrectly — the skeleton appeared as a block element below the `$` sign instead of inline next to it.

Two changes:
- **`TokenInput`**: Make the fiat value container `inline-flex` with `items-center gap-x-1` so `$` and the skeleton/value always align inline
- **Swap skeletons**: Update `SwapFormSkeleton` and `RedeemSkeleton` to use the same skeleton style as `RenderFiatValue` (`h-full` + `w-8` container)

### Screenshots

https://github.com/user-attachments/assets/60c9c395-4231-493f-a72c-53ef1d61bc03

### Related issue(s)

Closes #314

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.