### PR TITLE
Scope subgraph entities per staking vault

### DIFF
--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vetro-app-subgraph",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "scripts": {
     "prebuild": "npm run codegen",

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,6 +1,7 @@
 type VaultHistory @entity(immutable: false) {
   id: ID!
   shareValue: BigInt!
+  stakingVaultAddress: Bytes!
   timestamp: BigInt! # Timestamp fixed to YYYY-MM-DD 00:00:00 UTC
 }
 
@@ -15,10 +16,12 @@ type ExitTicket @entity(immutable: false) {
   requestId: BigInt!
   requestTxHash: Bytes!
   shares: BigInt!
+  stakingVaultAddress: Bytes!
 }
 
 type ExitTicketQueueSummary @entity(immutable: false) {
   id: ID!
   openTickets: Int!
   shares: BigInt!
+  stakingVaultAddress: Bytes!
 }

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -1,4 +1,4 @@
-import { BigInt, dataSource, ethereum } from "@graphprotocol/graph-ts";
+import { Address, BigInt, dataSource, ethereum } from "@graphprotocol/graph-ts";
 
 import {
   ExitTicket,
@@ -12,28 +12,37 @@ import {
   WithdrawRequested,
 } from "../generated/StakingVault/StakingVault";
 
-function loadOrCreateQueueSummary(): ExitTicketQueueSummary {
-  let summary = ExitTicketQueueSummary.load("singleton");
+const buildId = (vaultAddress: Address, suffix: string): string =>
+  `${vaultAddress.toHexString()}-${suffix}`;
+
+function loadOrCreateQueueSummary(
+  vaultAddress: Address,
+): ExitTicketQueueSummary {
+  const id = vaultAddress.toHexString();
+  let summary = ExitTicketQueueSummary.load(id);
   if (summary == null) {
-    summary = new ExitTicketQueueSummary("singleton");
+    summary = new ExitTicketQueueSummary(id);
     summary.shares = BigInt.fromI32(0);
     summary.openTickets = 0;
+    summary.stakingVaultAddress = vaultAddress;
   }
   return summary;
 }
 
 export function handleBlock(block: ethereum.Block): void {
   const daySeconds = BigInt.fromI32(86400);
+  // Integer-divide then re-multiply to snap block.timestamp to the start of the UTC day (00:00:00).
   const dayTimestamp = block.timestamp.div(daySeconds).times(daySeconds);
 
-  const id = dayTimestamp.toString();
+  const vaultAddress = dataSource.address();
+  const id = buildId(vaultAddress, dayTimestamp.toString());
   let entity = VaultHistory.load(id);
   if (entity == null) {
     entity = new VaultHistory(id);
     entity.timestamp = dayTimestamp;
+    entity.stakingVaultAddress = vaultAddress;
   }
 
-  const vaultAddress = dataSource.address();
   const vault = StakingVault.bind(vaultAddress);
   const decimals = vault.decimals();
   const oneShare = BigInt.fromI32(10).pow(<u8>decimals);
@@ -44,7 +53,8 @@ export function handleBlock(block: ethereum.Block): void {
 }
 
 export function handleWithdrawRequested(event: WithdrawRequested): void {
-  const id = event.params.requestId.toString();
+  const vaultAddress = dataSource.address();
+  const id = buildId(vaultAddress, event.params.requestId.toString());
   const entity = new ExitTicket(id);
 
   entity.owner = event.params.owner;
@@ -52,12 +62,13 @@ export function handleWithdrawRequested(event: WithdrawRequested): void {
   entity.claimableAt = event.params.claimableAt;
   entity.requestId = event.params.requestId;
   entity.shares = event.params.shares;
+  entity.stakingVaultAddress = vaultAddress;
 
   entity.requestTxHash = event.transaction.hash;
 
   entity.save();
 
-  const summary = loadOrCreateQueueSummary();
+  const summary = loadOrCreateQueueSummary(vaultAddress);
 
   summary.shares = summary.shares.plus(event.params.shares);
   summary.openTickets = summary.openTickets + 1;
@@ -66,7 +77,8 @@ export function handleWithdrawRequested(event: WithdrawRequested): void {
 }
 
 export function handleWithdrawCancelled(event: WithdrawCancelled): void {
-  const id = event.params.requestId.toString();
+  const vaultAddress = dataSource.address();
+  const id = buildId(vaultAddress, event.params.requestId.toString());
   const entity = ExitTicket.load(id);
   if (entity == null) {
     return;
@@ -76,7 +88,7 @@ export function handleWithdrawCancelled(event: WithdrawCancelled): void {
 
   entity.save();
 
-  const summary = loadOrCreateQueueSummary();
+  const summary = loadOrCreateQueueSummary(vaultAddress);
 
   summary.shares = summary.shares.minus(entity.shares);
   summary.openTickets = summary.openTickets - 1;
@@ -85,7 +97,8 @@ export function handleWithdrawCancelled(event: WithdrawCancelled): void {
 }
 
 export function handleWithdrawClaimed(event: WithdrawClaimed): void {
-  const id = event.params.requestId.toString();
+  const vaultAddress = dataSource.address();
+  const id = buildId(vaultAddress, event.params.requestId.toString());
   const entity = ExitTicket.load(id);
   if (entity == null) {
     return;
@@ -95,7 +108,7 @@ export function handleWithdrawClaimed(event: WithdrawClaimed): void {
 
   entity.save();
 
-  const summary = loadOrCreateQueueSummary();
+  const summary = loadOrCreateQueueSummary(vaultAddress);
 
   summary.shares = summary.shares.minus(entity.shares);
   summary.openTickets = summary.openTickets - 1;

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -63,7 +63,7 @@ describe("handleBlock", function () {
     handleBlock(block);
 
     const dayTimestamp = timestamp.div(daySeconds).times(daySeconds);
-    const id = dayTimestamp.toString();
+    const id = `${vaultAddressString}-${dayTimestamp.toString()}`;
     assert.entityCount("VaultHistory", 1);
     assert.fieldEquals(
       "VaultHistory",
@@ -76,6 +76,12 @@ describe("handleBlock", function () {
       id,
       "shareValue",
       currentShareValue.toString(),
+    );
+    assert.fieldEquals(
+      "VaultHistory",
+      id,
+      "stakingVaultAddress",
+      vaultAddressString,
     );
   });
 
@@ -91,7 +97,7 @@ describe("handleBlock", function () {
     handleBlock(block1);
 
     const dayTimestamp = timestamp1.div(daySeconds).times(daySeconds);
-    const id = dayTimestamp.toString();
+    const id = `${vaultAddressString}-${dayTimestamp.toString()}`;
     assert.entityCount("VaultHistory", 1);
 
     mockVaultCalls(decimals, updatedShareValue);
@@ -117,6 +123,7 @@ describe("handleBlock", function () {
 describe("handleWithdrawRequested", function () {
   beforeEach(function () {
     clearStore();
+    dataSourceMock.setAddress(vaultAddressString);
   });
 
   test("creates ExitTicket from event", function () {
@@ -134,7 +141,7 @@ describe("handleWithdrawRequested", function () {
     );
     handleWithdrawRequested(event);
 
-    const id = requestId.toString();
+    const id = `${vaultAddressString}-${requestId.toString()}`;
     assert.entityCount("ExitTicket", 1);
     assert.fieldEquals("ExitTicket", id, "owner", ownerAddress.toHexString());
     assert.fieldEquals("ExitTicket", id, "assets", assets.toString());
@@ -144,20 +151,32 @@ describe("handleWithdrawRequested", function () {
     assert.fieldEquals(
       "ExitTicket",
       id,
+      "stakingVaultAddress",
+      vaultAddressString,
+    );
+    assert.fieldEquals(
+      "ExitTicket",
+      id,
       "requestTxHash",
       event.transaction.hash.toHexString(),
     );
     assert.fieldEquals(
       "ExitTicketQueueSummary",
-      "singleton",
+      vaultAddressString,
       "openTickets",
       "1",
     );
     assert.fieldEquals(
       "ExitTicketQueueSummary",
-      "singleton",
+      vaultAddressString,
       "shares",
       shares.toString(),
+    );
+    assert.fieldEquals(
+      "ExitTicketQueueSummary",
+      vaultAddressString,
+      "stakingVaultAddress",
+      vaultAddressString,
     );
   });
 });
@@ -165,6 +184,7 @@ describe("handleWithdrawRequested", function () {
 describe("handleWithdrawCancelled", function () {
   beforeEach(function () {
     clearStore();
+    dataSourceMock.setAddress(vaultAddressString);
   });
 
   test("updates ExitTicket when cancelled", function () {
@@ -182,7 +202,7 @@ describe("handleWithdrawCancelled", function () {
     );
     handleWithdrawRequested(requestEvent);
 
-    const id = requestId.toString();
+    const id = `${vaultAddressString}-${requestId.toString()}`;
     assert.entityCount("ExitTicket", 1);
 
     const cancelEvent = createWithdrawCancelledEvent(
@@ -202,11 +222,16 @@ describe("handleWithdrawCancelled", function () {
     );
     assert.fieldEquals(
       "ExitTicketQueueSummary",
-      "singleton",
+      vaultAddressString,
       "openTickets",
       "0",
     );
-    assert.fieldEquals("ExitTicketQueueSummary", "singleton", "shares", "0");
+    assert.fieldEquals(
+      "ExitTicketQueueSummary",
+      vaultAddressString,
+      "shares",
+      "0",
+    );
   });
 
   test("ignores missing ExitTicket on cancel", function () {
@@ -229,6 +254,7 @@ describe("handleWithdrawCancelled", function () {
 describe("handleWithdrawClaimed", function () {
   beforeEach(function () {
     clearStore();
+    dataSourceMock.setAddress(vaultAddressString);
   });
 
   test("updates ExitTicket when claimed", function () {
@@ -246,7 +272,7 @@ describe("handleWithdrawClaimed", function () {
     );
     handleWithdrawRequested(requestEvent);
 
-    const id = requestId.toString();
+    const id = `${vaultAddressString}-${requestId.toString()}`;
     assert.entityCount("ExitTicket", 1);
 
     const claimEvent = createWithdrawClaimedEvent(
@@ -266,11 +292,16 @@ describe("handleWithdrawClaimed", function () {
     );
     assert.fieldEquals(
       "ExitTicketQueueSummary",
-      "singleton",
+      vaultAddressString,
       "openTickets",
       "0",
     );
-    assert.fieldEquals("ExitTicketQueueSummary", "singleton", "shares", "0");
+    assert.fieldEquals(
+      "ExitTicketQueueSummary",
+      vaultAddressString,
+      "shares",
+      "0",
+    );
   });
 
   test("ignores missing ExitTicket on claim", function () {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

Prefix VaultHistory and ExitTicket IDs with the vault address, and key ExitTicketQueueSummary by vault address so each vault has its own summary. Add a stakingVaultAddress field to the three entities and populate it from dataSource.address() in every handler. Update matchstick tests to set the data source address and assert the new id shape and field.

Only one vault is configured today, but additional vaults per chain are on the roadmap and would otherwise collide on these IDs.

This does not affect the API as the values are filtered by address and not by Staking Vault.

This subgraph will need redeployment 

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #239 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
