### PR TITLE
Bump hemilabs/actions/setup-node-env to v2.3.0

### DIFF
--- a/.github/workflows/subgraph-deployment.yml
+++ b/.github/workflows/subgraph-deployment.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: hemilabs/actions/setup-node-env@e67f2b7d682accaeb026ebe393f8a161b2daa35b # v2.2.0
+      - uses: hemilabs/actions/setup-node-env@8f87619b7f0122c39e14a32514ab3e4e0d4c3966 # v2.3.0
         with:
           package-manager: pnpm
       - run: npm run deploy -- --deploy-key "$GRAPH_API_KEY"


### PR DESCRIPTION
### Description

Updates the `hemilabs/actions/setup-node-env` action used in the subgraph deployment workflow from v2.2.0 to v2.3.0.

The deploy-subgraph workflow (example: https://github.com/vetro-protocol/vetro-monorepo/actions/runs/24671411093) was emitting warnings about actions running on Node 20, which is deprecated. This was fixed in the v2.3.0 release of `hemilabs/actions/setup-node-env`.

Note: the equivalent issue has not yet been addressed in the `hemilabs/.github` repo — it should be updated once https://github.com/hemilabs/.github/pull/25 lands.

### Screenshots

N/A

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.