### PR TITLE
Freeze position review metrics during mutation

### DIFF
--- a/web/src/components/borrow/borrowMoreForm.tsx
+++ b/web/src/components/borrow/borrowMoreForm.tsx
@@ -303,6 +303,7 @@ export function BorrowMoreForm({ market, onClose }: Props) {
     borrowApy: market.borrowApy,
     borrowInput,
     collateralToken,
+    frozen: isActive,
     loanToken,
     position: positionInfo,
   });

--- a/web/src/components/borrow/repayLoanForm.tsx
+++ b/web/src/components/borrow/repayLoanForm.tsx
@@ -328,6 +328,7 @@ export function RepayLoanForm({ market, onClose }: Props) {
   const { current, updated } = useRepayReview({
     borrowApy: market.borrowApy,
     collateralToken,
+    frozen: isActive,
     loanToken,
     position: positionInfo,
     repayInput,

--- a/web/src/components/borrow/supplyCollateralForm.tsx
+++ b/web/src/components/borrow/supplyCollateralForm.tsx
@@ -320,6 +320,7 @@ export function SupplyCollateralForm({ market, onClose }: Props) {
     borrowApy: market.borrowApy,
     collateralInput,
     collateralToken,
+    frozen: isActive,
     loanToken,
     position: positionInfo,
   });

--- a/web/src/components/borrow/withdrawCollateralForm.tsx
+++ b/web/src/components/borrow/withdrawCollateralForm.tsx
@@ -260,6 +260,7 @@ export function WithdrawCollateralForm({ market, onClose }: Props) {
     borrowApy: market.borrowApy,
     collateralInput,
     collateralToken,
+    frozen: isActive,
     loanToken,
     position: positionInfo,
   });

--- a/web/src/hooks/borrow/useBorrowMoreReview.ts
+++ b/web/src/hooks/borrow/useBorrowMoreReview.ts
@@ -7,6 +7,7 @@ type Params = {
   borrowApy: number;
   borrowInput: string;
   collateralToken: Token;
+  frozen?: boolean;
   loanToken: Token;
   position: AccrualPosition | undefined;
 };
@@ -15,12 +16,14 @@ export const useBorrowMoreReview = ({
   borrowApy,
   borrowInput,
   collateralToken,
+  frozen,
   loanToken,
   position,
 }: Params) =>
   usePositionReview({
     borrowApy,
     collateralToken,
+    frozen,
     getUpdatedPosition: (pos, amount) => ({
       borrowShares: pos.market.toBorrowShares(
         pos.market.toBorrowAssets(pos.borrowShares) + amount,

--- a/web/src/hooks/borrow/usePositionReview.ts
+++ b/web/src/hooks/borrow/usePositionReview.ts
@@ -1,4 +1,5 @@
 import type { AccrualPosition, Market } from "@morpho-org/blue-sdk";
+import { useRef } from "react";
 import type { Token } from "types";
 import {
   calculateDailyInterestCost,
@@ -70,6 +71,7 @@ const buildMetrics = function ({
 type Params = {
   borrowApy: number;
   collateralToken: Token;
+  frozen?: boolean;
   getUpdatedPosition: (position: AccrualPosition, amount: bigint) => Position;
   input: string;
   inputToken: Token;
@@ -80,6 +82,7 @@ type Params = {
 export const usePositionReview = function ({
   borrowApy,
   collateralToken,
+  frozen = false,
   getUpdatedPosition,
   input,
   inputToken,
@@ -87,9 +90,18 @@ export const usePositionReview = function ({
   position,
 }: Params): { current: PositionMetrics; updated: PositionMetrics | null } {
   const { data: prices } = usePrices();
+  const resultRef = useRef<{
+    current: PositionMetrics;
+    updated: PositionMetrics | null;
+  }>({ current: nullMetrics, updated: null });
+
+  if (frozen) {
+    return resultRef.current;
+  }
 
   if (!position) {
-    return { current: nullMetrics, updated: null };
+    resultRef.current = { current: nullMetrics, updated: null };
+    return resultRef.current;
   }
 
   const loanUsdPrice = prices
@@ -114,7 +126,8 @@ export const usePositionReview = function ({
 
   const parsedInput = parseFloat(input);
   if (!parsedInput || isNaN(parsedInput)) {
-    return { current, updated: null };
+    resultRef.current = { current, updated: null };
+    return resultRef.current;
   }
 
   const amount = parseTokenUnits(input, inputToken);
@@ -125,5 +138,6 @@ export const usePositionReview = function ({
     position: updatedPosition,
   });
 
-  return { current, updated };
+  resultRef.current = { current, updated };
+  return resultRef.current;
 };

--- a/web/src/hooks/borrow/useRepayReview.ts
+++ b/web/src/hooks/borrow/useRepayReview.ts
@@ -7,6 +7,7 @@ import { usePositionReview } from "./usePositionReview";
 type Params = {
   borrowApy: number;
   collateralToken: Token;
+  frozen?: boolean;
   loanToken: Token;
   position: AccrualPosition | undefined;
   repayInput: string;
@@ -15,6 +16,7 @@ type Params = {
 export const useRepayReview = ({
   borrowApy,
   collateralToken,
+  frozen,
   loanToken,
   position,
   repayInput,
@@ -22,6 +24,7 @@ export const useRepayReview = ({
   usePositionReview({
     borrowApy,
     collateralToken,
+    frozen,
     getUpdatedPosition(pos, amount) {
       const updatedBorrowAssets =
         pos.market.toBorrowAssets(pos.borrowShares) - amount;

--- a/web/src/hooks/borrow/useSupplyCollateralReview.ts
+++ b/web/src/hooks/borrow/useSupplyCollateralReview.ts
@@ -7,6 +7,7 @@ type Params = {
   borrowApy: number;
   collateralInput: string;
   collateralToken: Token;
+  frozen?: boolean;
   loanToken: Token;
   position: AccrualPosition | undefined;
 };
@@ -15,12 +16,14 @@ export const useSupplyCollateralReview = ({
   borrowApy,
   collateralInput,
   collateralToken,
+  frozen,
   loanToken,
   position,
 }: Params) =>
   usePositionReview({
     borrowApy,
     collateralToken,
+    frozen,
     getUpdatedPosition: (pos, amount) => ({
       borrowShares: pos.borrowShares,
       collateral: pos.collateral + amount,

--- a/web/src/hooks/borrow/useWithdrawCollateralReview.ts
+++ b/web/src/hooks/borrow/useWithdrawCollateralReview.ts
@@ -8,6 +8,7 @@ type Params = {
   borrowApy: number;
   collateralInput: string;
   collateralToken: Token;
+  frozen?: boolean;
   loanToken: Token;
   position: AccrualPosition | undefined;
 };
@@ -16,12 +17,14 @@ export const useWithdrawCollateralReview = ({
   borrowApy,
   collateralInput,
   collateralToken,
+  frozen,
   loanToken,
   position,
 }: Params) =>
   usePositionReview({
     borrowApy,
     collateralToken,
+    frozen,
     getUpdatedPosition(pos, amount) {
       const updatedCollateral = pos.collateral - amount;
       return {


### PR DESCRIPTION
### Description

When a borrow mutation confirms, optimistic `setQueryData` updates change the cached position data. This causes the Position Review section to show incorrect values for 2-3 seconds until the drawer closes.

Adds a `frozen` flag to `usePositionReview` that preserves the last computed metrics while the form flow is active (i.e., `flowStatus !== "idle"`). When frozen, the hook skips all recomputation and returns the previously cached result.

### Screenshots

https://github.com/user-attachments/assets/30c72b9b-73ac-4ef2-adac-c5725d2229a8

### Related issue(s)

Closes #196

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.