### PR TITLE
Rename useVusd to usePeggedToken

### DIFF
--- a/web/src/components/appNotifications.tsx
+++ b/web/src/components/appNotifications.tsx
@@ -5,7 +5,7 @@ import { type StackItem, Stack } from "components/base/stack";
 import { useAtRiskPositions } from "hooks/borrow/useAtRiskPositions";
 import { useCountdown } from "hooks/useCountdown";
 import { useGetRedeemRequest } from "hooks/useGetRedeemRequest";
-import { useVusd } from "hooks/useVusd";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router";
 import { formatAmount } from "utils/token";
@@ -47,7 +47,7 @@ function useLiquidationItems(): StackItem[] {
 
 function useRedeemItem(): StackItem | undefined {
   const { data: redeemRequest } = useGetRedeemRequest();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
   const { lang } = useParams();
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -62,9 +62,9 @@ function useRedeemItem(): StackItem | undefined {
 
   const formattedAmount = formatAmount({
     amount: amountLocked,
-    decimals: vusd.decimals,
+    decimals: peggedToken.decimals,
     isError: false,
-    symbol: vusd.symbol,
+    symbol: peggedToken.symbol,
   });
 
   function handleClick() {

--- a/web/src/components/borrow/positionsEmptyState.tsx
+++ b/web/src/components/borrow/positionsEmptyState.tsx
@@ -1,6 +1,6 @@
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { Button } from "components/base/button";
-import { useVusd } from "hooks/useVusd";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { useTranslation } from "react-i18next";
 
 const DisconnectedWalletIcon = () => (
@@ -86,7 +86,7 @@ export function PositionsDisconnectedState() {
 
 export function PositionsEmptyState() {
   const { t } = useTranslation();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
 
   return (
     <div className="flex items-center justify-center border-b border-gray-200 bg-white px-8 py-12">
@@ -98,7 +98,7 @@ export function PositionsEmptyState() {
           </span>
           <span className="font-normal text-gray-500">
             {t("pages.borrow.no-positions-description", {
-              symbol: vusd.symbol,
+              symbol: peggedToken.symbol,
             })}
           </span>
         </div>

--- a/web/src/components/swapForm/cancelRedeemModal.tsx
+++ b/web/src/components/swapForm/cancelRedeemModal.tsx
@@ -3,7 +3,7 @@ import { Button } from "components/base/button";
 import { Modal } from "components/base/modal";
 import { useActivityTracking } from "hooks/useActivityTracking";
 import { useCancelRedeemRequest } from "hooks/useCancelRedeemRequest";
-import { useVusd } from "hooks/useVusd";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { formatUnits } from "viem";
@@ -24,14 +24,14 @@ export function CancelRedeemModal({
   const { openConnectModal } = useConnectModal();
   const [isCancelling, setIsCancelling] = useState(false);
   const { t } = useTranslation();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
 
   const { onCompleted, onFailed, onPending, onTransactionHash } =
     useActivityTracking({
       page: "swap",
       text: t("pages.swap.activity.cancel-redeem-text", {
-        amount: formatUnits(redeemableAmount, vusd.decimals),
-        symbol: vusd.symbol,
+        amount: formatUnits(redeemableAmount, peggedToken.decimals),
+        symbol: peggedToken.symbol,
       }),
       title: `${t("nav.swap")} · ${t("pages.swap.redeem-queue.cancel-redeem")}`,
     });
@@ -77,7 +77,7 @@ export function CancelRedeemModal({
           </h4>
           <p className="text-b-regular text-gray-500">
             {t("pages.swap.redeem-queue.cancel-redeem-description", {
-              symbol: vusd.symbol,
+              symbol: peggedToken.symbol,
             })}
           </p>
         </div>

--- a/web/src/components/swapForm/index.tsx
+++ b/web/src/components/swapForm/index.tsx
@@ -1,6 +1,6 @@
 import { useDebounce } from "@hemilabs/react-hooks/useDebounce";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { useSwapMode } from "hooks/useSwapMode";
-import { useVusd } from "hooks/useVusd";
 import { useWhitelistedTokens } from "hooks/useWhitelistedTokens";
 import { useReducer } from "react";
 import type { Token } from "types";
@@ -92,10 +92,10 @@ function SwapFormContent({
 
 export function SwapForm() {
   const [mode, setMode] = useSwapMode();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
   const { data: whitelistedTokens } = useWhitelistedTokens();
 
-  if (vusd === undefined || whitelistedTokens === undefined) {
+  if (peggedToken === undefined || whitelistedTokens === undefined) {
     return <SwapFormSkeleton />;
   }
 
@@ -103,7 +103,7 @@ export function SwapForm() {
     <SwapFormContent
       mode={mode}
       setMode={setMode}
-      vusd={vusd}
+      vusd={peggedToken}
       whitelistedTokens={whitelistedTokens}
     />
   );

--- a/web/src/components/swapForm/redeemQueue.tsx
+++ b/web/src/components/swapForm/redeemQueue.tsx
@@ -5,12 +5,12 @@ import { useActivityTracking } from "hooks/useActivityTracking";
 import { useGetRedeemRequest } from "hooks/useGetRedeemRequest";
 import { useMainnet } from "hooks/useMainnet";
 import { useMaxWithdraw } from "hooks/useMaxWithdraw";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { usePreviewRedeem } from "hooks/usePreviewRedeem";
 import { useRedeem } from "hooks/useRedeem";
 import { useRedeemFee } from "hooks/useRedeemFee";
 import { useSwapRedeemFees } from "hooks/useSwapRedeemFees";
 import { useTotalRedeemFees } from "hooks/useTotalRedeemFees";
-import { useVusd } from "hooks/useVusd";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Token } from "types";
@@ -33,7 +33,7 @@ type Props = {
 export function RedeemQueue({ whitelistedTokens }: Props) {
   const ethereumChain = useMainnet();
   const { t } = useTranslation();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
   const { data: nativeBalanceData } = useNativeBalance(ethereumChain.id);
   const nativeBalance = nativeBalanceData?.value;
   const { data: redeemRequest, isLoading } = useGetRedeemRequest();
@@ -49,7 +49,7 @@ export function RedeemQueue({ whitelistedTokens }: Props) {
   const hasRequest = amountLocked > 0n;
 
   const amountBigInt = fromInputValue
-    ? parseTokenUnits(fromInputValue, vusd)
+    ? parseTokenUnits(fromInputValue, peggedToken)
     : 0n;
 
   const { data: maxWithdraw } = useMaxWithdraw(toToken.address);
@@ -60,7 +60,7 @@ export function RedeemQueue({ whitelistedTokens }: Props) {
   });
 
   const unitRedeemPreview = usePreviewRedeem({
-    peggedTokenIn: parseUnits("1", vusd.decimals),
+    peggedTokenIn: parseUnits("1", peggedToken.decimals),
     tokenOut: toToken.address,
   });
 
@@ -83,7 +83,7 @@ export function RedeemQueue({ whitelistedTokens }: Props) {
       page: "swap",
       text: t("pages.swap.activity.claim-redeem-text", {
         fromAmount: fromInputValue,
-        fromSymbol: vusd.symbol,
+        fromSymbol: peggedToken.symbol,
         toAmount: outputValue,
         toSymbol: toToken.symbol,
       }),
@@ -93,7 +93,7 @@ export function RedeemQueue({ whitelistedTokens }: Props) {
   const networkFeeQueryData = useSwapRedeemFees({
     amount: amountBigInt,
     approveAmount: undefined,
-    fromToken: vusd,
+    fromToken: peggedToken,
     minAmountOut: redeemPreview,
     tokenOut: toToken.address,
   });
@@ -112,7 +112,7 @@ export function RedeemQueue({ whitelistedTokens }: Props) {
     amount: amountBigInt,
     // no approval is needed when redeeming from the queue
     approveAmount: undefined,
-    fromToken: vusd,
+    fromToken: peggedToken,
     minAmountOut: redeemPreview,
     tokenOut: toToken.address,
   });
@@ -148,7 +148,7 @@ export function RedeemQueue({ whitelistedTokens }: Props) {
   });
 
   const handleMaxClick = () =>
-    setFromInputValue(formatUnits(amountLocked, vusd.decimals));
+    setFromInputValue(formatUnits(amountLocked, peggedToken.decimals));
 
   const handleSubmit = function () {
     setFlowStatus("redeem-ready");
@@ -171,7 +171,7 @@ export function RedeemQueue({ whitelistedTokens }: Props) {
         placeholder={
           <RedeemQueueEmptyState whitelistedTokens={whitelistedTokens} />
         }
-        vusd={vusd}
+        vusd={peggedToken}
       />
       {isDrawerOpen && (
         <ClaimRedeemDrawer
@@ -179,7 +179,7 @@ export function RedeemQueue({ whitelistedTokens }: Props) {
           amountLocked={amountLocked}
           flowStatus={flowStatus}
           fromAmount={fromInputValue}
-          fromToken={vusd}
+          fromToken={peggedToken}
           inputError={inputError}
           networkFee={networkFee}
           onClose={handleClose}
@@ -208,7 +208,7 @@ export function RedeemQueue({ whitelistedTokens }: Props) {
         onClose={() => setToastType(undefined)}
         toToken={toToken}
         toastType={toastType}
-        vusd={vusd}
+        vusd={peggedToken}
       />
     </>
   );

--- a/web/src/components/swapForm/redeemQueueEmptyState.tsx
+++ b/web/src/components/swapForm/redeemQueueEmptyState.tsx
@@ -1,4 +1,4 @@
-import { useVusd } from "hooks/useVusd";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { useWithdrawalDelay } from "hooks/useWithdrawalDelay";
 import { useTranslation } from "react-i18next";
 import type { Token } from "types";
@@ -76,8 +76,8 @@ type Props = {
 
 export function RedeemQueueEmptyState({ whitelistedTokens }: Props) {
   const { t } = useTranslation();
-  const { data: vusd } = useVusd();
-  const { symbol } = vusd;
+  const { data: peggedToken } = usePeggedToken();
+  const { symbol } = peggedToken;
   const { data: seconds } = useWithdrawalDelay({
     select: (data) => Number(data),
   });

--- a/web/src/components/swapForm/redeemTutorialModal.tsx
+++ b/web/src/components/swapForm/redeemTutorialModal.tsx
@@ -1,6 +1,6 @@
 import { Modal } from "components/base/modal";
 import { StripedDivider } from "components/stripedDivider";
-import { useVusd } from "hooks/useVusd";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { useWithdrawalDelay } from "hooks/useWithdrawalDelay";
 import type { ReactNode } from "react";
 import { Trans, useTranslation } from "react-i18next";
@@ -38,7 +38,7 @@ const StepSection = ({ badge, children, image }: StepSectionProps) => (
 
 export function RedeemTutorialModal({ onClose, whitelistedTokens }: Props) {
   const { t } = useTranslation();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
   const { data: seconds } = useWithdrawalDelay({
     select: (data) => Number(data),
   });
@@ -75,14 +75,14 @@ export function RedeemTutorialModal({ onClose, whitelistedTokens }: Props) {
             <Trans
               components={{ strong: <span className="text-gray-900" /> }}
               i18nKey="pages.swap.tutorial.step-1-paragraph-1"
-              values={{ symbol: vusd.symbol }}
+              values={{ symbol: peggedToken.symbol }}
             />
           </p>
           <p className="text-base font-semibold text-gray-500">
             {t("pages.swap.tutorial.step-1-paragraph-2", {
               count: seconds,
               seconds,
-              symbol: vusd.symbol,
+              symbol: peggedToken.symbol,
             })}
           </p>
         </StepSection>

--- a/web/src/fetchers/fetchCollateralizationRatio.ts
+++ b/web/src/fetchers/fetchCollateralizationRatio.ts
@@ -12,13 +12,13 @@ const fetchTreasuryTotal = async function ({
   chainId,
   client,
   gatewayAddress,
-  oneVusd,
+  oneUnit,
   queryClient,
 }: {
   chainId: number;
   client: Client;
   gatewayAddress: Address;
-  oneVusd: bigint;
+  oneUnit: bigint;
   queryClient: QueryClient;
 }) {
   const treasuryTokens = await queryClient.ensureQueryData(
@@ -31,7 +31,7 @@ const fetchTreasuryTotal = async function ({
           chainId,
           client,
           gatewayAddress,
-          peggedTokenIn: oneVusd,
+          peggedTokenIn: oneUnit,
           tokenOut: tokenAddress as Address,
         }),
       ),
@@ -42,7 +42,7 @@ const fetchTreasuryTotal = async function ({
   for (let i = 0; i < treasuryTokens.length; i++) {
     const rate = tokensPerVusd[i];
     if (rate > 0n) {
-      total += (BigInt(treasuryTokens[i].withdrawable) * oneVusd) / rate;
+      total += (BigInt(treasuryTokens[i].withdrawable) * oneUnit) / rate;
     }
   }
   return total;
@@ -57,11 +57,11 @@ export const fetchCollateralizationRatio = async function ({
 }) {
   const chainId = client.chain!.id;
   const gatewayAddress = getGatewayAddress(chainId);
-  const vusd = await queryClient.ensureQueryData(
+  const peggedToken = await queryClient.ensureQueryData(
     peggedTokenQueryOptions({ client, queryClient }),
   );
-  const { decimals } = vusd;
-  const oneVusd = 10n ** BigInt(decimals);
+  const { decimals } = peggedToken;
+  const oneUnit = 10n ** BigInt(decimals);
 
   const [backing, { vusdMinted }, treasuryTotal] = await Promise.all([
     queryClient.ensureQueryData(analyticsBackingVusdOptions()).then((b) => ({
@@ -73,7 +73,7 @@ export const fetchCollateralizationRatio = async function ({
       chainId,
       client,
       gatewayAddress,
-      oneVusd,
+      oneUnit,
       queryClient,
     }),
   ]);

--- a/web/src/fetchers/fetchCollateralizationRatio.ts
+++ b/web/src/fetchers/fetchCollateralizationRatio.ts
@@ -3,8 +3,8 @@ import { getGatewayAddress } from "@vetro-protocol/gateway";
 import { analyticsBackingVusdOptions } from "hooks/useAnalyticsBackingVusd";
 import { analyticsTotalsOptions } from "hooks/useAnalyticsTotals";
 import { analyticsTreasuryOptions } from "hooks/useAnalyticsTreasury";
+import { peggedTokenQueryOptions } from "hooks/usePeggedToken";
 import { previewRedeemTokenOptions } from "hooks/usePreviewRedeem";
-import { vusdOptions } from "hooks/useVusd";
 import { type Address, type Client, formatUnits } from "viem";
 
 // Converts treasury token holdings to VUSD using on-chain previewRedeem prices.
@@ -58,7 +58,7 @@ export const fetchCollateralizationRatio = async function ({
   const chainId = client.chain!.id;
   const gatewayAddress = getGatewayAddress(chainId);
   const vusd = await queryClient.ensureQueryData(
-    vusdOptions({ client, queryClient }),
+    peggedTokenQueryOptions({ client, queryClient }),
   );
   const { decimals } = vusd;
   const oneVusd = 10n ** BigInt(decimals);

--- a/web/src/hooks/useCancelRedeemRequest.ts
+++ b/web/src/hooks/useCancelRedeemRequest.ts
@@ -11,7 +11,7 @@ import { useAccount } from "wagmi";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { redeemRequestQueryKey } from "./useGetRedeemRequest";
 import { useMainnet } from "./useMainnet";
-import { useVusd } from "./useVusd";
+import { usePeggedToken } from "./usePeggedToken";
 
 export const useCancelRedeemRequest = function ({
   onEmitter,
@@ -29,9 +29,9 @@ export const useCancelRedeemRequest = function ({
   const updateNativeBalanceAfterReceipt = useUpdateNativeBalanceAfterReceipt(
     ethereumChain.id,
   );
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
 
-  const vusdBalanceQueryKey = tokenBalanceQueryKey(vusd, address);
+  const vusdBalanceQueryKey = tokenBalanceQueryKey(peggedToken, address);
 
   return useMutation({
     async mutationFn() {

--- a/web/src/hooks/useDeposit.ts
+++ b/web/src/hooks/useDeposit.ts
@@ -11,12 +11,12 @@ import { useAccount } from "wagmi";
 
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
+import { usePeggedToken } from "./usePeggedToken";
 import {
   previewDepositQueryKey,
   previewDepositTokenOptions,
 } from "./usePreviewDeposit";
 import { treasuryReservesQueryKey } from "./useTreasuryReserves";
-import { useVusd } from "./useVusd";
 
 export const useDeposit = function ({
   amountIn,
@@ -38,7 +38,7 @@ export const useDeposit = function ({
   const updateNativeBalanceAfterReceipt = useUpdateNativeBalanceAfterReceipt(
     ethereumChain.id,
   );
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
 
   const allowanceKey = allowanceQueryKey({
     owner: account,
@@ -59,7 +59,7 @@ export const useDeposit = function ({
     gatewayAddress,
   });
 
-  const vusdBalanceQueryKey = tokenBalanceQueryKey(vusd, account);
+  const vusdBalanceQueryKey = tokenBalanceQueryKey(peggedToken, account);
 
   return useMutation({
     async mutationFn() {

--- a/web/src/hooks/useInstantWithdraw.ts
+++ b/web/src/hooks/useInstantWithdraw.ts
@@ -10,8 +10,8 @@ import { useAccount } from "wagmi";
 
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
+import { usePeggedToken } from "./usePeggedToken";
 import { stakedBalanceQueryKey } from "./useStakedBalance";
-import { useVusd } from "./useVusd";
 
 type InstantWithdrawStatus = "completed" | "failed" | "withdrawing";
 
@@ -38,9 +38,9 @@ export const useInstantWithdraw = function ({
   const updateNativeBalanceAfterReceipt = useUpdateNativeBalanceAfterReceipt(
     chain.id,
   );
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
 
-  const vusdBalanceKey = tokenBalanceQueryKey(vusd, account);
+  const vusdBalanceKey = tokenBalanceQueryKey(peggedToken, account);
 
   const sharesBalanceKey = tokenBalanceQueryKey(
     { address: stakingVaultAddress, chainId: chain.id },

--- a/web/src/hooks/usePeggedToken.ts
+++ b/web/src/hooks/usePeggedToken.ts
@@ -11,9 +11,12 @@ import type { Chain, Client } from "viem";
 
 import { useEthereumClient } from "./useEthereumClient";
 
-const vusdQueryKey = (chainId: Chain["id"] | undefined) => ["vusd", chainId];
+const peggedTokenQueryKey = (chainId: Chain["id"] | undefined) => [
+  "vusd",
+  chainId,
+];
 
-export const vusdOptions = ({
+export const peggedTokenQueryOptions = ({
   client,
   queryClient,
 }: {
@@ -29,11 +32,11 @@ export const vusdOptions = ({
         gatewayAddress: getGatewayAddress(client!.chain!.id),
         queryClient,
       }),
-    queryKey: vusdQueryKey(client?.chain?.id),
+    queryKey: peggedTokenQueryKey(client?.chain?.id),
   });
 
-export const useVusd = function () {
+export const usePeggedToken = function () {
   const client = useEthereumClient();
   const queryClient = useQueryClient();
-  return useQuery(vusdOptions({ client, queryClient }));
+  return useQuery(peggedTokenQueryOptions({ client, queryClient }));
 };

--- a/web/src/hooks/useRedeem.ts
+++ b/web/src/hooks/useRedeem.ts
@@ -14,13 +14,13 @@ import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { redeemRequestQueryKey } from "./useGetRedeemRequest";
 import { useMainnet } from "./useMainnet";
 import { maxWithdrawQueryKey } from "./useMaxWithdraw";
+import { usePeggedToken } from "./usePeggedToken";
 import {
   previewRedeemQueryKey,
   previewRedeemTokenOptions,
 } from "./usePreviewRedeem";
 import { redeemDelayOptions } from "./useRedeemDelay";
 import { treasuryReservesQueryKey } from "./useTreasuryReserves";
-import { useVusd } from "./useVusd";
 
 export const useRedeem = function ({
   approveAmount,
@@ -45,7 +45,7 @@ export const useRedeem = function ({
     ethereumChain.id,
   );
 
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
 
   const requestQueryKey = redeemRequestQueryKey({
     address: account,
@@ -55,10 +55,10 @@ export const useRedeem = function ({
   const allowanceKey = allowanceQueryKey({
     owner: account,
     spender: gatewayAddress,
-    token: vusd,
+    token: peggedToken,
   });
 
-  const vusdBalanceQueryKey = tokenBalanceQueryKey(vusd, account);
+  const vusdBalanceQueryKey = tokenBalanceQueryKey(peggedToken, account);
 
   const treasuryReservesKey = treasuryReservesQueryKey({
     chainId: ethereumChain.id,

--- a/web/src/hooks/useRequestRedeem.ts
+++ b/web/src/hooks/useRequestRedeem.ts
@@ -12,7 +12,7 @@ import { useAccount } from "wagmi";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { redeemRequestQueryKey } from "./useGetRedeemRequest";
 import { useMainnet } from "./useMainnet";
-import { useVusd } from "./useVusd";
+import { usePeggedToken } from "./usePeggedToken";
 
 export const useRequestRedeem = function ({
   approveAmount,
@@ -29,9 +29,9 @@ export const useRequestRedeem = function ({
   const ethereumChain = useMainnet();
   const { queryKey: nativeBalanceKey } = useNativeBalance(ethereumChain.id);
   const queryClient = useQueryClient();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
 
-  const vusdBalanceQueryKey = tokenBalanceQueryKey(vusd, address);
+  const vusdBalanceQueryKey = tokenBalanceQueryKey(peggedToken, address);
 
   const updateNativeBalanceAfterReceipt = useUpdateNativeBalanceAfterReceipt(
     ethereumChain.id,

--- a/web/src/hooks/useStakeDeposit.ts
+++ b/web/src/hooks/useStakeDeposit.ts
@@ -74,7 +74,7 @@ export const useStakeDeposit = function ({
         throw new Error("No account connected");
       }
       if (!peggedToken) {
-        throw new Error("VUSD token not loaded");
+        throw new Error("Pegged Token not loaded");
       }
 
       await ensureConnectedTo(chain.id);

--- a/web/src/hooks/useStakeDeposit.ts
+++ b/web/src/hooks/useStakeDeposit.ts
@@ -11,8 +11,8 @@ import { useAccount } from "wagmi";
 
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
+import { usePeggedToken } from "./usePeggedToken";
 import { stakedBalanceQueryKey } from "./useStakedBalance";
-import { useVusd } from "./useVusd";
 
 type DepositStatus =
   | "approve-failed"
@@ -47,15 +47,15 @@ export const useStakeDeposit = function ({
   const updateNativeBalanceAfterReceipt = useUpdateNativeBalanceAfterReceipt(
     chain.id,
   );
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
 
   const allowanceKey = allowanceQueryKey({
     owner: account,
     spender: stakingVaultAddress,
-    token: { address: vusd?.address, chainId: chain.id },
+    token: { address: peggedToken?.address, chainId: chain.id },
   });
 
-  const vusdBalanceKey = tokenBalanceQueryKey(vusd, account);
+  const vusdBalanceKey = tokenBalanceQueryKey(peggedToken, account);
 
   const sharesBalanceKey = tokenBalanceQueryKey(
     { address: stakingVaultAddress, chainId: chain.id },
@@ -73,7 +73,7 @@ export const useStakeDeposit = function ({
       if (!account) {
         throw new Error("No account connected");
       }
-      if (!vusd) {
+      if (!peggedToken) {
         throw new Error("VUSD token not loaded");
       }
 
@@ -83,7 +83,7 @@ export const useStakeDeposit = function ({
         approveAmount,
         assets,
         receiver: account,
-        token: vusd.address,
+        token: peggedToken.address,
       });
 
       emitter.on("user-signed-approval", function () {

--- a/web/src/pages/analytics/index.tsx
+++ b/web/src/pages/analytics/index.tsx
@@ -3,8 +3,8 @@ import { StripedDivider } from "components/stripedDivider";
 import { useAnalyticsTotals } from "hooks/useAnalyticsTotals";
 import { useAnalyticsTreasury } from "hooks/useAnalyticsTreasury";
 import { useCollateralizationRatio } from "hooks/useCollateralizationRatio";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { useVariableStakeExitQueue } from "hooks/useVariableStakeExitQueue";
-import { useVusd } from "hooks/useVusd";
 import { useWhitelistedTokens } from "hooks/useWhitelistedTokens";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
@@ -84,7 +84,7 @@ export const Analytics = function () {
     isError: isExitQueueError,
     isLoading: isExitQueueLoading,
   } = useVariableStakeExitQueue();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
   const {
     data: whitelistedTokens,
     isError: isWhitelistedTokensError,
@@ -100,10 +100,12 @@ export const Analytics = function () {
   const isTokensError = isTreasuryError || isWhitelistedTokensError;
   const tokens = { treasuryTokens: treasury, whitelistedTokens };
 
-  const [tvlValue, stakedValue] = toTotalsValues(totals, vusd.decimals);
+  const [tvlValue, stakedValue] = toTotalsValues(totals, peggedToken.decimals);
 
   const exitQueueValue = exitQueue
-    ? formatUsd(Number(formatUnits(exitQueue.vusdInCooldown, vusd.decimals)))
+    ? formatUsd(
+        Number(formatUnits(exitQueue.vusdInCooldown, peggedToken.decimals)),
+      )
     : "";
 
   const yieldItems = toYieldItems(tokens);

--- a/web/src/pages/borrow.tsx
+++ b/web/src/pages/borrow.tsx
@@ -3,15 +3,17 @@ import { MarketsTable } from "components/borrow/marketsTable";
 import { PositionsTable } from "components/borrow/positionsTable";
 import { StripedDivider } from "components/stripedDivider";
 import { marketIds } from "constants/borrow";
-import { useVusd } from "hooks/useVusd";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { useTranslation } from "react-i18next";
 
 export const Borrow = function () {
   const { t } = useTranslation();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
   return (
     <>
-      <PageTitle value={t("pages.borrow.title", { symbol: vusd.symbol })} />
+      <PageTitle
+        value={t("pages.borrow.title", { symbol: peggedToken.symbol })}
+      />
       <MarketsTable marketIds={marketIds} />
       <div className="w-full border-b border-gray-200 bg-gray-100">
         <StripedDivider />

--- a/web/src/pages/earn/components/earnStats/index.tsx
+++ b/web/src/pages/earn/components/earnStats/index.tsx
@@ -1,9 +1,9 @@
 import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
 import { getStakingVaultAddress } from "@vetro-protocol/earn";
 import { useMainnet } from "hooks/useMainnet";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { useStakedBalance } from "hooks/useStakedBalance";
 import { useSvusd } from "hooks/useSvusd";
-import { useVusd } from "hooks/useVusd";
 import { useTranslation } from "react-i18next";
 import { formatUnits } from "viem";
 
@@ -17,7 +17,7 @@ export function EarnStats() {
   const chain = useMainnet();
   const stakingVaultAddress = getStakingVaultAddress(chain.id);
   const { data: svusd } = useSvusd();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
 
   const { data: stakedBalance, isLoading: isLoadingStakedBalance } =
     useStakedBalance();
@@ -26,8 +26,8 @@ export function EarnStats() {
     useTokenBalance({ address: stakingVaultAddress, chainId: chain.id });
 
   const formatStakedBalance = function () {
-    if (stakedBalance !== undefined && vusd) {
-      return `${formatUnits(stakedBalance, vusd.decimals)} ${vusd.symbol}`;
+    if (stakedBalance !== undefined && peggedToken) {
+      return `${formatUnits(stakedBalance, peggedToken.decimals)} ${peggedToken.symbol}`;
     }
     return "";
   };

--- a/web/src/pages/earn/components/exitTickets/actionsCell.tsx
+++ b/web/src/pages/earn/components/exitTickets/actionsCell.tsx
@@ -4,7 +4,7 @@ import { Toast } from "components/base/toast";
 import { Tooltip } from "components/tooltip";
 import { useActivityTracking } from "hooks/useActivityTracking";
 import { useClaimWithdraw } from "hooks/useClaimWithdraw";
-import { useVusd } from "hooks/useVusd";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { TrashIcon } from "pages/earn/icons/trashIcon";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -74,7 +74,7 @@ export function ActionsCell({
 }: Props) {
   const { t } = useTranslation();
   const { openConnectModal } = useConnectModal();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
   const status = getTicketStatus(ticket);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isWithdrawing, setIsWithdrawing] = useState(false);
@@ -82,7 +82,7 @@ export function ActionsCell({
 
   const formattedAmount = formatAmount({
     amount: BigInt(ticket.assets),
-    decimals: vusd?.decimals ?? 18,
+    decimals: peggedToken?.decimals ?? 18,
     isError: false,
   });
 
@@ -91,7 +91,7 @@ export function ActionsCell({
       page: "earn",
       text: t("pages.earn.activity.claim-withdraw-text", {
         amount: formattedAmount,
-        symbol: vusd?.symbol,
+        symbol: peggedToken?.symbol,
       }),
       title: `${t("nav.earn")} · ${t("pages.earn.exit-tickets.withdraw")}`,
     });

--- a/web/src/pages/earn/components/exitTickets/deleteTicketModal.tsx
+++ b/web/src/pages/earn/components/exitTickets/deleteTicketModal.tsx
@@ -3,7 +3,7 @@ import { Button } from "components/base/button";
 import { Modal } from "components/base/modal";
 import { useActivityTracking } from "hooks/useActivityTracking";
 import { useCancelWithdraw } from "hooks/useCancelWithdraw";
-import { useVusd } from "hooks/useVusd";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { formatAmount } from "utils/token";
@@ -21,12 +21,12 @@ export function DeleteTicketModal({ onClose, onSuccess, ticket }: Props) {
   const { t } = useTranslation();
   const { isConnected } = useAccount();
   const { openConnectModal } = useConnectModal();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
   const [isDeleting, setIsDeleting] = useState(false);
 
   const formattedAmount = formatAmount({
     amount: BigInt(ticket.assets),
-    decimals: vusd?.decimals ?? 18,
+    decimals: peggedToken?.decimals ?? 18,
     isError: false,
   });
 
@@ -35,7 +35,7 @@ export function DeleteTicketModal({ onClose, onSuccess, ticket }: Props) {
       page: "earn",
       text: t("pages.earn.activity.cancel-withdraw-text", {
         amount: formattedAmount,
-        symbol: vusd?.symbol,
+        symbol: peggedToken?.symbol,
       }),
       title: `${t("nav.earn")} · ${t("pages.earn.exit-tickets.delete-title")}`,
     });

--- a/web/src/pages/earn/components/exitTickets/withdrawalCell.tsx
+++ b/web/src/pages/earn/components/exitTickets/withdrawalCell.tsx
@@ -1,4 +1,4 @@
-import { useVusd } from "hooks/useVusd";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { useTranslation } from "react-i18next";
 import { formatAmount } from "utils/token";
 
@@ -10,10 +10,10 @@ type Props = {
 
 export function WithdrawalCell({ ticket }: Props) {
   const { t } = useTranslation();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
   const amount = formatAmount({
     amount: BigInt(ticket.assets),
-    decimals: vusd?.decimals ?? 18,
+    decimals: peggedToken?.decimals ?? 18,
     isError: false,
   });
 

--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -1,9 +1,9 @@
 import { getStakingVaultAddress } from "@vetro-protocol/earn";
 import { useApy } from "hooks/useApy";
 import { useMainnet } from "hooks/useMainnet";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { usePoolDeposits } from "hooks/usePoolDeposits";
 import { useUserRewards } from "hooks/useUserRewards";
-import { useVusd } from "hooks/useVusd";
 import { useTranslation } from "react-i18next";
 import { formatUsd } from "utils/currency";
 import { formatEvmAddress } from "utils/format";
@@ -17,7 +17,7 @@ export function PoolInfoBar() {
   const { t } = useTranslation();
   const chain = useMainnet();
   const stakingVaultAddress = getStakingVaultAddress(chain.id);
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
 
   const { data: apy, isLoading: isLoadingApy } = useApy();
   const { data: poolDeposits, isLoading: isLoadingDeposits } =
@@ -30,8 +30,8 @@ export function PoolInfoBar() {
     })) ?? [];
 
   function formatPoolDeposits() {
-    if (poolDeposits !== undefined && vusd) {
-      const formatted = Number(formatUnits(poolDeposits, vusd.decimals));
+    if (poolDeposits !== undefined && peggedToken) {
+      const formatted = Number(formatUnits(poolDeposits, peggedToken.decimals));
       return formatUsd(formatted);
     }
     return undefined;

--- a/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
@@ -16,9 +16,9 @@ import { Balance } from "components/tokenInput/balance";
 import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
 import { useActivityTracking } from "hooks/useActivityTracking";
 import { useMainnet } from "hooks/useMainnet";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { useStakeDeposit } from "hooks/useStakeDeposit";
 import { useSvusd } from "hooks/useSvusd";
-import { useVusd } from "hooks/useVusd";
 import { useTotalDepositFees } from "pages/earn/hooks/useTotalDepositFees";
 import { type FormEvent, useCallback } from "react";
 import { useTranslation } from "react-i18next";
@@ -169,7 +169,7 @@ export function StakeDepositForm({
   const { openConnectModal } = useConnectModal();
   const { t } = useTranslation();
   const { data: svusd } = useSvusd();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
   const { mutate: watchToken } = useAddTokenToWallet({
     token: {
       address: svusd!.address,
@@ -180,7 +180,7 @@ export function StakeDepositForm({
   const stakingVaultAddress = getStakingVaultAddress(chain.id);
 
   const { data: vusdBalance, isError: isVusdBalanceError } = useTokenBalance({
-    address: vusd?.address,
+    address: peggedToken?.address,
     chainId: chain.id,
   });
 
@@ -190,10 +190,12 @@ export function StakeDepositForm({
   const { data: currentAllowance } = useAllowance({
     owner: account,
     spender: stakingVaultAddress,
-    token: vusd,
+    token: peggedToken,
   });
 
-  const amountBigInt = vusd ? parseUnits(inputValue, vusd.decimals) : 0n;
+  const amountBigInt = peggedToken
+    ? parseUnits(inputValue, peggedToken.decimals)
+    : 0n;
 
   const needsApproval =
     currentAllowance !== undefined && currentAllowance < amountBigInt;
@@ -205,7 +207,7 @@ export function StakeDepositForm({
       page: "earn",
       text: t("pages.earn.activity.deposit-text", {
         amount: inputValue,
-        symbol: vusd?.symbol,
+        symbol: peggedToken?.symbol,
       }),
       title: `${t("nav.earn")} · ${t("pages.earn.stake.deposit")}`,
     });
@@ -245,7 +247,7 @@ export function StakeDepositForm({
   const depositFeesQuery = useTotalDepositFees({
     amount: amountBigInt,
     approveAmount,
-    token: vusd,
+    token: peggedToken,
   });
 
   const inputError = getStakeErrors({
@@ -256,7 +258,7 @@ export function StakeDepositForm({
 
   const formattedBalance = formatAmount({
     amount: vusdBalance,
-    decimals: vusd.decimals,
+    decimals: peggedToken.decimals,
     isError: isVusdBalanceError,
   });
 
@@ -294,13 +296,15 @@ export function StakeDepositForm({
             />
           }
           errorKey={balancesLoaded ? inputError : undefined}
-          fiatValue={<RenderFiatValue token={vusd} value={amountBigInt} />}
+          fiatValue={
+            <RenderFiatValue token={peggedToken} value={amountBigInt} />
+          }
           label={t("pages.earn.stake.you-will-stake")}
           maxButton={
-            <SetMaxErc20Balance onClick={handleMaxClick} token={vusd!} />
+            <SetMaxErc20Balance onClick={handleMaxClick} token={peggedToken!} />
           }
           onChange={onInputChange}
-          tokenSelector={<TokenSelectorReadOnly {...vusd} />}
+          tokenSelector={<TokenSelectorReadOnly {...peggedToken} />}
           value={inputValue}
         />
       </div>
@@ -324,7 +328,7 @@ export function StakeDepositForm({
           <NetworkFees
             label={t("pages.earn.stake.fees-label", {
               amount: inputValue,
-              token: vusd.symbol,
+              token: peggedToken.symbol,
             })}
             networkFee={depositFeesQuery}
             sectionClassName="px-6"

--- a/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
@@ -11,9 +11,9 @@ import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
 import { useActivityTracking } from "hooks/useActivityTracking";
 import { useInstantWithdraw } from "hooks/useInstantWithdraw";
 import { useMainnet } from "hooks/useMainnet";
+import { usePeggedToken } from "hooks/usePeggedToken";
 import { useStakedBalance } from "hooks/useStakedBalance";
 import { useStakeWithdraw } from "hooks/useStakeWithdraw";
-import { useVusd } from "hooks/useVusd";
 import { useCanInstantWithdraw } from "pages/earn/hooks/useCanInstantWithdraw";
 import { useCooldownDuration } from "pages/earn/hooks/useCooldownDuration";
 import { useTotalWithdrawFees } from "pages/earn/hooks/useTotalWithdrawFees";
@@ -139,13 +139,13 @@ export function StakeWithdrawForm({
   const { data: cooldownDays } = useCooldownDuration();
   const { openConnectModal } = useConnectModal();
   const { t } = useTranslation();
-  const { data: vusd } = useVusd();
+  const { data: peggedToken } = usePeggedToken();
 
   const instantTracking = useActivityTracking({
     page: "earn",
     text: t("pages.earn.activity.instant-withdraw-text", {
       amount: inputValue,
-      symbol: vusd?.symbol,
+      symbol: peggedToken?.symbol,
     }),
     title: `${t("nav.earn")} · ${t("pages.earn.stake.instant-withdraw")}`,
   });
@@ -154,7 +154,7 @@ export function StakeWithdrawForm({
     page: "earn",
     text: t("pages.earn.activity.request-withdraw-text", {
       amount: inputValue,
-      symbol: vusd?.symbol,
+      symbol: peggedToken?.symbol,
     }),
     title: `${t("nav.earn")} · ${t("pages.earn.stake.withdraw")}`,
   });
@@ -167,7 +167,9 @@ export function StakeWithdrawForm({
   const { data: nativeBalanceData } = useNativeBalance(chain.id);
   const nativeBalance = nativeBalanceData?.value;
 
-  const amountBigInt = vusd ? parseUnits(inputValue, vusd.decimals) : 0n;
+  const amountBigInt = peggedToken
+    ? parseUnits(inputValue, peggedToken.decimals)
+    : 0n;
 
   const handleRequestWithdrawSuccess = function () {
     onSuccess({
@@ -230,7 +232,7 @@ export function StakeWithdrawForm({
 
   const formattedBalance = formatAmount({
     amount: stakedBalance,
-    decimals: vusd?.decimals ?? 18,
+    decimals: peggedToken?.decimals ?? 18,
     isError: isStakedBalanceError,
   });
 
@@ -266,16 +268,18 @@ export function StakeWithdrawForm({
             />
           }
           errorKey={balancesLoaded ? inputError : undefined}
-          fiatValue={<RenderFiatValue token={vusd} value={amountBigInt} />}
+          fiatValue={
+            <RenderFiatValue token={peggedToken} value={amountBigInt} />
+          }
           label={t("pages.earn.stake.you-will-withdraw")}
           maxButton={
             <SetMaxStakedBalance
-              decimals={vusd!.decimals}
+              decimals={peggedToken!.decimals}
               onClick={handleMaxClick}
             />
           }
           onChange={onInputChange}
-          tokenSelector={<TokenSelectorReadOnly {...vusd} />}
+          tokenSelector={<TokenSelectorReadOnly {...peggedToken} />}
           value={inputValue}
         />
       </div>
@@ -304,7 +308,7 @@ export function StakeWithdrawForm({
           <NetworkFees
             label={t("pages.earn.stake.withdrawing-fees-label", {
               amount: inputValue,
-              token: vusd.symbol,
+              token: peggedToken.symbol,
             })}
             networkFee={withdrawFeesQuery}
             sectionClassName="px-6"

--- a/web/test/fetchers/fetchCollateralizationRatio.test.ts
+++ b/web/test/fetchers/fetchCollateralizationRatio.test.ts
@@ -1,8 +1,8 @@
 import { analyticsBackingVusdOptions } from "hooks/useAnalyticsBackingVusd";
 import { analyticsTotalsOptions } from "hooks/useAnalyticsTotals";
 import { analyticsTreasuryOptions } from "hooks/useAnalyticsTreasury";
+import { peggedTokenQueryOptions } from "hooks/usePeggedToken";
 import { previewRedeemTokenOptions } from "hooks/usePreviewRedeem";
-import { vusdOptions } from "hooks/useVusd";
 import type { Client } from "viem";
 import { describe, expect, it, vi } from "vitest";
 
@@ -29,8 +29,8 @@ vi.mock("hooks/usePreviewRedeem", () => ({
   previewRedeemTokenOptions: vi.fn(),
 }));
 
-vi.mock("hooks/useVusd", () => ({
-  vusdOptions: vi.fn(),
+vi.mock("hooks/usePeggedToken", () => ({
+  peggedTokenQueryOptions: vi.fn(),
 }));
 
 const mockClient = { chain: { id: 1 } } as unknown as Client;
@@ -52,7 +52,7 @@ const setupMocks = function ({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(fn as any).mockReturnValue({ queryFn, queryKey });
 
-  mock(vusdOptions, () => vusd, ["vusd"]);
+  mock(peggedTokenQueryOptions, () => vusd, ["vusd"]);
   mock(analyticsBackingVusdOptions, () => backing, ["analytics-backing-vusd"]);
   mock(analyticsTotalsOptions, () => totals, ["analytics-totals"]);
   mock(analyticsTreasuryOptions, () => treasury, ["analytics-treasury"]);


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This is the first PR of a series of changes to add support for multiple pegged tokens.

This PR renames the `useVusd` to `usePeggedToken` and replaces the variable `vusd` to `peggedToken`. Next PR will be removing the hardcoded data of `vusd` and handling loading instances, so we can add support for a new Gateway, Treasury, etc for `veBTC`

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #239

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
