### PR TITLE
Index sVetBTC staking vault in subgraph

### DIFF
--- a/subgraph/networks.json
+++ b/subgraph/networks.json
@@ -1,8 +1,12 @@
 {
   "mainnet": {
-    "StakingVault": {
+    "sVusdStakingVault": {
       "address": "0x476310E34D2810f7d79C43A74E4D79405bd7a925",
       "startBlock": 24625396
+    },
+    "sVetBTCStakingVault": {
+      "address": "0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e",
+      "startBlock": 24931128
     }
   }
 }

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vetro-app-subgraph",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "scripts": {
     "prebuild": "npm run codegen",

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -10,7 +10,8 @@ import {
   WithdrawCancelled,
   WithdrawClaimed,
   WithdrawRequested,
-} from "../generated/StakingVault/StakingVault";
+  // The code generated is the same for both vaults
+} from "../generated/sVusdStakingVault/StakingVault";
 
 const buildId = (vaultAddress: Address, suffix: string): string =>
   `${vaultAddress.toHexString()}-${suffix}`;

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -5,12 +5,40 @@ schema:
   file: ./schema.graphql
 dataSources:
   - kind: ethereum
-    name: StakingVault
+    name: sVusdStakingVault
     network: mainnet
     source:
       address: "0x476310E34D2810f7d79C43A74E4D79405bd7a925"
       abi: StakingVault
       startBlock: 24625396
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - ExitTicket
+        - ExitTicketQueueSummary
+        - VaultHistory
+      abis:
+        - name: StakingVault
+          file: ./abis/StakingVault.json
+      eventHandlers:
+        - event: WithdrawCancelled(indexed address,indexed uint256,uint256,uint256)
+          handler: handleWithdrawCancelled
+        - event: WithdrawClaimed(indexed address,indexed address,indexed uint256,uint256)
+          handler: handleWithdrawClaimed
+        - event: WithdrawRequested(indexed address,indexed uint256,uint256,uint256,uint256)
+          handler: handleWithdrawRequested
+      blockHandlers:
+        - handler: handleBlock
+      file: ./src/earn.ts
+  - kind: ethereum
+    name: sVetBTCStakingVault
+    network: mainnet
+    source:
+      address: "0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e"
+      abi: StakingVault
+      startBlock: 24931128
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9

--- a/subgraph/tests/earn-utils.ts
+++ b/subgraph/tests/earn-utils.ts
@@ -5,7 +5,7 @@ import {
   WithdrawCancelled,
   WithdrawClaimed,
   WithdrawRequested,
-} from "../generated/StakingVault/StakingVault";
+} from "../generated/sVusdStakingVault/StakingVault";
 
 export function createMockBlock(
   number: BigInt,


### PR DESCRIPTION
### Description

Add a second data source to the subgraph so it indexes the newly deployed sVetBTC staking vault at `0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e` (starts at block `24931128`) alongside the existing sVUSD vault. The existing `StakingVault` data source is renamed to `sVusdStakingVault` so both vaults have asset-specific, unambiguous names in `networks.json`, `subgraph.yaml`, and the `generated/` tree. Both vaults share the same ABI and the existing mapping file (`src/earn.ts`) — every handler already routes per-vault via `dataSource.address()`, so no code changes were needed there beyond the import path update. Subgraph version bumped to `1.3.0`.

### Screenshots

N/A — subgraph-only change.

### Related issue(s)

Related to #239

### Checklist

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.