### PR TITLE
Support multiple pegged tokens (pt 8)

### DIFF
--- a/web/src/components/base/badge/index.tsx
+++ b/web/src/components/base/badge/index.tsx
@@ -3,17 +3,32 @@ import type { ReactNode } from "react";
 const variants = {
   blue: "bg-blue-500 text-white",
   gray: "bg-gray-50 text-gray-600 shadow-bs",
+  green: "bg-emerald-100 text-emerald-500",
+  "light-red": "bg-rose-50 text-rose-500",
   red: "bg-rose-500 text-white",
+} as const;
+
+const hoverVariants = {
+  blue: "hover:bg-blue-600",
+  gray: "hover:bg-gray-100 hover:text-gray-900",
+  green: "hover:bg-emerald-200",
+  "light-red": "hover:bg-rose-100",
+  red: "hover:bg-rose-600",
 } as const;
 
 type Props = {
   children: ReactNode;
+  hoverable?: boolean;
   variant?: keyof typeof variants;
 };
 
-export const Badge = ({ children, variant = "gray" }: Props) => (
+export const Badge = ({
+  children,
+  hoverable = false,
+  variant = "gray",
+}: Props) => (
   <span
-    className={`text-caption inline-flex h-4 items-center justify-center rounded-md px-1.5 ${variants[variant]}`}
+    className={`text-caption inline-flex h-4 items-center justify-center rounded-md px-1.5 ${variants[variant]} ${hoverable ? `cursor-pointer ${hoverVariants[variant]}` : ""}`}
   >
     {children}
   </span>

--- a/web/src/fetchers/fetchTotalMintFees.ts
+++ b/web/src/fetchers/fetchTotalMintFees.ts
@@ -64,13 +64,7 @@ export const fetchTotalMintFees = async function ({
         }),
       )
       .then((protocolFeeBps) => applyBps(amount, protocolFeeBps)),
-    queryClient.ensureQueryData(
-      pricesOptions({
-        client,
-        gatewayAddress: fromToken.gatewayAddress,
-        queryClient,
-      }),
-    ),
+    queryClient.ensureQueryData(pricesOptions({ client, queryClient })),
   ]);
 
   const ethPrice = parseEthPrice(prices);

--- a/web/src/fetchers/fetchTotalRedeemFees.ts
+++ b/web/src/fetchers/fetchTotalRedeemFees.ts
@@ -70,13 +70,7 @@ export const fetchTotalRedeemFees = async function ({
         }),
       )
       .then((protocolFeeBps) => applyBps(amount, protocolFeeBps)),
-    queryClient.ensureQueryData(
-      pricesOptions({
-        client,
-        gatewayAddress: fromToken.gatewayAddress,
-        queryClient,
-      }),
-    ),
+    queryClient.ensureQueryData(pricesOptions({ client, queryClient })),
   ]);
 
   const ethPrice = parseEthPrice(prices);

--- a/web/src/fetchers/fetchTotalStakedUsd.ts
+++ b/web/src/fetchers/fetchTotalStakedUsd.ts
@@ -1,5 +1,4 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { peggedTokensByGatewayQueryOptions } from "hooks/usePeggedTokensByGateway";
 import { pricesOptions } from "hooks/usePrices";
 import { stakedBalanceQueryOptions } from "hooks/useStakedBalance";
 import { vaultPeggedTokenQueryOptions } from "hooks/useVaultPeggedToken";
@@ -22,24 +21,13 @@ export const fetchTotalStakedUsd = async function ({
     throw new Error("Client is missing a chain");
   }
 
-  // peggedTokensByGateway is indexed by gateway address; we only have the pegged
-  // token here, so reverse the index to look up gateway by pegged-token address.
-  // Kick off the fetch now (without awaiting) so it overlaps with the per-vault
-  // pegged-token fetch below.
-  const gatewayByPeggedTokenPromise = queryClient
-    .ensureQueryData(peggedTokensByGatewayQueryOptions({ client, queryClient }))
-    .then((peggedTokensByGateway) =>
-      Object.fromEntries(
-        Object.values(peggedTokensByGateway).map((token) => [
-          token.address,
-          token.gatewayAddress,
-        ]),
-      ),
-    );
+  const pricesPromise = queryClient.ensureQueryData(
+    pricesOptions({ client, queryClient }),
+  );
 
   const perVaultUsd = await Promise.all(
     stakingVaultAddresses.map(async function (stakingVaultAddress) {
-      const [peggedToken, gatewayByPeggedToken] = await Promise.all([
+      const [peggedToken, stakedAssets, prices] = await Promise.all([
         queryClient.ensureQueryData(
           vaultPeggedTokenQueryOptions({
             client,
@@ -47,16 +35,6 @@ export const fetchTotalStakedUsd = async function ({
             stakingVaultAddress,
           }),
         ),
-        gatewayByPeggedTokenPromise,
-      ]);
-      const gatewayAddress = gatewayByPeggedToken[peggedToken.address];
-      if (!gatewayAddress) {
-        throw new Error(
-          `No gateway found for pegged token ${peggedToken.address}`,
-        );
-      }
-
-      const [stakedAssets, prices] = await Promise.all([
         queryClient.ensureQueryData(
           stakedBalanceQueryOptions({
             account,
@@ -66,9 +44,7 @@ export const fetchTotalStakedUsd = async function ({
             stakingVaultAddress,
           }),
         ),
-        queryClient.ensureQueryData(
-          pricesOptions({ client, gatewayAddress, queryClient }),
-        ),
+        pricesPromise,
       ]);
 
       const amount = Number(formatUnits(stakedAssets, peggedToken.decimals));

--- a/web/src/hooks/useCancelWithdraw.ts
+++ b/web/src/hooks/useCancelWithdraw.ts
@@ -11,6 +11,7 @@ import { useAccount } from "wagmi";
 
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
+import { poolDepositsQueryKey } from "./usePoolDeposits";
 import { stakedBalanceQueryKey } from "./useStakedBalance";
 import { totalStakedUsdQueryKey } from "./useTotalStakedUsd";
 
@@ -48,6 +49,11 @@ export const useCancelWithdraw = function ({
 
   const stakedKey = stakedBalanceQueryKey({
     account: account!,
+    chainId: chain.id,
+    stakingVaultAddress,
+  });
+
+  const poolDepositsKey = poolDepositsQueryKey({
     chainId: chain.id,
     stakingVaultAddress,
   });
@@ -94,6 +100,10 @@ export const useCancelWithdraw = function ({
         queryClient.setQueryData(stakedKey, (old: bigint | undefined) =>
           old !== undefined ? old + assets : old,
         );
+        // Optimistically add assets back to pool deposits
+        queryClient.setQueryData(poolDepositsKey, (old: bigint | undefined) =>
+          old !== undefined ? old + assets : old,
+        );
       });
 
       return promise;
@@ -118,6 +128,13 @@ export const useCancelWithdraw = function ({
 
       queryClient.invalidateQueries({
         queryKey: totalStakedUsdQueryKey({ account, chainId: chain.id }),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: poolDepositsQueryKey({
+          chainId: chain.id,
+          stakingVaultAddress,
+        }),
       });
     },
   });

--- a/web/src/hooks/useInstantWithdraw.ts
+++ b/web/src/hooks/useInstantWithdraw.ts
@@ -11,6 +11,7 @@ import { useAccount } from "wagmi";
 
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
+import { poolDepositsQueryKey } from "./usePoolDeposits";
 import { stakedBalanceQueryKey } from "./useStakedBalance";
 import { totalStakedUsdQueryKey } from "./useTotalStakedUsd";
 
@@ -57,6 +58,11 @@ export const useInstantWithdraw = function ({
     stakingVaultAddress,
   });
 
+  const poolDepositsKey = poolDepositsQueryKey({
+    chainId: chain.id,
+    stakingVaultAddress,
+  });
+
   return useMutation({
     async mutationFn() {
       if (!account) {
@@ -96,6 +102,9 @@ export const useInstantWithdraw = function ({
       queryClient.setQueryData(stakedKey, (old: bigint | undefined) =>
         old !== undefined ? old - assets : old,
       );
+      queryClient.setQueryData(poolDepositsKey, (old: bigint | undefined) =>
+        old !== undefined ? old - assets : old,
+      );
     },
     onError() {
       onStatusChange?.("failed");
@@ -124,6 +133,13 @@ export const useInstantWithdraw = function ({
 
       queryClient.invalidateQueries({
         queryKey: totalStakedUsdQueryKey({ account, chainId: chain.id }),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: poolDepositsQueryKey({
+          chainId: chain.id,
+          stakingVaultAddress,
+        }),
       });
     },
   });

--- a/web/src/hooks/usePeggedTokensByGateway.ts
+++ b/web/src/hooks/usePeggedTokensByGateway.ts
@@ -11,7 +11,7 @@ import type { Address, Client } from "viem";
 import { useEthereumClient } from "./useEthereumClient";
 import { peggedTokenQueryOptions } from "./usePeggedToken";
 
-export const peggedTokensByGatewayQueryOptions = ({
+const peggedTokensByGatewayQueryOptions = ({
   client,
   queryClient,
 }: {

--- a/web/src/hooks/usePoolDeposits.ts
+++ b/web/src/hooks/usePoolDeposits.ts
@@ -4,6 +4,14 @@ import { useMainnet } from "hooks/useMainnet";
 import type { Address } from "viem";
 import { totalAssets } from "viem-erc4626/actions";
 
+export const poolDepositsQueryKey = ({
+  chainId,
+  stakingVaultAddress,
+}: {
+  chainId: number;
+  stakingVaultAddress: Address;
+}) => ["pool-deposits", chainId, stakingVaultAddress];
+
 export function usePoolDeposits(stakingVaultAddress: Address) {
   const chain = useMainnet();
   const client = useEthereumClient();
@@ -11,7 +19,10 @@ export function usePoolDeposits(stakingVaultAddress: Address) {
   return useQuery({
     enabled: !!client,
     queryFn: () => totalAssets(client!, { address: stakingVaultAddress }),
-    queryKey: ["pool-deposits", chain.id, stakingVaultAddress],
+    queryKey: poolDepositsQueryKey({
+      chainId: chain.id,
+      stakingVaultAddress,
+    }),
     refetchInterval: 5 * 60 * 1000, // 5 minutes
   });
 }

--- a/web/src/hooks/usePrices.ts
+++ b/web/src/hooks/usePrices.ts
@@ -4,7 +4,8 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import type { Address, Client } from "viem";
+import { gatewayAddresses } from "@vetro-protocol/gateway";
+import type { Client } from "viem";
 
 import { useEthereumClient } from "./useEthereumClient";
 import { oraclePricesOptions } from "./useOraclePrices";
@@ -12,38 +13,34 @@ import { tokenPricesOptions } from "./useTokenPrices";
 
 export const pricesOptions = ({
   client,
-  gatewayAddress,
   queryClient,
 }: {
   client: Client | undefined;
-  gatewayAddress?: Address;
   queryClient: QueryClient;
 }) =>
   queryOptions({
     enabled: !!client && !!client.chain,
     async queryFn() {
-      const [portalPrices, oraclePrices] = await Promise.all([
+      // Assumes whitelisted tokens are disjoint across gateways; if two
+      // gateways ever whitelist the same symbol, the later one wins on merge.
+      const [portalPrices, ...oraclePricesPerGateway] = await Promise.all([
         queryClient.ensureQueryData(tokenPricesOptions()),
-        queryClient.ensureQueryData(
-          oraclePricesOptions({ client, gatewayAddress, queryClient }),
+        ...gatewayAddresses.map((gatewayAddress) =>
+          queryClient.ensureQueryData(
+            oraclePricesOptions({ client, gatewayAddress, queryClient }),
+          ),
         ),
       ]);
-      return { ...portalPrices, ...oraclePrices };
+      return Object.assign({}, portalPrices, ...oraclePricesPerGateway);
     },
-    queryKey: ["prices", client?.chain?.id, gatewayAddress],
+    queryKey: ["prices", client?.chain?.id],
     refetchInterval: 60_000,
     staleTime: 30_000,
   });
 
-export const usePrices = function (gatewayAddress?: Address) {
+export const usePrices = function () {
   const client = useEthereumClient();
   const queryClient = useQueryClient();
 
-  return useQuery(
-    pricesOptions({
-      client,
-      gatewayAddress,
-      queryClient,
-    }),
-  );
+  return useQuery(pricesOptions({ client, queryClient }));
 };

--- a/web/src/hooks/useStakeDeposit.ts
+++ b/web/src/hooks/useStakeDeposit.ts
@@ -11,6 +11,7 @@ import { useAccount } from "wagmi";
 
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
+import { poolDepositsQueryKey } from "./usePoolDeposits";
 import { stakedBalanceQueryKey } from "./useStakedBalance";
 import { totalStakedUsdQueryKey } from "./useTotalStakedUsd";
 
@@ -66,6 +67,11 @@ export const useStakeDeposit = function ({
 
   const stakedKey = stakedBalanceQueryKey({
     account: account!,
+    chainId: chain.id,
+    stakingVaultAddress,
+  });
+
+  const poolDepositsKey = poolDepositsQueryKey({
     chainId: chain.id,
     stakingVaultAddress,
   });
@@ -149,6 +155,11 @@ export const useStakeDeposit = function ({
           queryClient.setQueryData(stakedKey, (old: bigint | undefined) =>
             old !== undefined ? old + assets : old,
           );
+          queryClient.setQueryData(
+            poolDepositsKey,
+            (old: bigint | undefined) =>
+              old !== undefined ? old + assets : old,
+          );
         },
       );
 
@@ -182,6 +193,13 @@ export const useStakeDeposit = function ({
 
       queryClient.invalidateQueries({
         queryKey: totalStakedUsdQueryKey({ account, chainId: chain.id }),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: poolDepositsQueryKey({
+          chainId: chain.id,
+          stakingVaultAddress,
+        }),
       });
     },
   });

--- a/web/src/hooks/useStakeWithdraw.ts
+++ b/web/src/hooks/useStakeWithdraw.ts
@@ -12,6 +12,7 @@ import { useAccount } from "wagmi";
 
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
+import { poolDepositsQueryKey } from "./usePoolDeposits";
 import { stakedBalanceQueryKey } from "./useStakedBalance";
 import { totalStakedUsdQueryKey } from "./useTotalStakedUsd";
 
@@ -50,6 +51,11 @@ export const useStakeWithdraw = function ({
 
   const stakedKey = stakedBalanceQueryKey({
     account: account!,
+    chainId: chain.id,
+    stakingVaultAddress,
+  });
+
+  const poolDepositsKey = poolDepositsQueryKey({
     chainId: chain.id,
     stakingVaultAddress,
   });
@@ -95,6 +101,12 @@ export const useStakeWithdraw = function ({
           // Optimistically update staked balance
           queryClient.setQueryData(stakedKey, (old: bigint | undefined) =>
             old !== undefined ? old - assets : old,
+          );
+          // Optimistically update pool deposits balance
+          queryClient.setQueryData(
+            poolDepositsKey,
+            (old: bigint | undefined) =>
+              old !== undefined ? old - assets : old,
           );
 
           // Optimistically add exit ticket to cache
@@ -146,6 +158,13 @@ export const useStakeWithdraw = function ({
 
       queryClient.invalidateQueries({
         queryKey: totalStakedUsdQueryKey({ account, chainId: chain.id }),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: poolDepositsQueryKey({
+          chainId: chain.id,
+          stakingVaultAddress,
+        }),
       });
     },
   });

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -265,6 +265,8 @@
       },
       "stats": {
         "earned-amount": "Your earned amount",
+        "from-pools": "From {{count}} pool",
+        "from-pools_other": "From {{count}} pools",
         "rewards": "Your rewards",
         "staked-balance": "Your staked balance"
       },

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -270,6 +270,8 @@
       },
       "stats": {
         "earned-amount": "Su monto ganado",
+        "from-pools": "De {{count}} fondo",
+        "from-pools_other": "De {{count}} fondos",
         "rewards": "Sus recompensas",
         "staked-balance": "Su balance stakeado"
       },

--- a/web/src/pages/earn/components/stakedBalanceStat/index.tsx
+++ b/web/src/pages/earn/components/stakedBalanceStat/index.tsx
@@ -1,9 +1,114 @@
+import { useQueries, useQueryClient } from "@tanstack/react-query";
+import { stakingVaultAddresses } from "@vetro-protocol/earn";
+import { Badge } from "components/base/badge";
+import { RenderFiatValue } from "components/base/fiatValue";
+import { TokenLogo } from "components/tokenLogo";
+import { Tooltip } from "components/tooltip";
+import { useEthereumClient } from "hooks/useEthereumClient";
+import { useMainnet } from "hooks/useMainnet";
+import { stakedBalanceQueryOptions } from "hooks/useStakedBalance";
 import { useTotalStakedUsd } from "hooks/useTotalStakedUsd";
+import { useVaultPeggedToken } from "hooks/useVaultPeggedToken";
 import { useTranslation } from "react-i18next";
 import { formatUsd } from "utils/currency";
+import { formatNumber } from "utils/format";
+import { type Address, formatUnits } from "viem";
+import { useAccount } from "wagmi";
 
 import { BoltIcon } from "../../icons/boltIcon";
 import { StatCard } from "../statCard";
+
+type PoolRowProps = {
+  balance: bigint;
+  stakingVaultAddress: Address;
+};
+
+function PoolRow({ balance, stakingVaultAddress }: PoolRowProps) {
+  const { data: peggedToken } = useVaultPeggedToken(stakingVaultAddress);
+
+  if (!peggedToken) {
+    return null;
+  }
+
+  const formattedTokenAmount = formatNumber(
+    formatUnits(balance, peggedToken.decimals),
+  );
+
+  return (
+    <div className="flex items-center gap-1 sm:min-w-52">
+      <TokenLogo
+        logoURI={peggedToken.logoURI}
+        size="small"
+        symbol={peggedToken.symbol}
+      />
+      <span className="text-xsm mr-auto font-medium text-white">
+        {peggedToken.symbol}
+      </span>
+      <span className="text-xsm font-medium text-white">
+        $<RenderFiatValue token={peggedToken} value={balance} />
+      </span>
+      <span className="text-xsm font-medium text-gray-400">
+        ({formattedTokenAmount} {peggedToken.symbol})
+      </span>
+    </div>
+  );
+}
+
+function FromPoolsBadge() {
+  const { t } = useTranslation();
+  const { address: account } = useAccount();
+  const chain = useMainnet();
+  const client = useEthereumClient();
+  const queryClient = useQueryClient();
+
+  const balanceQueries = useQueries({
+    queries: stakingVaultAddresses.map((stakingVaultAddress) =>
+      stakedBalanceQueryOptions({
+        account,
+        chainId: chain.id,
+        client,
+        queryClient,
+        stakingVaultAddress,
+      }),
+    ),
+  });
+
+  const activeVaults = stakingVaultAddresses
+    .map((stakingVaultAddress, idx) => ({
+      balance: balanceQueries[idx].data,
+      stakingVaultAddress,
+    }))
+    .filter(
+      (vault): vault is PoolRowProps =>
+        vault.balance !== undefined && vault.balance > 0n,
+    );
+
+  const count = activeVaults.length;
+
+  if (count === 0) {
+    return null;
+  }
+
+  return (
+    <Tooltip
+      content={
+        <div className="flex flex-col gap-1">
+          {activeVaults.map(({ balance, stakingVaultAddress }) => (
+            <PoolRow
+              balance={balance}
+              key={stakingVaultAddress}
+              stakingVaultAddress={stakingVaultAddress}
+            />
+          ))}
+        </div>
+      }
+    >
+      <Badge hoverable variant="gray">
+        {t("pages.earn.stats.from-pools", { count })}
+      </Badge>
+    </Tooltip>
+  );
+}
 
 export function StakedBalanceStat() {
   const { t } = useTranslation();
@@ -11,6 +116,7 @@ export function StakedBalanceStat() {
 
   return (
     <StatCard
+      badge={<FromPoolsBadge />}
       icon={<BoltIcon />}
       isLoading={isLoading}
       label={t("pages.earn.stats.staked-balance")}

--- a/web/src/pages/earn/components/statCard/index.tsx
+++ b/web/src/pages/earn/components/statCard/index.tsx
@@ -2,13 +2,14 @@ import type { ReactNode } from "react";
 import Skeleton from "react-loading-skeleton";
 
 type Props = {
+  badge?: ReactNode;
   icon: ReactNode;
   isLoading?: boolean;
   label: string;
   value: string;
 };
 
-export function StatCard({ icon, isLoading, label, value }: Props) {
+export function StatCard({ badge, icon, isLoading, label, value }: Props) {
   const renderValue = function () {
     if (value) {
       return value;
@@ -26,6 +27,7 @@ export function StatCard({ icon, isLoading, label, value }: Props) {
         <div className="size-4">{icon}</div>
       </div>
       <h3 className="text-2xl font-semibold text-gray-900">{renderValue()}</h3>
+      {badge && <div className="self-start empty:hidden">{badge}</div>}
     </div>
   );
 }

--- a/web/src/pages/earn/index.tsx
+++ b/web/src/pages/earn/index.tsx
@@ -15,7 +15,7 @@ export function Earn() {
   return (
     <>
       <PageTitle value={t("pages.earn.title")} />
-      <div className="flex flex-col border-y border-gray-200 bg-gray-100 *:-mt-px md:flex-row md:items-center md:justify-center md:gap-14 md:px-14 md:*:w-[267px]">
+      <div className="flex flex-col border-y border-gray-200 bg-gray-100 *:-mt-px md:flex-row md:justify-center md:gap-14 md:px-14 md:*:w-[267px]">
         <EarnStats />
       </div>
       {stakingVaultAddresses.map((stakingVaultAddress) => (

--- a/web/stories/badge.stories.tsx
+++ b/web/stories/badge.stories.tsx
@@ -3,10 +3,16 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Badge } from "../src/components/base/badge";
 
 const meta: Meta<typeof Badge> = {
+  args: {
+    hoverable: false,
+  },
   argTypes: {
+    hoverable: {
+      control: "boolean",
+    },
     variant: {
       control: "select",
-      options: ["blue", "gray", "red"],
+      options: ["blue", "gray", "green", "light-red", "red"],
     },
   },
   component: Badge,
@@ -27,6 +33,20 @@ export const Gray: Story = {
   args: {
     children: "Default",
     variant: "gray",
+  },
+};
+
+export const Green: Story = {
+  args: {
+    children: "Active",
+    variant: "green",
+  },
+};
+
+export const LightRed: Story = {
+  args: {
+    children: "Warning",
+    variant: "light-red",
   },
 };
 

--- a/web/test/fetchers/fetchTotalStakedUsd.test.ts
+++ b/web/test/fetchers/fetchTotalStakedUsd.test.ts
@@ -1,8 +1,6 @@
-import { peggedTokensByGatewayQueryOptions } from "hooks/usePeggedTokensByGateway";
 import { pricesOptions } from "hooks/usePrices";
 import { stakedBalanceQueryOptions } from "hooks/useStakedBalance";
 import { vaultPeggedTokenQueryOptions } from "hooks/useVaultPeggedToken";
-import type { TokenWithGateway } from "types";
 import { knownTokens } from "utils/tokenList";
 import type { Address, Client } from "viem";
 import { mainnet } from "viem/chains";
@@ -16,28 +14,13 @@ const client = { chain: mainnet } as unknown as Client;
 
 const vault1 = "0x1111111111111111111111111111111111111111" as Address;
 const vault2 = "0x2222222222222222222222222222222222222222" as Address;
-const gateway1 = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as Address;
-const gateway2 = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as Address;
 
 const vusd = knownTokens.find((token) => token.symbol === "VUSD")!;
 const usdc = knownTokens.find((token) => token.symbol === "USDC")!;
 
-const vusdWithGateway: TokenWithGateway = {
-  ...vusd,
-  gatewayAddress: gateway1,
-};
-const usdcWithGateway: TokenWithGateway = {
-  ...usdc,
-  gatewayAddress: gateway2,
-};
-
 describe("fetchTotalStakedUsd", function () {
   it("returns staked amount times price for a single vault", async function () {
     const queryClient = createTestQueryClient();
-    queryClient.setQueryData(
-      peggedTokensByGatewayQueryOptions({ client, queryClient }).queryKey,
-      { [gateway1]: vusdWithGateway },
-    );
     queryClient.setQueryData(
       vaultPeggedTokenQueryOptions({
         client,
@@ -57,10 +40,9 @@ describe("fetchTotalStakedUsd", function () {
       10n * 10n ** 18n,
     );
     // VUSD's priceSymbol is USDT, so getTokenPrice looks up the USDT key.
-    queryClient.setQueryData(
-      pricesOptions({ client, gatewayAddress: gateway1, queryClient }).queryKey,
-      { USDT: "1" },
-    );
+    queryClient.setQueryData(pricesOptions({ client, queryClient }).queryKey, {
+      USDT: "1",
+    });
 
     const result = await fetchTotalStakedUsd({
       account,
@@ -72,15 +54,8 @@ describe("fetchTotalStakedUsd", function () {
     expect(result).toBe(10);
   });
 
-  it("sums staked values across multiple vaults on different gateways", async function () {
+  it("sums staked values across multiple vaults", async function () {
     const queryClient = createTestQueryClient();
-    queryClient.setQueryData(
-      peggedTokensByGatewayQueryOptions({ client, queryClient }).queryKey,
-      {
-        [gateway1]: vusdWithGateway,
-        [gateway2]: usdcWithGateway,
-      },
-    );
     queryClient.setQueryData(
       vaultPeggedTokenQueryOptions({
         client,
@@ -117,14 +92,10 @@ describe("fetchTotalStakedUsd", function () {
       }).queryKey,
       25n * 10n ** 6n,
     );
-    queryClient.setQueryData(
-      pricesOptions({ client, gatewayAddress: gateway1, queryClient }).queryKey,
-      { USDT: "1" } as Record<string, string>,
-    );
-    queryClient.setQueryData(
-      pricesOptions({ client, gatewayAddress: gateway2, queryClient }).queryKey,
-      { USDC: "1.1" } as Record<string, string>,
-    );
+    queryClient.setQueryData(pricesOptions({ client, queryClient }).queryKey, {
+      USDC: "1.1",
+      USDT: "1",
+    } as Record<string, string>);
 
     const result = await fetchTotalStakedUsd({
       account,
@@ -139,10 +110,6 @@ describe("fetchTotalStakedUsd", function () {
 
   it("contributes 0 when the pegged token has no price entry", async function () {
     const queryClient = createTestQueryClient();
-    queryClient.setQueryData(
-      peggedTokensByGatewayQueryOptions({ client, queryClient }).queryKey,
-      { [gateway1]: vusdWithGateway } as Record<Address, TokenWithGateway>,
-    );
     queryClient.setQueryData(
       vaultPeggedTokenQueryOptions({
         client,
@@ -162,7 +129,7 @@ describe("fetchTotalStakedUsd", function () {
       10n * 10n ** 18n,
     );
     queryClient.setQueryData(
-      pricesOptions({ client, gatewayAddress: gateway1, queryClient }).queryKey,
+      pricesOptions({ client, queryClient }).queryKey,
       {},
     );
 
@@ -174,31 +141,6 @@ describe("fetchTotalStakedUsd", function () {
     });
 
     expect(result).toBe(0);
-  });
-
-  it("throws when a vault's pegged token has no matching gateway", async function () {
-    const queryClient = createTestQueryClient();
-    queryClient.setQueryData(
-      peggedTokensByGatewayQueryOptions({ client, queryClient }).queryKey,
-      {},
-    );
-    queryClient.setQueryData(
-      vaultPeggedTokenQueryOptions({
-        client,
-        queryClient,
-        stakingVaultAddress: vault1,
-      }).queryKey,
-      vusd,
-    );
-
-    await expect(
-      fetchTotalStakedUsd({
-        account,
-        client,
-        queryClient,
-        stakingVaultAddresses: [vault1],
-      }),
-    ).rejects.toThrow(/No gateway found for pegged token/);
   });
 
   it("throws when the client has no chain", async function () {


### PR DESCRIPTION
### Description

Part 8 of the vetBTC/svetBTC rollout, focused on making price/pool data gateway-agnostic and surfacing per-pool staked balances on Earn.

- 31f8eb0 `usePrices` now fetches oracle prices for every gateway in `gatewayAddresses` and merges them into a single flat price map, so callers don't need to know which gateway a token belongs to. Simplifies `fetchTotalStakedUsd`.
- cde4215 Earn's staked-balance stat gets a "From X pools" badge; hovering opens a tooltip listing each active pool with token amount and USD value. `StatCard` gains an optional `badge` slot, and the stats row now stretches to match the tallest card.
- f7c06dc The `pool-deposits` query (shown on the Pool Info Bar) is now optimistically patched and invalidated in the success/settled callbacks of the deposit/withdraw/instant-withdraw/cancel-withdraw mutations, so it no longer goes stale until a page refresh.
- 98169d2 `Badge` gets an optional `hoverable` prop that adds matching `hover:bg-*` and `cursor-pointer` so it can be used as an interactive element. Storybook meta extended to cover all variants and the new prop.

### Screenshots


https://github.com/user-attachments/assets/0a3d6207-f972-4a72-8eed-657574747444

Note: There's a text color update of the badge on hover, that was added after this recording

### Related issue(s)

Related to #239

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.