### PR TITLE
Support multiple pegged tokens (part 6) — staked balance stat

### DIFF
--- a/web/src/fetchers/fetchTotalStakedUsd.ts
+++ b/web/src/fetchers/fetchTotalStakedUsd.ts
@@ -1,0 +1,81 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { peggedTokensByGatewayQueryOptions } from "hooks/usePeggedTokensByGateway";
+import { pricesOptions } from "hooks/usePrices";
+import { stakedBalanceQueryOptions } from "hooks/useStakedBalance";
+import { vaultPeggedTokenQueryOptions } from "hooks/useVaultPeggedToken";
+import { getTokenPrice } from "utils/token";
+import { type Address, type Client, formatUnits } from "viem";
+
+export const fetchTotalStakedUsd = async function ({
+  account,
+  client,
+  queryClient,
+  stakingVaultAddresses,
+}: {
+  account: Address;
+  client: Client;
+  queryClient: QueryClient;
+  stakingVaultAddresses: readonly Address[];
+}): Promise<number> {
+  const chainId = client.chain?.id;
+  if (chainId === undefined) {
+    throw new Error("Client is missing a chain");
+  }
+
+  // peggedTokensByGateway is indexed by gateway address; we only have the pegged
+  // token here, so reverse the index to look up gateway by pegged-token address.
+  // Kick off the fetch now (without awaiting) so it overlaps with the per-vault
+  // pegged-token fetch below.
+  const gatewayByPeggedTokenPromise = queryClient
+    .ensureQueryData(peggedTokensByGatewayQueryOptions({ client, queryClient }))
+    .then((peggedTokensByGateway) =>
+      Object.fromEntries(
+        Object.values(peggedTokensByGateway).map((token) => [
+          token.address,
+          token.gatewayAddress,
+        ]),
+      ),
+    );
+
+  const perVaultUsd = await Promise.all(
+    stakingVaultAddresses.map(async function (stakingVaultAddress) {
+      const [peggedToken, gatewayByPeggedToken] = await Promise.all([
+        queryClient.ensureQueryData(
+          vaultPeggedTokenQueryOptions({
+            client,
+            queryClient,
+            stakingVaultAddress,
+          }),
+        ),
+        gatewayByPeggedTokenPromise,
+      ]);
+      const gatewayAddress = gatewayByPeggedToken[peggedToken.address];
+      if (!gatewayAddress) {
+        throw new Error(
+          `No gateway found for pegged token ${peggedToken.address}`,
+        );
+      }
+
+      const [stakedAssets, prices] = await Promise.all([
+        queryClient.ensureQueryData(
+          stakedBalanceQueryOptions({
+            account,
+            chainId,
+            client,
+            queryClient,
+            stakingVaultAddress,
+          }),
+        ),
+        queryClient.ensureQueryData(
+          pricesOptions({ client, gatewayAddress, queryClient }),
+        ),
+      ]);
+
+      const amount = Number(formatUnits(stakedAssets, peggedToken.decimals));
+      const price = Number(getTokenPrice(peggedToken, prices));
+      return amount * price;
+    }),
+  );
+
+  return perVaultUsd.reduce((sum, value) => sum + value, 0);
+};

--- a/web/src/hooks/useInstantWithdraw.ts
+++ b/web/src/hooks/useInstantWithdraw.ts
@@ -12,6 +12,7 @@ import { useAccount } from "wagmi";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { stakedBalanceQueryKey } from "./useStakedBalance";
+import { totalStakedUsdQueryKey } from "./useTotalStakedUsd";
 
 type InstantWithdrawStatus = "completed" | "failed" | "withdrawing";
 
@@ -109,13 +110,20 @@ export const useInstantWithdraw = function ({
       });
 
       // Shares must be refetched before staked balance, because
-      // useStakedBalance uses ensureQueryData to read shares from cache
-      await queryClient.invalidateQueries({
+      // useStakedBalance uses ensureQueryData to read shares from cache.
+      // refetchQueries (not invalidateQueries) is required because the
+      // shares query has no mounted observer — invalidation alone would
+      // only mark it stale, and ensureQueryData returns stale cached data.
+      await queryClient.refetchQueries({
         queryKey: sharesBalanceKey,
       });
 
       queryClient.invalidateQueries({
         queryKey: stakedKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: totalStakedUsdQueryKey({ account, chainId: chain.id }),
       });
     },
   });

--- a/web/src/hooks/usePeggedTokensByGateway.ts
+++ b/web/src/hooks/usePeggedTokensByGateway.ts
@@ -1,16 +1,24 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type QueryClient,
+  queryOptions,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { gatewayAddresses } from "@vetro-protocol/gateway";
 import type { TokenWithGateway } from "types";
-import type { Address } from "viem";
+import type { Address, Client } from "viem";
 
 import { useEthereumClient } from "./useEthereumClient";
 import { peggedTokenQueryOptions } from "./usePeggedToken";
 
-export const usePeggedTokensByGateway = function () {
-  const client = useEthereumClient();
-  const queryClient = useQueryClient();
-
-  return useQuery({
+export const peggedTokensByGatewayQueryOptions = ({
+  client,
+  queryClient,
+}: {
+  client: Client | undefined;
+  queryClient: QueryClient;
+}) =>
+  queryOptions({
     enabled: !!client,
     queryFn: () =>
       Promise.all(
@@ -29,6 +37,12 @@ export const usePeggedTokensByGateway = function () {
             tokens.map((t) => [t.gatewayAddress, t]),
           ) as Record<Address, TokenWithGateway>,
       ),
-    queryKey: ["pegged-tokens", client?.chain.id],
+    queryKey: ["pegged-tokens", client?.chain?.id],
   });
+
+export const usePeggedTokensByGateway = function () {
+  const client = useEthereumClient();
+  const queryClient = useQueryClient();
+
+  return useQuery(peggedTokensByGatewayQueryOptions({ client, queryClient }));
 };

--- a/web/src/hooks/useStakeDeposit.ts
+++ b/web/src/hooks/useStakeDeposit.ts
@@ -12,6 +12,7 @@ import { useAccount } from "wagmi";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { stakedBalanceQueryKey } from "./useStakedBalance";
+import { totalStakedUsdQueryKey } from "./useTotalStakedUsd";
 
 type DepositStatus =
   | "approve-failed"
@@ -167,13 +168,20 @@ export const useStakeDeposit = function ({
       });
 
       // Shares must be refetched before staked balance, because
-      // useStakedBalance uses ensureQueryData to read shares from cache
-      await queryClient.invalidateQueries({
+      // useStakedBalance uses ensureQueryData to read shares from cache.
+      // refetchQueries (not invalidateQueries) is required because the
+      // shares query has no mounted observer — invalidation alone would
+      // only mark it stale, and ensureQueryData returns stale cached data.
+      await queryClient.refetchQueries({
         queryKey: sharesBalanceKey,
       });
 
       queryClient.invalidateQueries({
         queryKey: stakedKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: totalStakedUsdQueryKey({ account, chainId: chain.id }),
       });
     },
   });

--- a/web/src/hooks/useStakeWithdraw.ts
+++ b/web/src/hooks/useStakeWithdraw.ts
@@ -13,6 +13,7 @@ import { useAccount } from "wagmi";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { stakedBalanceQueryKey } from "./useStakedBalance";
+import { totalStakedUsdQueryKey } from "./useTotalStakedUsd";
 
 type WithdrawStatus = "completed" | "request-failed" | "requesting";
 
@@ -130,13 +131,20 @@ export const useStakeWithdraw = function ({
       });
 
       // Shares must be refetched before staked balance, because
-      // useStakedBalance uses ensureQueryData to read shares from cache
-      await queryClient.invalidateQueries({
+      // useStakedBalance uses ensureQueryData to read shares from cache.
+      // refetchQueries (not invalidateQueries) is required because the
+      // shares query has no mounted observer — invalidation alone would
+      // only mark it stale, and ensureQueryData returns stale cached data.
+      await queryClient.refetchQueries({
         queryKey: sharesBalanceKey,
       });
 
       queryClient.invalidateQueries({
         queryKey: stakedKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: totalStakedUsdQueryKey({ account, chainId: chain.id }),
       });
     },
   });

--- a/web/src/hooks/useStakedBalance.ts
+++ b/web/src/hooks/useStakedBalance.ts
@@ -1,8 +1,13 @@
 import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type QueryClient,
+  queryOptions,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useEthereumClient } from "hooks/useEthereumClient";
 import { useMainnet } from "hooks/useMainnet";
-import type { Address } from "viem";
+import type { Address, Client } from "viem";
 import { convertToAssets } from "viem-erc4626/actions";
 import { useAccount } from "wagmi";
 
@@ -16,20 +21,27 @@ export const stakedBalanceQueryKey = ({
   stakingVaultAddress: Address;
 }) => ["staked-balance", chainId, stakingVaultAddress, account];
 
-export function useStakedBalance(stakingVaultAddress: Address) {
-  const { address: account } = useAccount();
-  const chain = useMainnet();
-  const client = useEthereumClient();
-  const queryClient = useQueryClient();
-
-  return useQuery({
+export const stakedBalanceQueryOptions = ({
+  account,
+  chainId,
+  client,
+  queryClient,
+  stakingVaultAddress,
+}: {
+  account: Address | undefined;
+  chainId: number;
+  client: Client | undefined;
+  queryClient: QueryClient;
+  stakingVaultAddress: Address;
+}) =>
+  queryOptions({
     enabled: !!client && !!account,
     async queryFn() {
       const shares = await queryClient.ensureQueryData(
         tokenBalanceQueryOptions({
           account: account!,
           client: client!,
-          token: { address: stakingVaultAddress, chainId: chain.id },
+          token: { address: stakingVaultAddress, chainId },
         }),
       );
       return convertToAssets(client!, {
@@ -39,8 +51,24 @@ export function useStakedBalance(stakingVaultAddress: Address) {
     },
     queryKey: stakedBalanceQueryKey({
       account: account!,
-      chainId: chain.id,
+      chainId,
       stakingVaultAddress,
     }),
   });
+
+export function useStakedBalance(stakingVaultAddress: Address) {
+  const { address: account } = useAccount();
+  const chain = useMainnet();
+  const client = useEthereumClient();
+  const queryClient = useQueryClient();
+
+  return useQuery(
+    stakedBalanceQueryOptions({
+      account,
+      chainId: chain.id,
+      client,
+      queryClient,
+      stakingVaultAddress,
+    }),
+  );
 }

--- a/web/src/hooks/useTotalStakedUsd.ts
+++ b/web/src/hooks/useTotalStakedUsd.ts
@@ -2,7 +2,16 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { fetchTotalStakedUsd } from "fetchers/fetchTotalStakedUsd";
 import { useEthereumClient } from "hooks/useEthereumClient";
+import type { Address } from "viem";
 import { useAccount } from "wagmi";
+
+export const totalStakedUsdQueryKey = ({
+  account,
+  chainId,
+}: {
+  account: Address | undefined;
+  chainId: number | undefined;
+}) => ["total-staked-usd", chainId, account];
 
 export function useTotalStakedUsd() {
   const { address: account } = useAccount();
@@ -18,6 +27,6 @@ export function useTotalStakedUsd() {
         queryClient,
         stakingVaultAddresses,
       }),
-    queryKey: ["total-staked-usd", client?.chain?.id, account],
+    queryKey: totalStakedUsdQueryKey({ account, chainId: client?.chain?.id }),
   });
 }

--- a/web/src/hooks/useTotalStakedUsd.ts
+++ b/web/src/hooks/useTotalStakedUsd.ts
@@ -1,0 +1,23 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { stakingVaultAddresses } from "@vetro-protocol/earn";
+import { fetchTotalStakedUsd } from "fetchers/fetchTotalStakedUsd";
+import { useEthereumClient } from "hooks/useEthereumClient";
+import { useAccount } from "wagmi";
+
+export function useTotalStakedUsd() {
+  const { address: account } = useAccount();
+  const client = useEthereumClient();
+  const queryClient = useQueryClient();
+
+  return useQuery({
+    enabled: !!client && !!account,
+    queryFn: () =>
+      fetchTotalStakedUsd({
+        account: account!,
+        client: client!,
+        queryClient,
+        stakingVaultAddresses,
+      }),
+    queryKey: ["total-staked-usd", client?.chain?.id, account],
+  });
+}

--- a/web/src/hooks/useVaultPeggedToken.ts
+++ b/web/src/hooks/useVaultPeggedToken.ts
@@ -17,7 +17,7 @@ const vaultPeggedTokenQueryKey = ({
   stakingVaultAddress: Address;
 }) => ["vault-pegged-token", chainId, stakingVaultAddress];
 
-const vaultPeggedTokenQueryOptions = ({
+export const vaultPeggedTokenQueryOptions = ({
   client,
   queryClient,
   stakingVaultAddress,

--- a/web/src/pages/earn/components/earnStats/index.tsx
+++ b/web/src/pages/earn/components/earnStats/index.tsx
@@ -1,60 +1,17 @@
-import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
-import { stakingVaultAddresses } from "@vetro-protocol/earn";
-import { useMainnet } from "hooks/useMainnet";
-import { useShareToken } from "hooks/useShareToken";
-import { useStakedBalance } from "hooks/useStakedBalance";
-import { useVaultPeggedToken } from "hooks/useVaultPeggedToken";
 import { useTranslation } from "react-i18next";
-import { formatUnits } from "viem";
 
-import { BoltIcon } from "../../icons/boltIcon";
 import { SparklesIcon } from "../../icons/sparklesIcon";
-import { TrendingUpIcon } from "../../icons/trendingUpIcon";
+import { EarnedAmountStat } from "../earnedAmountStat";
+import { StakedBalanceStat } from "../stakedBalanceStat";
 import { StatCard } from "../statCard";
 
 export function EarnStats() {
   const { t } = useTranslation();
-  const chain = useMainnet();
-  // TODO using the only staking vault address to simplify this PR
-  // we will handle multiple addresses in the next PR
-  const stakingVaultAddress = stakingVaultAddresses[0];
-  const { data: shareToken } = useShareToken(stakingVaultAddress);
-  const { data: peggedToken } = useVaultPeggedToken(stakingVaultAddress);
-
-  const { data: stakedBalance, isLoading: isLoadingStakedBalance } =
-    useStakedBalance(stakingVaultAddress);
-
-  const { data: earnedAmount, isLoading: isLoadingEarnedAmount } =
-    useTokenBalance({ address: stakingVaultAddress, chainId: chain.id });
-
-  const formatStakedBalance = function () {
-    if (stakedBalance !== undefined && peggedToken) {
-      return `${formatUnits(stakedBalance, peggedToken.decimals)} ${peggedToken.symbol}`;
-    }
-    return "";
-  };
-
-  const formatEarnedAmount = function () {
-    if (earnedAmount !== undefined && shareToken) {
-      return `${formatUnits(earnedAmount, shareToken.decimals)} ${shareToken.symbol}`;
-    }
-    return "";
-  };
 
   return (
     <>
-      <StatCard
-        icon={<BoltIcon />}
-        isLoading={isLoadingStakedBalance}
-        label={t("pages.earn.stats.staked-balance")}
-        value={formatStakedBalance()}
-      />
-      <StatCard
-        icon={<TrendingUpIcon />}
-        isLoading={isLoadingEarnedAmount}
-        label={t("pages.earn.stats.earned-amount")}
-        value={formatEarnedAmount()}
-      />
+      <StakedBalanceStat />
+      <EarnedAmountStat />
       {/* TODO - Rewards should be implemented as soon we have the API available */}
       {/* See https://github.com/vetro-protocol/vetro-monorepo/issues/69 */}
       <StatCard

--- a/web/src/pages/earn/components/earnStats/index.tsx
+++ b/web/src/pages/earn/components/earnStats/index.tsx
@@ -56,6 +56,7 @@ export function EarnStats() {
         value={formatEarnedAmount()}
       />
       {/* TODO - Rewards should be implemented as soon we have the API available */}
+      {/* See https://github.com/vetro-protocol/vetro-monorepo/issues/69 */}
       <StatCard
         icon={<SparklesIcon />}
         label={t("pages.earn.stats.rewards")}

--- a/web/src/pages/earn/components/earnedAmountStat/index.tsx
+++ b/web/src/pages/earn/components/earnedAmountStat/index.tsx
@@ -1,0 +1,23 @@
+import { useTotalStakedUsd } from "hooks/useTotalStakedUsd";
+import { useTranslation } from "react-i18next";
+import { formatUsd } from "utils/currency";
+
+import { TrendingUpIcon } from "../../icons/trendingUpIcon";
+import { StatCard } from "../statCard";
+
+// TODO earned amount should sum yield across all staking vaults in USD;
+// temporarily mirroring the staked balance until the proper calculation lands.
+// See https://github.com/vetro-protocol/vetro-monorepo/issues/333
+export function EarnedAmountStat() {
+  const { t } = useTranslation();
+  const { data, isLoading } = useTotalStakedUsd();
+
+  return (
+    <StatCard
+      icon={<TrendingUpIcon />}
+      isLoading={isLoading}
+      label={t("pages.earn.stats.earned-amount")}
+      value={data !== undefined ? formatUsd(data) : ""}
+    />
+  );
+}

--- a/web/src/pages/earn/components/stakedBalanceStat/index.tsx
+++ b/web/src/pages/earn/components/stakedBalanceStat/index.tsx
@@ -1,0 +1,20 @@
+import { useTotalStakedUsd } from "hooks/useTotalStakedUsd";
+import { useTranslation } from "react-i18next";
+import { formatUsd } from "utils/currency";
+
+import { BoltIcon } from "../../icons/boltIcon";
+import { StatCard } from "../statCard";
+
+export function StakedBalanceStat() {
+  const { t } = useTranslation();
+  const { data, isLoading } = useTotalStakedUsd();
+
+  return (
+    <StatCard
+      icon={<BoltIcon />}
+      isLoading={isLoading}
+      label={t("pages.earn.stats.staked-balance")}
+      value={data !== undefined ? formatUsd(data) : ""}
+    />
+  );
+}

--- a/web/test/fetchers/fetchTotalStakedUsd.test.ts
+++ b/web/test/fetchers/fetchTotalStakedUsd.test.ts
@@ -1,0 +1,216 @@
+import { peggedTokensByGatewayQueryOptions } from "hooks/usePeggedTokensByGateway";
+import { pricesOptions } from "hooks/usePrices";
+import { stakedBalanceQueryOptions } from "hooks/useStakedBalance";
+import { vaultPeggedTokenQueryOptions } from "hooks/useVaultPeggedToken";
+import type { TokenWithGateway } from "types";
+import { knownTokens } from "utils/tokenList";
+import type { Address, Client } from "viem";
+import { mainnet } from "viem/chains";
+import { describe, expect, it } from "vitest";
+
+import { fetchTotalStakedUsd } from "../../src/fetchers/fetchTotalStakedUsd";
+import { createTestQueryClient } from "../utils";
+
+const account = "0x0000000000000000000000000000000000000abc" as Address;
+const client = { chain: mainnet } as unknown as Client;
+
+const vault1 = "0x1111111111111111111111111111111111111111" as Address;
+const vault2 = "0x2222222222222222222222222222222222222222" as Address;
+const gateway1 = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as Address;
+const gateway2 = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as Address;
+
+const vusd = knownTokens.find((token) => token.symbol === "VUSD")!;
+const usdc = knownTokens.find((token) => token.symbol === "USDC")!;
+
+const vusdWithGateway: TokenWithGateway = {
+  ...vusd,
+  gatewayAddress: gateway1,
+};
+const usdcWithGateway: TokenWithGateway = {
+  ...usdc,
+  gatewayAddress: gateway2,
+};
+
+describe("fetchTotalStakedUsd", function () {
+  it("returns staked amount times price for a single vault", async function () {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      peggedTokensByGatewayQueryOptions({ client, queryClient }).queryKey,
+      { [gateway1]: vusdWithGateway },
+    );
+    queryClient.setQueryData(
+      vaultPeggedTokenQueryOptions({
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      vusd,
+    );
+    queryClient.setQueryData(
+      stakedBalanceQueryOptions({
+        account,
+        chainId: mainnet.id,
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      10n * 10n ** 18n,
+    );
+    // VUSD's priceSymbol is USDT, so getTokenPrice looks up the USDT key.
+    queryClient.setQueryData(
+      pricesOptions({ client, gatewayAddress: gateway1, queryClient }).queryKey,
+      { USDT: "1" },
+    );
+
+    const result = await fetchTotalStakedUsd({
+      account,
+      client,
+      queryClient,
+      stakingVaultAddresses: [vault1],
+    });
+
+    expect(result).toBe(10);
+  });
+
+  it("sums staked values across multiple vaults on different gateways", async function () {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      peggedTokensByGatewayQueryOptions({ client, queryClient }).queryKey,
+      {
+        [gateway1]: vusdWithGateway,
+        [gateway2]: usdcWithGateway,
+      },
+    );
+    queryClient.setQueryData(
+      vaultPeggedTokenQueryOptions({
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      vusd,
+    );
+    queryClient.setQueryData(
+      vaultPeggedTokenQueryOptions({
+        client,
+        queryClient,
+        stakingVaultAddress: vault2,
+      }).queryKey,
+      usdc,
+    );
+    queryClient.setQueryData(
+      stakedBalanceQueryOptions({
+        account,
+        chainId: mainnet.id,
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      5n * 10n ** 18n,
+    );
+    queryClient.setQueryData(
+      stakedBalanceQueryOptions({
+        account,
+        chainId: mainnet.id,
+        client,
+        queryClient,
+        stakingVaultAddress: vault2,
+      }).queryKey,
+      25n * 10n ** 6n,
+    );
+    queryClient.setQueryData(
+      pricesOptions({ client, gatewayAddress: gateway1, queryClient }).queryKey,
+      { USDT: "1" } as Record<string, string>,
+    );
+    queryClient.setQueryData(
+      pricesOptions({ client, gatewayAddress: gateway2, queryClient }).queryKey,
+      { USDC: "1.1" } as Record<string, string>,
+    );
+
+    const result = await fetchTotalStakedUsd({
+      account,
+      client,
+      queryClient,
+      stakingVaultAddresses: [vault1, vault2],
+    });
+
+    // 5 VUSD * $1 + 25 USDC * $1.1 = 32.5
+    expect(result).toBe(32.5);
+  });
+
+  it("contributes 0 when the pegged token has no price entry", async function () {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      peggedTokensByGatewayQueryOptions({ client, queryClient }).queryKey,
+      { [gateway1]: vusdWithGateway } as Record<Address, TokenWithGateway>,
+    );
+    queryClient.setQueryData(
+      vaultPeggedTokenQueryOptions({
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      vusd,
+    );
+    queryClient.setQueryData(
+      stakedBalanceQueryOptions({
+        account,
+        chainId: mainnet.id,
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      10n * 10n ** 18n,
+    );
+    queryClient.setQueryData(
+      pricesOptions({ client, gatewayAddress: gateway1, queryClient }).queryKey,
+      {},
+    );
+
+    const result = await fetchTotalStakedUsd({
+      account,
+      client,
+      queryClient,
+      stakingVaultAddresses: [vault1],
+    });
+
+    expect(result).toBe(0);
+  });
+
+  it("throws when a vault's pegged token has no matching gateway", async function () {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      peggedTokensByGatewayQueryOptions({ client, queryClient }).queryKey,
+      {},
+    );
+    queryClient.setQueryData(
+      vaultPeggedTokenQueryOptions({
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      vusd,
+    );
+
+    await expect(
+      fetchTotalStakedUsd({
+        account,
+        client,
+        queryClient,
+        stakingVaultAddresses: [vault1],
+      }),
+    ).rejects.toThrow(/No gateway found for pegged token/);
+  });
+
+  it("throws when the client has no chain", async function () {
+    const clientWithoutChain = {} as Client;
+
+    await expect(
+      fetchTotalStakedUsd({
+        account,
+        client: clientWithoutChain,
+        queryClient: createTestQueryClient(),
+        stakingVaultAddresses: [vault1],
+      }),
+    ).rejects.toThrow(/Client is missing a chain/);
+  });
+});


### PR DESCRIPTION
### Description

Part 6 of supporting multiple Pegged Tokens in Vetro.

This PR adds a "Staked balance" stat card to the Earn page that aggregates each vault's staked assets priced in USD, paving the way for the multi-vault view. It also splits `EarnStats` into per-stat components so each card owns its data fetching, and fixes a staleness bug where the staked balance (and "available to withdraw" in the withdraw drawer) didn't refresh after a deposit/withdraw.

**Commits:**

- 66ad0f2 Link missing issue in TODO
- 36fc088 Extract peggedTokensByGateway query options — enables non-hook callers (fetchers) to reuse the same query via `queryClient.ensureQueryData`.
- df043d5 Extract stakedBalance query options — same pattern as above.
- 3b51547 Add staked-balance stat to Earn page — introduces `fetchTotalStakedUsd` + `useTotalStakedUsd` and a new `StakedBalanceStat` card.
- fbf08da Split EarnStats into per-stat components — each stat owns its data fetching; drops single-vault hardcoding.
- e64e7c5 Refresh staked balances after stake mutations — invalidate the total-staked-usd query and switch shares to `refetchQueries` so `useStakedBalance` reads fresh shares in its `ensureQueryData` call.

### Screenshots

<img width="609" height="434" alt="image" src="https://github.com/user-attachments/assets/4160212f-7c3f-4ed8-8860-c74039e08951" />

### Related issue(s)

Related to #239

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.