### PR TITLE
Accept gatewayAddress as parameter in wallet actions

### DIFF
--- a/packages/gateway/src/actions/wallet/cancelRedeemRequest.ts
+++ b/packages/gateway/src/actions/wallet/cancelRedeemRequest.ts
@@ -1,20 +1,29 @@
 import { EventEmitter } from "events";
 import { toPromiseEvent } from "to-promise-event";
 import {
+  type Address,
   type TransactionReceipt,
   type WalletClient,
   encodeFunctionData,
+  isAddress,
+  isAddressEqual,
+  zeroAddress,
 } from "viem";
 import { waitForTransactionReceipt, writeContract } from "viem/actions";
 
 import { gatewayAbi } from "../../abi/gatewayAbi.js";
-import { getGatewayAddress } from "../../getGatewayAddress.js";
 import type { CancelRedeemRequestEvents } from "../../types.js";
+
+export type CancelRedeemRequestParams = {
+  gatewayAddress: Address;
+};
 
 const canCancelRedeemRequest = function ({
   client,
+  gatewayAddress,
 }: {
   client: WalletClient;
+  gatewayAddress: Address;
 }): {
   canCancelRedeemRequest: boolean;
   reason?: string;
@@ -37,25 +46,39 @@ const canCancelRedeemRequest = function ({
       reason: "Client must have an account",
     };
   }
+  // Validate gateway address
+  if (!gatewayAddress || !isAddress(gatewayAddress)) {
+    return {
+      canCancelRedeemRequest: false,
+      reason: "Invalid gateway address",
+    };
+  }
+  if (isAddressEqual(gatewayAddress, zeroAddress)) {
+    return {
+      canCancelRedeemRequest: false,
+      reason: "Gateway address cannot be zero address",
+    };
+  }
 
   return { canCancelRedeemRequest: true };
 };
 
-const runCancelRedeemRequest = (walletClient: WalletClient) =>
+const runCancelRedeemRequest = (
+  walletClient: WalletClient,
+  { gatewayAddress }: CancelRedeemRequestParams,
+) =>
   async function (emitter: EventEmitter<CancelRedeemRequestEvents>) {
     try {
       const { canCancelRedeemRequest: canCancelRedeemRequestFlag, reason } =
         canCancelRedeemRequest({
           client: walletClient,
+          gatewayAddress,
         });
 
       if (!canCancelRedeemRequestFlag) {
         emitter.emit("cancel-redeem-request-failed-validation", reason!);
         return;
       }
-
-      // already validated
-      const gatewayAddress = getGatewayAddress(walletClient.chain!.id);
 
       emitter.emit("pre-cancel-redeem-request");
 

--- a/packages/gateway/src/actions/wallet/deposit.ts
+++ b/packages/gateway/src/actions/wallet/deposit.ts
@@ -13,12 +13,12 @@ import { waitForTransactionReceipt, writeContract } from "viem/actions";
 import { allowance, approve } from "viem-erc20/actions";
 
 import { gatewayAbi } from "../../abi/gatewayAbi.js";
-import { getGatewayAddress } from "../../getGatewayAddress.js";
 import type { DepositEvents } from "../../types.js";
 
 export type DepositParams = {
   amountIn: bigint;
   approveAmount?: bigint;
+  gatewayAddress: Address;
   minPeggedTokenOut: bigint;
   receiver: Address;
   tokenIn: Address;
@@ -28,6 +28,7 @@ const canDeposit = function ({
   amountIn,
   approveAmount,
   client,
+  gatewayAddress,
   minPeggedTokenOut,
   receiver,
   tokenIn,
@@ -35,6 +36,7 @@ const canDeposit = function ({
   amountIn: bigint;
   approveAmount: bigint;
   client: WalletClient;
+  gatewayAddress: Address;
   minPeggedTokenOut: bigint;
   receiver: Address;
   tokenIn: Address;
@@ -60,6 +62,19 @@ const canDeposit = function ({
     return {
       canDeposit: false,
       reason: "Client must have an account",
+    };
+  }
+  // Validate gateway address
+  if (!gatewayAddress || !isAddress(gatewayAddress)) {
+    return {
+      canDeposit: false,
+      reason: "Invalid gateway address",
+    };
+  }
+  if (isAddressEqual(gatewayAddress, zeroAddress)) {
+    return {
+      canDeposit: false,
+      reason: "Gateway address cannot be zero address",
     };
   }
   // Validate tokenIn address
@@ -134,6 +149,7 @@ const runDeposit = (
   {
     amountIn,
     approveAmount = amountIn,
+    gatewayAddress,
     minPeggedTokenOut,
     receiver,
     tokenIn,
@@ -145,6 +161,7 @@ const runDeposit = (
         amountIn,
         approveAmount,
         client: walletClient,
+        gatewayAddress,
         minPeggedTokenOut,
         receiver,
         tokenIn,
@@ -154,9 +171,6 @@ const runDeposit = (
         emitter.emit("deposit-failed-validation", reason!);
         return;
       }
-
-      // already validated
-      const gatewayAddress = getGatewayAddress(walletClient.chain!.id);
 
       // Check current allowance
       const currentAllowance = await allowance(walletClient, {
@@ -255,7 +269,7 @@ export const encodeDeposit = ({
   minPeggedTokenOut,
   receiver,
   tokenIn,
-}: DepositParams) =>
+}: Omit<DepositParams, "gatewayAddress">) =>
   encodeFunctionData({
     abi: gatewayAbi,
     args: [tokenIn, amountIn, minPeggedTokenOut, receiver],

--- a/packages/gateway/src/actions/wallet/redeem.ts
+++ b/packages/gateway/src/actions/wallet/redeem.ts
@@ -13,7 +13,6 @@ import { waitForTransactionReceipt, writeContract } from "viem/actions";
 import { allowance, approve } from "viem-erc20/actions";
 
 import { gatewayAbi } from "../../abi/gatewayAbi.js";
-import { getGatewayAddress } from "../../getGatewayAddress.js";
 import type { RedeemEvents } from "../../types.js";
 import { getMaxWithdraw } from "../public/getMaxWithdraw.js";
 import { getPeggedToken } from "../public/getPeggedToken.js";
@@ -22,6 +21,7 @@ import { isInstantRedeemWhitelisted } from "../public/isInstantRedeemWhitelisted
 
 export type RedeemParams = {
   approveAmount?: bigint;
+  gatewayAddress: Address;
   minAmountOut: bigint;
   peggedTokenIn: bigint;
   receiver: Address;
@@ -31,6 +31,7 @@ export type RedeemParams = {
 const canRedeem = async function ({
   approveAmount,
   client,
+  gatewayAddress,
   minAmountOut,
   peggedTokenIn,
   receiver,
@@ -38,6 +39,7 @@ const canRedeem = async function ({
 }: {
   approveAmount: bigint;
   client: WalletClient;
+  gatewayAddress: Address;
   minAmountOut: bigint;
   peggedTokenIn: bigint;
   receiver: Address;
@@ -64,6 +66,19 @@ const canRedeem = async function ({
     return {
       canRedeem: false,
       reason: "Client must have an account",
+    };
+  }
+  // Validate gateway address
+  if (!gatewayAddress || !isAddress(gatewayAddress)) {
+    return {
+      canRedeem: false,
+      reason: "Invalid gateway address",
+    };
+  }
+  if (isAddressEqual(gatewayAddress, zeroAddress)) {
+    return {
+      canRedeem: false,
+      reason: "Gateway address cannot be zero address",
     };
   }
   // Validate tokenOut address
@@ -130,7 +145,6 @@ const canRedeem = async function ({
   }
 
   // Check treasury has enough balance for the requested token
-  const gatewayAddress = getGatewayAddress(client.chain.id);
   const maxWithdrawable = await getMaxWithdraw(client, {
     address: gatewayAddress,
     tokenOut,
@@ -149,18 +163,21 @@ const canRedeem = async function ({
 const runRedeem = (
   walletClient: WalletClient,
   {
+    approveAmount,
+    gatewayAddress,
     minAmountOut,
     peggedTokenIn,
-    approveAmount = peggedTokenIn,
     receiver,
     tokenOut,
   }: RedeemParams,
 ) =>
   async function (emitter: EventEmitter<RedeemEvents>) {
+    const resolvedApproveAmount = approveAmount ?? peggedTokenIn;
     try {
       const { canRedeem: canRedeemFlag, reason } = await canRedeem({
-        approveAmount,
+        approveAmount: resolvedApproveAmount,
         client: walletClient,
+        gatewayAddress,
         minAmountOut,
         peggedTokenIn,
         receiver,
@@ -171,9 +188,6 @@ const runRedeem = (
         emitter.emit("redeem-failed-validation", reason!);
         return;
       }
-
-      // already validated
-      const gatewayAddress = getGatewayAddress(walletClient.chain!.id);
 
       // Check if user is whitelisted for instant redeem
       const [isWhitelisted, delayEnabled] = await Promise.all([
@@ -207,7 +221,7 @@ const runRedeem = (
 
           const approvalHash = await approve(walletClient, {
             address: peggedTokenAddress,
-            amount: approveAmount,
+            amount: resolvedApproveAmount,
             spender: gatewayAddress,
           }).catch(function (error: Error) {
             emitter.emit("user-signing-approval-error", error);

--- a/packages/gateway/src/actions/wallet/requestRedeem.ts
+++ b/packages/gateway/src/actions/wallet/requestRedeem.ts
@@ -1,30 +1,36 @@
 import { EventEmitter } from "events";
 import { toPromiseEvent } from "to-promise-event";
 import {
+  type Address,
   type TransactionReceipt,
   type WalletClient,
   encodeFunctionData,
+  isAddress,
+  isAddressEqual,
+  zeroAddress,
 } from "viem";
 import { waitForTransactionReceipt, writeContract } from "viem/actions";
 import { allowance, approve } from "viem-erc20/actions";
 
 import { gatewayAbi } from "../../abi/gatewayAbi.js";
-import { getGatewayAddress } from "../../getGatewayAddress.js";
 import type { RequestRedeemEvents } from "../../types.js";
 import { getPeggedToken } from "../public/getPeggedToken.js";
 
 export type RequestRedeemParams = {
   approveAmount?: bigint;
+  gatewayAddress: Address;
   peggedTokenAmount: bigint;
 };
 
 const canRequestRedeem = function ({
   approveAmount,
   client,
+  gatewayAddress,
   peggedTokenAmount,
 }: {
   approveAmount: bigint;
   client: WalletClient;
+  gatewayAddress: Address;
   peggedTokenAmount: bigint;
 }): {
   canRequestRedeem: boolean;
@@ -46,6 +52,19 @@ const canRequestRedeem = function ({
     return {
       canRequestRedeem: false,
       reason: "Client must have an account",
+    };
+  }
+  // Validate gateway address
+  if (!gatewayAddress || !isAddress(gatewayAddress)) {
+    return {
+      canRequestRedeem: false,
+      reason: "Invalid gateway address",
+    };
+  }
+  if (isAddressEqual(gatewayAddress, zeroAddress)) {
+    return {
+      canRequestRedeem: false,
+      reason: "Gateway address cannot be zero address",
     };
   }
 
@@ -75,7 +94,7 @@ const canRequestRedeem = function ({
 
 const runRequestRedeem = (
   walletClient: WalletClient,
-  { approveAmount, peggedTokenAmount }: RequestRedeemParams,
+  { approveAmount, gatewayAddress, peggedTokenAmount }: RequestRedeemParams,
 ) =>
   async function (emitter: EventEmitter<RequestRedeemEvents>) {
     const resolvedApproveAmount = approveAmount ?? peggedTokenAmount;
@@ -84,6 +103,7 @@ const runRequestRedeem = (
         canRequestRedeem({
           approveAmount: resolvedApproveAmount,
           client: walletClient,
+          gatewayAddress,
           peggedTokenAmount,
         });
 
@@ -91,9 +111,6 @@ const runRequestRedeem = (
         emitter.emit("request-redeem-failed-validation", reason!);
         return;
       }
-
-      // already validated
-      const gatewayAddress = getGatewayAddress(walletClient.chain!.id);
 
       // Get the pegged token address
       const peggedTokenAddress = await getPeggedToken(walletClient, {

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -13,7 +13,10 @@ import {
   previewDeposit,
   previewRedeem,
 } from "./actions/public/index.js";
-import { cancelRedeemRequest } from "./actions/wallet/cancelRedeemRequest.js";
+import {
+  type CancelRedeemRequestParams,
+  cancelRedeemRequest,
+} from "./actions/wallet/cancelRedeemRequest.js";
 import { type DepositParams, deposit } from "./actions/wallet/deposit.js";
 import { type RedeemParams, redeem } from "./actions/wallet/redeem.js";
 import {
@@ -25,6 +28,8 @@ import {
 export { gatewayAbi } from "./abi/gatewayAbi.js";
 // Export gateway address utility
 export { getGatewayAddress } from "./getGatewayAddress.js";
+
+export type { CancelRedeemRequestParams };
 
 export {
   type CancelRedeemRequestEvents,
@@ -62,7 +67,8 @@ export const gatewayPublicActions = () => (client: Client) => ({
 });
 
 export const gatewayWalletActions = () => (client: WalletClient) => ({
-  cancelRedeemRequest: () => cancelRedeemRequest(client),
+  cancelRedeemRequest: (params: CancelRedeemRequestParams) =>
+    cancelRedeemRequest(client, params),
   deposit: (params: DepositParams) => deposit(client, params),
   redeem: (params: RedeemParams) => redeem(client, params),
   requestRedeem: (params: RequestRedeemParams) => requestRedeem(client, params),

--- a/packages/gateway/test/wallet/cancelRedeemRequest.test.ts
+++ b/packages/gateway/test/wallet/cancelRedeemRequest.test.ts
@@ -1,4 +1,5 @@
 import {
+  type Address,
   type TransactionReceipt,
   type WalletClient,
   zeroAddress,
@@ -15,19 +16,27 @@ vi.mock("viem/actions", () => ({
   writeContract: vi.fn(),
 }));
 
+const mockGatewayAddress =
+  "0x3333333333333333333333333333333333333333" as Address;
+
 // @ts-expect-error - mock client
 const mockWalletClient = {
   account: {
-    address: zeroAddress,
+    address: "0x1111111111111111111111111111111111111111" as Address,
   },
   chain: sepolia,
 } as WalletClient;
+
+const validParameters = {
+  gatewayAddress: mockGatewayAddress,
+};
 
 describe("cancelRedeemRequest", function () {
   it("should emit 'cancel-redeem-request-failed-validation' if client is not defined", async function () {
     const { emitter, promise } = cancelRedeemRequest(
       // @ts-expect-error - Testing invalid input
       undefined,
+      validParameters,
     );
 
     const onFailedValidation = vi.fn();
@@ -49,7 +58,10 @@ describe("cancelRedeemRequest", function () {
       account: mockWalletClient.account,
     } as WalletClient;
 
-    const { emitter, promise } = cancelRedeemRequest(clientWithoutChain);
+    const { emitter, promise } = cancelRedeemRequest(
+      clientWithoutChain,
+      validParameters,
+    );
 
     const onFailedValidation = vi.fn();
     const onSettled = vi.fn();
@@ -71,7 +83,10 @@ describe("cancelRedeemRequest", function () {
       chain: sepolia,
     } as WalletClient;
 
-    const { emitter, promise } = cancelRedeemRequest(clientWithoutAccount);
+    const { emitter, promise } = cancelRedeemRequest(
+      clientWithoutAccount,
+      validParameters,
+    );
 
     const onFailedValidation = vi.fn();
     const onSettled = vi.fn();
@@ -87,10 +102,52 @@ describe("cancelRedeemRequest", function () {
     expect(onSettled).toHaveBeenCalledOnce();
   });
 
+  it("should emit 'cancel-redeem-request-failed-validation' if gateway address is not valid", async function () {
+    const { emitter, promise } = cancelRedeemRequest(mockWalletClient, {
+      // @ts-expect-error - Testing invalid input
+      gatewayAddress: "invalid_gateway",
+    });
+
+    const onFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("cancel-redeem-request-failed-validation", onFailedValidation);
+    emitter.on("cancel-redeem-request-settled", onSettled);
+
+    await promise;
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Invalid gateway address",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'cancel-redeem-request-failed-validation' if gateway address is zero address", async function () {
+    const { emitter, promise } = cancelRedeemRequest(mockWalletClient, {
+      gatewayAddress: zeroAddress,
+    });
+
+    const onFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("cancel-redeem-request-failed-validation", onFailedValidation);
+    emitter.on("cancel-redeem-request-settled", onSettled);
+
+    await promise;
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Gateway address cannot be zero address",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
   it("should emit 'user-signing-cancel-redeem-request-error' when signing fails", async function () {
     vi.mocked(writeContract).mockRejectedValue(new Error("Signing error"));
 
-    const { emitter, promise } = cancelRedeemRequest(mockWalletClient);
+    const { emitter, promise } = cancelRedeemRequest(
+      mockWalletClient,
+      validParameters,
+    );
 
     const onPreCancel = vi.fn();
     const onSigningError = vi.fn();
@@ -113,7 +170,10 @@ describe("cancelRedeemRequest", function () {
       new Error("Receipt error"),
     );
 
-    const { emitter, promise } = cancelRedeemRequest(mockWalletClient);
+    const { emitter, promise } = cancelRedeemRequest(
+      mockWalletClient,
+      validParameters,
+    );
 
     const onPreCancel = vi.fn();
     const onUserSigned = vi.fn();
@@ -141,7 +201,10 @@ describe("cancelRedeemRequest", function () {
     vi.mocked(writeContract).mockResolvedValue(zeroHash);
     vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt);
 
-    const { emitter, promise } = cancelRedeemRequest(mockWalletClient);
+    const { emitter, promise } = cancelRedeemRequest(
+      mockWalletClient,
+      validParameters,
+    );
 
     const onPreCancel = vi.fn();
     const onUserSigned = vi.fn();
@@ -172,7 +235,10 @@ describe("cancelRedeemRequest", function () {
     vi.mocked(writeContract).mockResolvedValue(zeroHash);
     vi.mocked(waitForTransactionReceipt).mockResolvedValue(receipt);
 
-    const { emitter, promise } = cancelRedeemRequest(mockWalletClient);
+    const { emitter, promise } = cancelRedeemRequest(
+      mockWalletClient,
+      validParameters,
+    );
 
     const onPreCancel = vi.fn();
     const onUserSigned = vi.fn();
@@ -198,7 +264,10 @@ describe("cancelRedeemRequest", function () {
       throw new Error("Unexpected");
     });
 
-    const { emitter, promise } = cancelRedeemRequest(mockWalletClient);
+    const { emitter, promise } = cancelRedeemRequest(
+      mockWalletClient,
+      validParameters,
+    );
 
     const onUnexpectedError = vi.fn();
     const onSettled = vi.fn();

--- a/packages/gateway/test/wallet/deposit.test.ts
+++ b/packages/gateway/test/wallet/deposit.test.ts
@@ -29,8 +29,12 @@ const mockWalletClient = {
   chain: sepolia,
 } as unknown as WalletClient;
 
+const mockGatewayAddress =
+  "0x3333333333333333333333333333333333333333" as Address;
+
 const validParameters = {
   amountIn: BigInt(1000),
+  gatewayAddress: mockGatewayAddress,
   minPeggedTokenOut: BigInt(900),
   receiver: "0x2222222222222222222222222222222222222222" as Address,
   tokenIn: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" as Address,
@@ -96,6 +100,54 @@ describe("deposit", function () {
 
     expect(onDepositFailedValidation).toHaveBeenCalledExactlyOnceWith(
       "Chain is not defined on wallet client",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'deposit-failed-validation' if gateway address is not valid", async function () {
+    const parameters = {
+      ...validParameters,
+      gatewayAddress: "invalid_gateway",
+    };
+
+    const { emitter, promise } = deposit(
+      mockWalletClient,
+      // @ts-expect-error - Testing invalid input
+      parameters,
+    );
+
+    const onDepositFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("deposit-failed-validation", onDepositFailedValidation);
+    emitter.on("deposit-settled", onSettled);
+
+    await promise;
+
+    expect(onDepositFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Invalid gateway address",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'deposit-failed-validation' if gateway address is zero address", async function () {
+    const parameters = {
+      ...validParameters,
+      gatewayAddress: zeroAddress,
+    };
+
+    const { emitter, promise } = deposit(mockWalletClient, parameters);
+
+    const onDepositFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("deposit-failed-validation", onDepositFailedValidation);
+    emitter.on("deposit-settled", onSettled);
+
+    await promise;
+
+    expect(onDepositFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Gateway address cannot be zero address",
     );
     expect(onSettled).toHaveBeenCalledOnce();
   });

--- a/packages/gateway/test/wallet/redeem.test.ts
+++ b/packages/gateway/test/wallet/redeem.test.ts
@@ -53,7 +53,11 @@ const mockWalletClient = {
   chain: sepolia,
 } as WalletClient;
 
+const mockGatewayAddress =
+  "0x3333333333333333333333333333333333333333" as Address;
+
 const validParameters = {
+  gatewayAddress: mockGatewayAddress,
   minAmountOut: BigInt(900),
   peggedTokenIn: BigInt(1000),
   receiver: "0x2222222222222222222222222222222222222222" as Address,
@@ -127,6 +131,54 @@ describe("redeem", function () {
 
     expect(onRedeemFailedValidation).toHaveBeenCalledExactlyOnceWith(
       "Chain is not defined on wallet client",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'redeem-failed-validation' if gateway address is not valid", async function () {
+    const parameters = {
+      ...validParameters,
+      gatewayAddress: "invalid_gateway",
+    };
+
+    const { emitter, promise } = redeem(
+      mockWalletClient,
+      // @ts-expect-error - Testing invalid input
+      parameters,
+    );
+
+    const onRedeemFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("redeem-failed-validation", onRedeemFailedValidation);
+    emitter.on("redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onRedeemFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Invalid gateway address",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'redeem-failed-validation' if gateway address is zero address", async function () {
+    const parameters = {
+      ...validParameters,
+      gatewayAddress: zeroAddress,
+    };
+
+    const { emitter, promise } = redeem(mockWalletClient, parameters);
+
+    const onRedeemFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("redeem-failed-validation", onRedeemFailedValidation);
+    emitter.on("redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onRedeemFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Gateway address cannot be zero address",
     );
     expect(onSettled).toHaveBeenCalledOnce();
   });

--- a/packages/gateway/test/wallet/requestRedeem.test.ts
+++ b/packages/gateway/test/wallet/requestRedeem.test.ts
@@ -38,7 +38,11 @@ const mockWalletClient = {
   chain: sepolia,
 } as WalletClient;
 
+const mockGatewayAddress =
+  "0x3333333333333333333333333333333333333333" as Address;
+
 const validParameters = {
+  gatewayAddress: mockGatewayAddress,
   peggedTokenAmount: BigInt(1000),
 };
 
@@ -113,8 +117,59 @@ describe("requestRedeem", function () {
     expect(onSettled).toHaveBeenCalledOnce();
   });
 
+  it("should emit 'request-redeem-failed-validation' if gateway address is not valid", async function () {
+    const parameters = {
+      ...validParameters,
+      gatewayAddress: "invalid_gateway",
+    };
+
+    const { emitter, promise } = requestRedeem(
+      mockWalletClient,
+      // @ts-expect-error - Testing invalid input
+      parameters,
+    );
+
+    const onFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("request-redeem-failed-validation", onFailedValidation);
+    emitter.on("request-redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Invalid gateway address",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'request-redeem-failed-validation' if gateway address is zero address", async function () {
+    const parameters = {
+      ...validParameters,
+      gatewayAddress: zeroAddress,
+    };
+
+    const { emitter, promise } = requestRedeem(mockWalletClient, parameters);
+
+    const onFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+
+    emitter.on("request-redeem-failed-validation", onFailedValidation);
+    emitter.on("request-redeem-settled", onSettled);
+
+    await promise;
+
+    expect(onFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Gateway address cannot be zero address",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
   it("should emit 'request-redeem-failed-validation' if peggedTokenAmount is not a bigint", async function () {
-    const parameters = { peggedTokenAmount: 1000 };
+    const parameters = {
+      gatewayAddress: mockGatewayAddress,
+      peggedTokenAmount: 1000,
+    };
 
     const { emitter, promise } = requestRedeem(
       mockWalletClient,
@@ -137,7 +192,10 @@ describe("requestRedeem", function () {
   });
 
   it("should emit 'request-redeem-failed-validation' if peggedTokenAmount is zero", async function () {
-    const parameters = { peggedTokenAmount: BigInt(0) };
+    const parameters = {
+      gatewayAddress: mockGatewayAddress,
+      peggedTokenAmount: BigInt(0),
+    };
 
     const { emitter, promise } = requestRedeem(mockWalletClient, parameters);
 
@@ -156,7 +214,10 @@ describe("requestRedeem", function () {
   });
 
   it("should emit 'request-redeem-failed-validation' if peggedTokenAmount is negative", async function () {
-    const parameters = { peggedTokenAmount: BigInt(-1) };
+    const parameters = {
+      gatewayAddress: mockGatewayAddress,
+      peggedTokenAmount: BigInt(-1),
+    };
 
     const { emitter, promise } = requestRedeem(mockWalletClient, parameters);
 
@@ -177,6 +238,7 @@ describe("requestRedeem", function () {
   it("should emit 'request-redeem-failed-validation' if approveAmount is less than peggedTokenAmount", async function () {
     const parameters = {
       approveAmount: BigInt(999),
+      gatewayAddress: mockGatewayAddress,
       peggedTokenAmount: BigInt(1000),
     };
 
@@ -203,6 +265,7 @@ describe("requestRedeem", function () {
 
     const parameters = {
       approveAmount: BigInt(10000),
+      gatewayAddress: mockGatewayAddress,
       peggedTokenAmount: BigInt(1000),
     };
 

--- a/web/src/hooks/useCancelRedeemRequest.ts
+++ b/web/src/hooks/useCancelRedeemRequest.ts
@@ -3,7 +3,10 @@ import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { type CancelRedeemRequestEvents } from "@vetro-protocol/gateway";
+import {
+  type CancelRedeemRequestEvents,
+  getGatewayAddress,
+} from "@vetro-protocol/gateway";
 import { cancelRedeemRequest } from "@vetro-protocol/gateway/actions";
 import type { EventEmitter } from "events";
 import { useAccount } from "wagmi";
@@ -24,6 +27,7 @@ export const useCancelRedeemRequest = function ({
   const { data: walletClient } = useEthereumWalletClient();
   const ensureConnectedTo = useEnsureConnectedTo();
   const ethereumChain = useMainnet();
+  const gatewayAddress = getGatewayAddress(ethereumChain.id);
   const { queryKey: nativeBalanceKey } = useNativeBalance(ethereumChain.id);
   const queryClient = useQueryClient();
   const updateNativeBalanceAfterReceipt = useUpdateNativeBalanceAfterReceipt(
@@ -41,7 +45,9 @@ export const useCancelRedeemRequest = function ({
 
       await ensureConnectedTo(ethereumChain.id);
 
-      const { emitter, promise } = cancelRedeemRequest(walletClient!);
+      const { emitter, promise } = cancelRedeemRequest(walletClient!, {
+        gatewayAddress,
+      });
 
       emitter.on("cancel-redeem-request-transaction-reverted", (receipt) =>
         updateNativeBalanceAfterReceipt(receipt),

--- a/web/src/hooks/useDeposit.ts
+++ b/web/src/hooks/useDeposit.ts
@@ -82,6 +82,7 @@ export const useDeposit = function ({
       const { emitter, promise } = deposit(walletClient!, {
         amountIn,
         approveAmount,
+        gatewayAddress,
         minPeggedTokenOut,
         receiver: account,
         tokenIn,

--- a/web/src/hooks/useRedeem.ts
+++ b/web/src/hooks/useRedeem.ts
@@ -111,6 +111,7 @@ export const useRedeem = function ({
 
       const { emitter, promise } = redeem(walletClient!, {
         approveAmount,
+        gatewayAddress,
         minAmountOut,
         peggedTokenIn,
         receiver: account,

--- a/web/src/hooks/useRequestRedeem.ts
+++ b/web/src/hooks/useRequestRedeem.ts
@@ -3,7 +3,11 @@ import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { gatewayAbi, type RequestRedeemEvents } from "@vetro-protocol/gateway";
+import {
+  gatewayAbi,
+  getGatewayAddress,
+  type RequestRedeemEvents,
+} from "@vetro-protocol/gateway";
 import { requestRedeem } from "@vetro-protocol/gateway/actions";
 import type { EventEmitter } from "events";
 import { parseEventLogs } from "viem";
@@ -27,6 +31,7 @@ export const useRequestRedeem = function ({
   const { data: walletClient } = useEthereumWalletClient();
   const ensureConnectedTo = useEnsureConnectedTo();
   const ethereumChain = useMainnet();
+  const gatewayAddress = getGatewayAddress(ethereumChain.id);
   const { queryKey: nativeBalanceKey } = useNativeBalance(ethereumChain.id);
   const queryClient = useQueryClient();
   const { data: peggedToken } = usePeggedToken();
@@ -47,6 +52,7 @@ export const useRequestRedeem = function ({
 
       const { emitter, promise } = requestRedeem(walletClient!, {
         approveAmount,
+        gatewayAddress,
         peggedTokenAmount,
       });
 


### PR DESCRIPTION
### Description

Make the `@vetro-protocol/gateway` package abstracted from the gateway address in its wallet actions (`deposit`, `redeem`, `requestRedeem`, `cancelRedeemRequest`). Previously, these actions internally derived the gateway address from the chain ID via `getGatewayAddress()`, coupling them to a single hardcoded address per chain.

Now each wallet action accepts `gatewayAddress` as a required parameter and validates it (valid address, not zero address). This enables the package to work with multiple gateway addresses — public actions already accepted the address as a parameter, so the package is now fully gateway-address-agnostic.

The `getGatewayAddress` utility remains exported for external consumers. In later PRs, the gateway address will be made dynamic so the app can support multiple gateways.

**Changes:**
- Added `gatewayAddress: Address` to params of all 4 wallet actions
- Added gateway address validation in each `can*` function
- Removed internal `getGatewayAddress` calls from wallet actions
- Exported new `CancelRedeemRequestParams` type
- Updated web consumer hooks to pass `gatewayAddress`
- Added validation tests for invalid/zero gateway address

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #239

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.