### PR TITLE
Add Token info to Earn pools

### DIFF
--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -1,10 +1,12 @@
 import { getStakingVaultAddress } from "@vetro-protocol/earn";
+import { TokenLogo } from "components/tokenLogo";
 import { useApy } from "hooks/useApy";
 import { useMainnet } from "hooks/useMainnet";
 import { usePeggedToken } from "hooks/usePeggedToken";
 import { usePoolDeposits } from "hooks/usePoolDeposits";
 import { useUserRewards } from "hooks/useUserRewards";
 import { useTranslation } from "react-i18next";
+import Skeleton from "react-loading-skeleton";
 import { formatUsd } from "utils/currency";
 import { formatEvmAddress } from "utils/format";
 import { type Address, formatUnits } from "viem";
@@ -51,6 +53,14 @@ export function PoolInfoBar({ gatewayAddress }: Props) {
   return (
     <div className="flex flex-col gap-6 border-b border-gray-200 bg-white p-4 sm:gap-4 md:flex-row md:items-center md:justify-between md:px-16 md:py-6">
       <div className="grid grid-cols-2 gap-4 sm:flex sm:items-center sm:justify-center sm:gap-6 md:justify-start md:gap-8">
+        {peggedToken ? (
+          <div className="flex size-10 items-center justify-center rounded-lg bg-blue-800/10">
+            <TokenLogo {...peggedToken} />
+          </div>
+        ) : (
+          <Skeleton borderRadius={8} height={40} width={40} />
+        )}
+        <PoolInfoItem label="Token" value={peggedToken?.symbol} />
         <PoolInfoItem
           label={t("pages.earn.pool-info.pool-contract")}
           value={formatEvmAddress(stakingVaultAddress)}

--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -1,5 +1,4 @@
 import { getStakingVaultAddress } from "@vetro-protocol/earn";
-import { gatewayAddresses } from "@vetro-protocol/gateway";
 import { useApy } from "hooks/useApy";
 import { useMainnet } from "hooks/useMainnet";
 import { usePeggedToken } from "hooks/usePeggedToken";
@@ -8,19 +7,21 @@ import { useUserRewards } from "hooks/useUserRewards";
 import { useTranslation } from "react-i18next";
 import { formatUsd } from "utils/currency";
 import { formatEvmAddress } from "utils/format";
-import { formatUnits } from "viem";
+import { type Address, formatUnits } from "viem";
 
 import { PoolInfoButtons } from "./poolInfoButtons";
 import { PoolInfoItem } from "./poolInfoItem";
 import { TokenIconStack } from "./tokenIconStack";
 
-export function PoolInfoBar() {
+type Props = {
+  gatewayAddress: Address;
+};
+
+export function PoolInfoBar({ gatewayAddress }: Props) {
   const { t } = useTranslation();
   const chain = useMainnet();
   const stakingVaultAddress = getStakingVaultAddress(chain.id);
-  // TODO using the only gateway to simplify this PR
-  // we will handle multiple gateways in the next PR
-  const { data: peggedToken } = usePeggedToken(gatewayAddresses[0]);
+  const { data: peggedToken } = usePeggedToken(gatewayAddress);
 
   const { data: apy, isLoading: isLoadingApy } = useApy();
   const { data: poolDeposits, isLoading: isLoadingDeposits } =

--- a/web/src/pages/earn/index.tsx
+++ b/web/src/pages/earn/index.tsx
@@ -1,3 +1,4 @@
+import { gatewayAddresses } from "@vetro-protocol/gateway";
 import { PageTitle } from "components/base/pageTitle";
 import { StripedDivider } from "components/stripedDivider";
 import { useTranslation } from "react-i18next";
@@ -17,7 +18,9 @@ export function Earn() {
       <div className="flex flex-col border-y border-gray-200 bg-gray-100 *:-mt-px md:flex-row md:items-center md:justify-center md:gap-14 md:px-14 md:*:w-[267px]">
         <EarnStats />
       </div>
-      <PoolInfoBar />
+      {gatewayAddresses.map((gatewayAddress) => (
+        <PoolInfoBar gatewayAddress={gatewayAddress} key={gatewayAddress} />
+      ))}
       {!canInstantWithdraw && (
         <>
           <div className="border-b border-gray-200 bg-gray-100">


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Part 4 of supporting multiple Pegged Tokens to Vetro

This PR adds the "Token" and "Token Logo" columns in the Earn page - so when multiple Pools are added, each one will show its own token and logo

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img width="1281" height="361" alt="image" src="https://github.com/user-attachments/assets/addf2d0d-f783-4efe-96ea-11283da0ea78" />

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #239

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
