### PR TITLE
Support multiple pegged tokens (part 7) — exit tickets

### DIFF
--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -124,6 +124,7 @@ export async function getUserExitTickets({
         requestId
         requestTxHash
         shares
+        stakingVaultAddress,
       }
     }`;
   const variables = {

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -136,6 +136,7 @@ export async function getUserExitTickets({
     throw new Error(`Invalid subgraph response for exit tickets of ${address}`);
   }
   if (exitTickets.length === 100) {
+    // TODO https://github.com/vetro-protocol/vetro-monorepo/issues/339
     console.warn(
       `Got exactly 100 exit tickets for ${address}. Implement pagination!`,
     );

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -124,7 +124,7 @@ export async function getUserExitTickets({
         requestId
         requestTxHash
         shares
-        stakingVaultAddress,
+        stakingVaultAddress
       }
     }`;
   const variables = {

--- a/web/src/hooks/useCancelWithdraw.ts
+++ b/web/src/hooks/useCancelWithdraw.ts
@@ -3,15 +3,16 @@ import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { cancelWithdraw } from "@vetro-protocol/earn/actions";
 import { exitTicketsQueryKey } from "pages/earn/hooks/useExitTickets";
 import type { ExitTicket } from "pages/earn/types";
+import type { Address } from "viem";
 import { useAccount } from "wagmi";
 
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { stakedBalanceQueryKey } from "./useStakedBalance";
+import { totalStakedUsdQueryKey } from "./useTotalStakedUsd";
 
 type CancelWithdrawStatus = "cancelling" | "completed" | "failed";
 
@@ -20,17 +21,15 @@ type Params = {
   onStatusChange: (status: CancelWithdrawStatus) => void;
   onTransactionHash?: (hash: string) => void;
   requestId: bigint;
+  stakingVaultAddress: Address;
 };
-
-// TODO using the only staking vault address to simplify this PR
-// we will handle multiple addresses in the next PR
-const stakingVaultAddress = stakingVaultAddresses[0];
 
 export const useCancelWithdraw = function ({
   assets,
   onStatusChange,
   onTransactionHash,
   requestId,
+  stakingVaultAddress,
 }: Params) {
   const { address: account } = useAccount();
   const chain = useMainnet();
@@ -104,12 +103,21 @@ export const useCancelWithdraw = function ({
         queryKey: nativeBalanceKey,
       });
 
-      await queryClient.invalidateQueries({
+      // Shares must be refetched before staked balance, because
+      // useStakedBalance uses ensureQueryData to read shares from cache.
+      // refetchQueries (not invalidateQueries) is required because the
+      // shares query has no mounted observer — invalidation alone would
+      // only mark it stale, and ensureQueryData returns stale cached data.
+      await queryClient.refetchQueries({
         queryKey: sharesBalanceKey,
       });
 
       queryClient.invalidateQueries({
         queryKey: stakedKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: totalStakedUsdQueryKey({ account, chainId: chain.id }),
       });
     },
   });

--- a/web/src/hooks/useClaimWithdraw.ts
+++ b/web/src/hooks/useClaimWithdraw.ts
@@ -3,10 +3,10 @@ import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { claimWithdraw } from "@vetro-protocol/earn/actions";
 import { exitTicketsQueryKey } from "pages/earn/hooks/useExitTickets";
 import type { ExitTicket } from "pages/earn/types";
+import type { Address } from "viem";
 import { useAccount } from "wagmi";
 
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
@@ -19,16 +19,14 @@ type Params = {
   onStatusChange: (status: ClaimWithdrawStatus) => void;
   onTransactionHash?: (hash: string) => void;
   requestId: bigint;
+  stakingVaultAddress: Address;
 };
-
-// TODO using the only staking vault address to simplify this PR
-// we will handle multiple addresses in the next PR
-const stakingVaultAddress = stakingVaultAddresses[0];
 
 export const useClaimWithdraw = function ({
   onStatusChange,
   onTransactionHash,
   requestId,
+  stakingVaultAddress,
 }: Params) {
   const { address: account } = useAccount();
   const chain = useMainnet();

--- a/web/src/hooks/useStakeWithdraw.ts
+++ b/web/src/hooks/useStakeWithdraw.ts
@@ -113,6 +113,7 @@ export const useStakeWithdraw = function ({
               requestId: args.requestId.toString(),
               requestTxHash: receipt.transactionHash,
               shares: args.shares.toString(),
+              stakingVaultAddress,
             };
 
             queryClient.setQueryData(

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -210,7 +210,7 @@
         "withdraw-all-toast-title": "All withdrawals complete",
         "withdraw-toast-description": "Your funds have been successfully withdrawn to your wallet.",
         "withdraw-toast-title": "Withdrawal complete",
-        "withdrawal-amount": "{{amount}} vUSD",
+        "withdrawal-amount": "{{amount}} {{symbol}}",
         "withdrawal-tx": "Withdrawal:",
         "withdrawing": "Withdrawing...",
         "withdrawn": "Withdrawn"

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -212,7 +212,7 @@
         "withdraw-all-toast-title": "Todos los retiros completados",
         "withdraw-toast-description": "Sus fondos han sido retirados exitosamente a su billetera.",
         "withdraw-toast-title": "Retiro completado",
-        "withdrawal-amount": "{{amount}} vUSD",
+        "withdrawal-amount": "{{amount}} {{symbol}}",
         "withdrawal-tx": "Retiro:",
         "withdrawing": "Retirando...",
         "withdrawn": "Retirado"

--- a/web/src/pages/earn/components/exitTickets/actionsCell.tsx
+++ b/web/src/pages/earn/components/exitTickets/actionsCell.tsx
@@ -1,11 +1,10 @@
 import { useConnectModal } from "@rainbow-me/rainbowkit";
-import { gatewayAddresses } from "@vetro-protocol/gateway";
 import { Button, ButtonIcon } from "components/base/button";
 import { Toast } from "components/base/toast";
 import { Tooltip } from "components/tooltip";
 import { useActivityTracking } from "hooks/useActivityTracking";
 import { useClaimWithdraw } from "hooks/useClaimWithdraw";
-import { usePeggedToken } from "hooks/usePeggedToken";
+import { useVaultPeggedToken } from "hooks/useVaultPeggedToken";
 import { TrashIcon } from "pages/earn/icons/trashIcon";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -27,22 +26,22 @@ type Props = {
 type WithdrawButtonProps = {
   disabled: boolean;
   isWithdrawing: boolean;
-  onConnectWallet: VoidFunction | undefined;
   onWithdraw: VoidFunction;
 };
 
 function WithdrawButton({
   disabled,
   isWithdrawing,
-  onConnectWallet,
+
   onWithdraw,
 }: WithdrawButtonProps) {
+  const { openConnectModal } = useConnectModal();
   const { t } = useTranslation();
   const { isConnected } = useAccount();
 
   if (!isConnected) {
     return (
-      <Button onClick={onConnectWallet} size="xSmall" variant="primary">
+      <Button onClick={openConnectModal} size="xSmall" variant="primary">
         {t("pages.swap.form.connect-wallet")}
       </Button>
     );
@@ -74,10 +73,8 @@ export function ActionsCell({
   ticket,
 }: Props) {
   const { t } = useTranslation();
-  const { openConnectModal } = useConnectModal();
-  // TODO using the only gateway to simplify this PR
-  // we will handle multiple gateways in the next PR
-  const { data: peggedToken } = usePeggedToken(gatewayAddresses[0]);
+
+  const { data: peggedToken } = useVaultPeggedToken(ticket.stakingVaultAddress);
   const status = getTicketStatus(ticket);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isWithdrawing, setIsWithdrawing] = useState(false);
@@ -119,6 +116,7 @@ export function ActionsCell({
     },
     onTransactionHash,
     requestId: BigInt(ticket.requestId),
+    stakingVaultAddress: ticket.stakingVaultAddress,
   });
 
   function handleWithdraw() {
@@ -135,7 +133,6 @@ export function ActionsCell({
             <WithdrawButton
               disabled={disabled}
               isWithdrawing={isWithdrawing}
-              onConnectWallet={openConnectModal}
               onWithdraw={handleWithdraw}
             />
           )}
@@ -152,10 +149,11 @@ export function ActionsCell({
           </Tooltip>
         </div>
       )}
-      {isModalOpen && (
+      {isModalOpen && peggedToken && (
         <DeleteTicketModal
           onClose={() => setIsModalOpen(false)}
           onSuccess={onDeleteSuccess}
+          peggedToken={peggedToken}
           ticket={ticket}
         />
       )}

--- a/web/src/pages/earn/components/exitTickets/dateCreatedCell.tsx
+++ b/web/src/pages/earn/components/exitTickets/dateCreatedCell.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import Skeleton from "react-loading-skeleton";
-import { formatDate } from "utils/date";
+import { formatDate, SECONDS_PER_DAY } from "utils/date";
 
 import { useCooldownDuration } from "../../hooks/useCooldownDuration";
 import type { ExitTicket } from "../../types";
@@ -25,7 +25,10 @@ export function DateCreatedCell({ ticket }: Props) {
 
   return (
     <span className="text-xsm font-normal text-gray-500">
-      {formatDate(Number(ticket.claimableAt) - data * 86400, i18n.language)}
+      {formatDate(
+        Number(ticket.claimableAt) - data * SECONDS_PER_DAY,
+        i18n.language,
+      )}
     </span>
   );
 }

--- a/web/src/pages/earn/components/exitTickets/dateCreatedCell.tsx
+++ b/web/src/pages/earn/components/exitTickets/dateCreatedCell.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from "react-i18next";
+import Skeleton from "react-loading-skeleton";
+import { formatDate } from "utils/date";
+
+import { useCooldownDuration } from "../../hooks/useCooldownDuration";
+import type { ExitTicket } from "../../types";
+
+type Props = {
+  ticket: ExitTicket;
+};
+
+export function DateCreatedCell({ ticket }: Props) {
+  const { i18n } = useTranslation();
+  const { data, isError, isLoading } = useCooldownDuration(
+    ticket.stakingVaultAddress,
+  );
+
+  if (isLoading) {
+    return <Skeleton width={100} />;
+  }
+
+  if (isError || data === undefined) {
+    return <span className="text-xsm font-normal text-gray-500">-</span>;
+  }
+
+  return (
+    <span className="text-xsm font-normal text-gray-500">
+      {formatDate(Number(ticket.claimableAt) - data * 86400, i18n.language)}
+    </span>
+  );
+}

--- a/web/src/pages/earn/components/exitTickets/deleteTicketModal.tsx
+++ b/web/src/pages/earn/components/exitTickets/deleteTicketModal.tsx
@@ -1,12 +1,11 @@
 import { useConnectModal } from "@rainbow-me/rainbowkit";
-import { gatewayAddresses } from "@vetro-protocol/gateway";
 import { Button } from "components/base/button";
 import { Modal } from "components/base/modal";
 import { useActivityTracking } from "hooks/useActivityTracking";
 import { useCancelWithdraw } from "hooks/useCancelWithdraw";
-import { usePeggedToken } from "hooks/usePeggedToken";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import type { Token } from "types";
 import { formatAmount } from "utils/token";
 import { useAccount } from "wagmi";
 
@@ -15,21 +14,25 @@ import type { ExitTicket } from "../../types";
 type Props = {
   onClose: VoidFunction;
   onSuccess?: VoidFunction;
+  peggedToken: Token;
   ticket: ExitTicket;
 };
 
-export function DeleteTicketModal({ onClose, onSuccess, ticket }: Props) {
+export function DeleteTicketModal({
+  onClose,
+  onSuccess,
+  peggedToken,
+  ticket,
+}: Props) {
   const { t } = useTranslation();
   const { isConnected } = useAccount();
   const { openConnectModal } = useConnectModal();
-  // TODO using the only gateway to simplify this PR
-  // we will handle multiple gateways in the next PR
-  const { data: peggedToken } = usePeggedToken(gatewayAddresses[0]);
+
   const [isDeleting, setIsDeleting] = useState(false);
 
   const formattedAmount = formatAmount({
     amount: BigInt(ticket.assets),
-    decimals: peggedToken?.decimals ?? 18,
+    decimals: peggedToken.decimals,
     isError: false,
   });
 
@@ -38,7 +41,7 @@ export function DeleteTicketModal({ onClose, onSuccess, ticket }: Props) {
       page: "earn",
       text: t("pages.earn.activity.cancel-withdraw-text", {
         amount: formattedAmount,
-        symbol: peggedToken?.symbol,
+        symbol: peggedToken.symbol,
       }),
       title: `${t("nav.earn")} · ${t("pages.earn.exit-tickets.delete-title")}`,
     });
@@ -65,6 +68,7 @@ export function DeleteTicketModal({ onClose, onSuccess, ticket }: Props) {
     },
     onTransactionHash,
     requestId: BigInt(ticket.requestId),
+    stakingVaultAddress: ticket.stakingVaultAddress,
   });
 
   function handleDelete() {

--- a/web/src/pages/earn/components/exitTickets/index.tsx
+++ b/web/src/pages/earn/components/exitTickets/index.tsx
@@ -14,15 +14,14 @@ import { useClaimWithdrawBatch } from "hooks/useClaimWithdrawBatch";
 import { TableCellsIcon } from "pages/earn/icons/tableCellsIcon";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { formatDate } from "utils/date";
 import { useAccount } from "wagmi";
 
-import { useCooldownDuration } from "../../hooks/useCooldownDuration";
 import { useExitTickets } from "../../hooks/useExitTickets";
 import type { ExitTicket } from "../../types";
 
 import { ActionsCell } from "./actionsCell";
 import { CooldownCell } from "./cooldownCell";
+import { DateCreatedCell } from "./dateCreatedCell";
 import { EmptyState } from "./emptyState";
 import { getTicketStatus } from "./getTicketStatus";
 import { TxsCell } from "./txsCell";
@@ -35,32 +34,18 @@ const statusLabels = {
 } as const;
 
 const getColumns = ({
-  cooldownDuration,
   isWithdrawingAll,
-  language,
   onDeleteSuccess,
   onWithdrawingChange,
   t,
 }: {
-  cooldownDuration: number | undefined;
   isWithdrawingAll: boolean;
-  language: string;
   onDeleteSuccess: VoidFunction;
   onWithdrawingChange: (isWithdrawing: boolean) => void;
   t: ReturnType<typeof useTranslation>["t"];
 }): ColumnDef<ExitTicket>[] => [
   {
-    cell: ({ row }) => (
-      <span className="text-xsm font-normal text-gray-500">
-        {/* Derive creation date by subtracting cooldown duration from claimableAt */}
-        {cooldownDuration !== undefined
-          ? formatDate(
-              Number(row.original.claimableAt) - cooldownDuration * 86400,
-              language,
-            )
-          : "-"}
-      </span>
-    ),
+    cell: ({ row }) => <DateCreatedCell ticket={row.original} />,
     header: () => (
       <Header text={t("pages.earn.exit-tickets.col-date-created")} />
     ),
@@ -122,9 +107,8 @@ const getColumns = ({
 const stakingVaultAddress = stakingVaultAddresses[0];
 
 export function ExitTickets() {
-  const { data: cooldownDuration } = useCooldownDuration(stakingVaultAddress);
   const { data, isLoading } = useExitTickets();
-  const { i18n, t } = useTranslation();
+  const { t } = useTranslation();
   const { isConnected } = useAccount();
   const { openConnectModal } = useConnectModal();
   const [selectedFilters, setSelectedFilters] = useState([
@@ -190,9 +174,7 @@ export function ExitTickets() {
   const columns = useMemo(
     () =>
       getColumns({
-        cooldownDuration,
         isWithdrawingAll,
-        language: i18n.language,
         onDeleteSuccess() {
           setShowDeleteToast(true);
         },
@@ -201,7 +183,7 @@ export function ExitTickets() {
         },
         t,
       }),
-    [cooldownDuration, i18n.language, isWithdrawingAll, t],
+    [isWithdrawingAll, t],
   );
 
   // Filter and sort data based on selected filters and ticket status

--- a/web/src/pages/earn/components/exitTickets/withdrawalCell.tsx
+++ b/web/src/pages/earn/components/exitTickets/withdrawalCell.tsx
@@ -1,6 +1,6 @@
-import { gatewayAddresses } from "@vetro-protocol/gateway";
-import { usePeggedToken } from "hooks/usePeggedToken";
+import { useVaultPeggedToken } from "hooks/useVaultPeggedToken";
 import { useTranslation } from "react-i18next";
+import Skeleton from "react-loading-skeleton";
 import { formatAmount } from "utils/token";
 
 import type { ExitTicket } from "../../types";
@@ -11,18 +11,28 @@ type Props = {
 
 export function WithdrawalCell({ ticket }: Props) {
   const { t } = useTranslation();
-  // TODO using the only gateway to simplify this PR
-  // we will handle multiple gateways in the next PR
-  const { data: peggedToken } = usePeggedToken(gatewayAddresses[0]);
-  const amount = formatAmount({
-    amount: BigInt(ticket.assets),
-    decimals: peggedToken?.decimals ?? 18,
-    isError: false,
-  });
-
-  return (
-    <span className="text-xsm font-medium text-gray-900">
-      {t("pages.earn.exit-tickets.withdrawal-amount", { amount })}
-    </span>
+  const { data: peggedToken, isError } = useVaultPeggedToken(
+    ticket.stakingVaultAddress,
   );
+
+  if (peggedToken) {
+    return (
+      <span className="text-xsm font-medium text-gray-900">
+        {t("pages.earn.exit-tickets.withdrawal-amount", {
+          amount: formatAmount({
+            amount: BigInt(ticket.assets),
+            decimals: peggedToken.decimals,
+            isError: false,
+          }),
+          symbol: peggedToken.symbol,
+        })}
+      </span>
+    );
+  }
+
+  if (isError) {
+    return <span className="text-xsm font-medium text-gray-900">-</span>;
+  }
+
+  return <Skeleton width={100} />;
 }

--- a/web/src/pages/earn/components/exitTickets/withdrawalCell.tsx
+++ b/web/src/pages/earn/components/exitTickets/withdrawalCell.tsx
@@ -1,3 +1,4 @@
+import { TokenLogo } from "components/tokenLogo";
 import { useVaultPeggedToken } from "hooks/useVaultPeggedToken";
 import { useTranslation } from "react-i18next";
 import Skeleton from "react-loading-skeleton";
@@ -17,7 +18,8 @@ export function WithdrawalCell({ ticket }: Props) {
 
   if (peggedToken) {
     return (
-      <span className="text-xsm font-medium text-gray-900">
+      <span className="text-xsm flex items-center gap-x-2 font-medium text-gray-900">
+        <TokenLogo size="small" {...peggedToken} />
         {t("pages.earn.exit-tickets.withdrawal-amount", {
           amount: formatAmount({
             amount: BigInt(ticket.assets),

--- a/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
@@ -138,7 +138,9 @@ export function StakeWithdrawForm({
   withdrawStep,
 }: Props) {
   const { isConnected } = useAccount();
-  const { data: canInstantWithdraw } = useCanInstantWithdraw();
+  const { data: canInstantWithdraw } = useCanInstantWithdraw({
+    stakingVaultAddress,
+  });
   const chain = useMainnet();
   const { data: cooldownDays } = useCooldownDuration(stakingVaultAddress);
   const { openConnectModal } = useConnectModal();

--- a/web/src/pages/earn/hooks/useCanInstantWithdraw.ts
+++ b/web/src/pages/earn/hooks/useCanInstantWithdraw.ts
@@ -1,5 +1,4 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
-import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { fetchCanInstantWithdraw } from "fetchers/fetchCanInstantWithdraw";
 import { useEthereumClient } from "hooks/useEthereumClient";
 import { useMainnet } from "hooks/useMainnet";
@@ -28,11 +27,11 @@ export const canInstantWithdrawOptions = ({
     queryKey: ["can-instant-withdraw", chainId, account, stakingVaultAddress],
   });
 
-// TODO using the only staking vault address to simplify this PR
-// we will handle multiple addresses in the next PR
-const stakingVaultAddress = stakingVaultAddresses[0];
-
-export function useCanInstantWithdraw() {
+export function useCanInstantWithdraw({
+  stakingVaultAddress,
+}: {
+  stakingVaultAddress: Address;
+}) {
   const { address: account } = useAccount();
   const chain = useMainnet();
   const client = useEthereumClient();

--- a/web/src/pages/earn/hooks/useShowExitTickets.ts
+++ b/web/src/pages/earn/hooks/useShowExitTickets.ts
@@ -1,0 +1,30 @@
+import { useQueries } from "@tanstack/react-query";
+import { stakingVaultAddresses } from "@vetro-protocol/earn";
+import { useEthereumClient } from "hooks/useEthereumClient";
+import { useMainnet } from "hooks/useMainnet";
+import { useAccount } from "wagmi";
+
+import { canInstantWithdrawOptions } from "./useCanInstantWithdraw";
+
+export function useShowExitTickets() {
+  const { address: account } = useAccount();
+  const chain = useMainnet();
+  const client = useEthereumClient();
+
+  return useQueries({
+    // Show the exit tickets section when at least one vault cannot
+    // instant-withdraw (including while still loading), since that vault
+    // requires the non-instant request flow that produces exit tickets.
+    combine: (results) => ({
+      data: results.some((result) => result.data === false),
+    }),
+    queries: stakingVaultAddresses.map((stakingVaultAddress) =>
+      canInstantWithdrawOptions({
+        account,
+        chainId: chain.id,
+        client,
+        stakingVaultAddress,
+      }),
+    ),
+  });
+}

--- a/web/src/pages/earn/index.tsx
+++ b/web/src/pages/earn/index.tsx
@@ -6,10 +6,10 @@ import { useTranslation } from "react-i18next";
 import { EarnStats } from "./components/earnStats";
 import { ExitTickets } from "./components/exitTickets";
 import { PoolInfoBar } from "./components/poolInfoBar";
-import { useCanInstantWithdraw } from "./hooks/useCanInstantWithdraw";
+import { useShowExitTickets } from "./hooks/useShowExitTickets";
 
 export function Earn() {
-  const { data: canInstantWithdraw } = useCanInstantWithdraw();
+  const { data: showExitTickets } = useShowExitTickets();
   const { t } = useTranslation();
 
   return (
@@ -24,7 +24,7 @@ export function Earn() {
           stakingVaultAddress={stakingVaultAddress}
         />
       ))}
-      {!canInstantWithdraw && (
+      {showExitTickets && (
         <>
           <div className="border-b border-gray-200 bg-gray-100">
             <StripedDivider />

--- a/web/src/pages/earn/index.tsx
+++ b/web/src/pages/earn/index.tsx
@@ -24,6 +24,8 @@ export function Earn() {
           stakingVaultAddress={stakingVaultAddress}
         />
       ))}
+      {/* TODO add skeleton loading for this section
+      See https://github.com/vetro-protocol/vetro-monorepo/issues/341 */}
       {showExitTickets && (
         <>
           <div className="border-b border-gray-200 bg-gray-100">

--- a/web/src/pages/earn/types.ts
+++ b/web/src/pages/earn/types.ts
@@ -1,4 +1,4 @@
-import type { Hash } from "viem";
+import type { Address, Hash } from "viem";
 
 export type ExitTicket = {
   assets: string;
@@ -10,4 +10,5 @@ export type ExitTicket = {
   requestId: string;
   requestTxHash: Hash;
   shares: string;
+  stakingVaultAddress: Address;
 };

--- a/web/src/utils/date.ts
+++ b/web/src/utils/date.ts
@@ -1,3 +1,5 @@
+export const SECONDS_PER_DAY = 86400;
+
 export const unixNowTimestamp = () => Math.floor(Date.now() / 1000);
 
 const toDate = (timestamp: number | string) =>


### PR DESCRIPTION
### Description

Part 7 of supporting multiple Pegged Tokens in Vetro.

This PR generalizes the Earn exit flow across vaults. Exit tickets now carry their own `stakingVaultAddress` (exposed via the API), and that address is threaded through the withdraw hooks (`useCancelWithdraw`, `useClaimWithdraw`, `useStakeWithdraw`) and exit-ticket cells so each ticket resolves its own vault and pegged token instead of assuming the first one. `useCanInstantWithdraw` is parameterized per vault, and the new `useShowExitTickets` aggregates the instant-withdraw check across all vaults to drive the Exit Tickets section visibility on the Earn page. The `withdrawal-amount` translation now interpolates the token symbol.

**Commits:**

- 68392cb Parameterize instant-withdraw by vault
- 7a07c7a Link issue missing to TODO
- 2230ea1 Expose StakingVaultAddress on API
- cfcaa66 Parameterize exit tickets by staking vault

### Screenshots

N/A — no visual changes.

### Related issue(s)

Related to #239

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.