### PR TITLE
Improve wording on swap form

### DIFF
--- a/web/src/components/swapForm/claimRedeemProgressDrawer.tsx
+++ b/web/src/components/swapForm/claimRedeemProgressDrawer.tsx
@@ -113,7 +113,7 @@ export function ClaimRedeemProgressDrawer({
           balance={<ToTokenBalance token={toToken} />}
           disabled
           fiatValue={<RenderFiatValue token={toToken} value={outputBigInt} />}
-          label={t("pages.swap.form.you-will-receive")}
+          label={t("pages.swap.form.you-will-receive-estimated")}
           tokenSelector={
             <TokenDropdown
               onChange={onTokenChange}

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -250,7 +250,7 @@ export function Deposit({
             fiatValue={
               <RenderFiatValue token={toToken} value={depositPreview} />
             }
-            label={t("pages.swap.form.you-will-receive")}
+            label={t("pages.swap.form.you-will-receive-estimated")}
             tokenSelector={<TokenSelectorReadOnly {...toToken} />}
             value={outputValue}
           />

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -236,7 +236,7 @@ export function OneStepRedeem({
             fiatValue={
               <RenderFiatValue token={toToken} value={redeemPreview} />
             }
-            label={t("pages.swap.form.you-will-receive")}
+            label={t("pages.swap.form.you-will-receive-estimated")}
             tokenSelector={
               <TokenDropdown
                 onChange={onTokenChange}

--- a/web/src/components/swapForm/redeemSkeleton.tsx
+++ b/web/src/components/swapForm/redeemSkeleton.tsx
@@ -50,7 +50,7 @@ export function RedeemSkeleton({ fromToken }: Props) {
               fiatValue={
                 <Skeleton className="h-full" containerClassName="w-8" />
               }
-              label={t("pages.swap.form.you-will-receive")}
+              label={t("pages.swap.form.you-will-receive-estimated")}
               tokenSelector={<TokenSelectorSkeleton />}
               value="0"
             />

--- a/web/src/components/swapForm/swapFormSkeleton.tsx
+++ b/web/src/components/swapForm/swapFormSkeleton.tsx
@@ -45,7 +45,7 @@ export function SwapFormSkeleton() {
               fiatValue={
                 <Skeleton className="h-full" containerClassName="w-8" />
               }
-              label={t("pages.swap.form.you-will-receive")}
+              label={t("pages.swap.form.you-will-receive-estimated")}
               tokenSelector={<TokenSelectorSkeleton />}
               value="0"
             />

--- a/web/src/components/swapForm/swapProgressDrawer.tsx
+++ b/web/src/components/swapForm/swapProgressDrawer.tsx
@@ -74,7 +74,7 @@ export function SwapProgressDrawer({
           {toToken && outputValue !== undefined && (
             <div className="flex flex-col gap-2">
               <p className="text-xsm text-gray-500">
-                {t("pages.swap.form.you-will-receive")}
+                {t("pages.swap.form.you-will-receive-estimated")}
               </p>
               <div className="flex items-center gap-3">
                 <p className="flex items-center gap-x-2 text-4xl leading-10 font-semibold tracking-tight text-gray-900">

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -314,8 +314,7 @@
         "send-to-queue": "Send to queue",
         "swap": "Swap",
         "you-are-swapping": "You are swapping",
-        "you-will-receive": "You will receive",
-        "you-will-receive-approximately": "You will receive (approximately)"
+        "you-will-receive-estimated": "You will receive (estimate)"
       },
       "progress": {
         "approve-description": "This allows the app to use this token for your swap.",

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -314,7 +314,7 @@
         "send-to-queue": "Send to queue",
         "swap": "Swap",
         "you-are-swapping": "You are swapping",
-        "you-will-receive-estimated": "You will receive (estimate)"
+        "you-will-receive-estimated": "You will receive (estimated)"
       },
       "progress": {
         "approve-description": "This allows the app to use this token for your swap.",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -319,8 +319,7 @@
         "send-to-queue": "Enviar a la cola",
         "swap": "Intercambiar",
         "you-are-swapping": "Vas a intercambiar",
-        "you-will-receive": "Vas a recibir",
-        "you-will-receive-approximately": "Vas a recibir (aproximadamente)"
+        "you-will-receive-estimated": "Va a recibir (estimado)"
       },
       "progress": {
         "approve-description": "Esto permite que la app use este token para su intercambio.",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR makes a small text update for the swap form, adding the "(estimate)" to the "You will receive"

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img width="886" height="1010" alt="image" src="https://github.com/user-attachments/assets/2bd8c487-33ef-44ee-8e0c-d303b2c257ac" />

<img width="1174" height="876" alt="image" src="https://github.com/user-attachments/assets/bcd20cdc-b5ef-4e19-b496-3d350eb292ac" />

<img width="444" height="618" alt="image" src="https://github.com/user-attachments/assets/618b1b4c-2867-4651-87d9-5b4f22da5902" />


### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #285

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
