### PR TITLE
Track average purchase price and add Transfer event handling

### DIFF
--- a/subgraph/abis/StakingVault.json
+++ b/subgraph/abis/StakingVault.json
@@ -179,5 +179,30 @@
       }
     ],
     "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
   }
 ]

--- a/subgraph/abis/StakingVault.json
+++ b/subgraph/abis/StakingVault.json
@@ -1,6 +1,25 @@
 [
   {
     "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "convertToAssets",
     "inputs": [
       {
@@ -30,6 +49,37 @@
       }
     ],
     "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "Deposit",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
   },
   {
     "type": "event",

--- a/subgraph/networks.json
+++ b/subgraph/networks.json
@@ -1,8 +1,12 @@
 {
   "mainnet": {
-    "StakingVault": {
+    "sVusdStakingVault": {
       "address": "0x476310E34D2810f7d79C43A74E4D79405bd7a925",
       "startBlock": 24625396
+    },
+    "sVetBTCStakingVault": {
+      "address": "0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e",
+      "startBlock": 24931128
     }
   }
 }

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vetro-app-subgraph",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "scripts": {
     "prebuild": "npm run codegen",

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -25,3 +25,10 @@ type ExitTicketQueueSummary @entity(immutable: false) {
   shares: BigInt!
   stakingVaultAddress: Bytes!
 }
+
+type UserStakingPosition @entity(immutable: false) {
+  averagePrice: BigInt!
+  id: ID!
+  owner: Bytes!
+  stakingVaultAddress: Bytes!
+}

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -27,8 +27,9 @@ type ExitTicketQueueSummary @entity(immutable: false) {
 }
 
 type UserStakingPosition @entity(immutable: false) {
-  averagePrice: BigInt!
   id: ID!
   owner: Bytes!
+  shares: BigInt!
   stakingVaultAddress: Bytes!
+  totalCostBasis: BigInt! # WAD-scaled (36 decimals when asset has 18 decimals)
 }

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -89,6 +89,14 @@ export function handleTransfer(event: Transfer): void {
   if (event.params.from.equals(Address.zero())) {
     return;
   }
+  // Self-transfer will cause incorrect average price dilution. Skip those.
+  if (event.params.from.equals(event.params.to)) {
+    return;
+  }
+  // Zero-value transfer will also cause incorrect average price dilution.
+  if (event.params.value.equals(BigInt.fromI32(0))) {
+    return;
+  }
 
   const vaultAddress = dataSource.address();
   const to = event.params.to;

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -13,7 +13,8 @@ import {
   WithdrawCancelled,
   WithdrawClaimed,
   WithdrawRequested,
-} from "../generated/StakingVault/StakingVault";
+  // The code generated is the same for both vaults
+} from "../generated/sVusdStakingVault/StakingVault";
 
 const buildId = (vaultAddress: Address, suffix: string): string =>
   `${vaultAddress.toHexString()}-${suffix}`;

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -9,6 +9,7 @@ import {
 import {
   Deposit,
   StakingVault,
+  Transfer,
   WithdrawCancelled,
   WithdrawClaimed,
   WithdrawRequested,
@@ -78,6 +79,34 @@ export function handleDeposit(event: Deposit): void {
     .times(entity.averagePrice)
     .plus(event.params.assets.times(WAD));
   entity.averagePrice = calculatedAssets.div(currentShares);
+
+  entity.save();
+}
+
+export function handleTransfer(event: Transfer): void {
+  // Skip mints as those are already handled by the Deposit event handler.
+  if (event.params.from.equals(Address.zero())) {
+    return;
+  }
+
+  const vaultAddress = dataSource.address();
+  const to = event.params.to;
+  const id = buildId(vaultAddress, to.toHexString());
+
+  let entity = UserStakingPosition.load(id);
+  if (entity == null) {
+    entity = new UserStakingPosition(id);
+    entity.averagePrice = BigInt.fromI32(0);
+    entity.owner = to;
+    entity.stakingVaultAddress = vaultAddress;
+  }
+
+  const vault = StakingVault.bind(vaultAddress);
+  const currentShares = vault.balanceOf(to);
+  const oldShares = currentShares.minus(event.params.value);
+
+  // Transferred-in shares are valued at 0, diluting the average price proportionally.
+  entity.averagePrice = entity.averagePrice.times(oldShares).div(currentShares);
 
   entity.save();
 }

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -89,6 +89,10 @@ export function handleTransfer(event: Transfer): void {
   if (event.params.from.equals(Address.zero())) {
     return;
   }
+  // Skip burns as those are not relevant.
+  if (event.params.to.equals(Address.zero())) {
+    return;
+  }
   // Self-transfer will cause incorrect average price dilution. Skip those.
   if (event.params.from.equals(event.params.to)) {
     return;

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -3,9 +3,11 @@ import { Address, BigInt, dataSource, ethereum } from "@graphprotocol/graph-ts";
 import {
   ExitTicket,
   ExitTicketQueueSummary,
+  UserStakingPosition,
   VaultHistory,
 } from "../generated/schema";
 import {
+  Deposit,
   StakingVault,
   WithdrawCancelled,
   WithdrawClaimed,
@@ -14,6 +16,8 @@ import {
 
 const buildId = (vaultAddress: Address, suffix: string): string =>
   `${vaultAddress.toHexString()}-${suffix}`;
+
+const WAD = BigInt.fromI32(10).pow(18);
 
 function loadOrCreateQueueSummary(
   vaultAddress: Address,
@@ -48,6 +52,32 @@ export function handleBlock(block: ethereum.Block): void {
   const oneShare = BigInt.fromI32(10).pow(<u8>decimals);
   const shareValue = vault.convertToAssets(oneShare);
   entity.shareValue = shareValue;
+
+  entity.save();
+}
+
+export function handleDeposit(event: Deposit): void {
+  const vaultAddress = dataSource.address();
+  const owner = event.params.owner;
+  const id = buildId(vaultAddress, owner.toHexString());
+
+  let entity = UserStakingPosition.load(id);
+  if (entity == null) {
+    entity = new UserStakingPosition(id);
+    entity.averagePrice = BigInt.fromI32(0);
+    entity.owner = owner;
+    entity.stakingVaultAddress = vaultAddress;
+  }
+
+  const vault = StakingVault.bind(vaultAddress);
+  const currentShares = vault.balanceOf(owner);
+  const newShares = event.params.shares;
+  const oldShares = currentShares.minus(newShares);
+
+  const calculatedAssets = oldShares
+    .times(entity.averagePrice)
+    .plus(event.params.assets.times(WAD));
+  entity.averagePrice = calculatedAssets.div(currentShares);
 
   entity.save();
 }

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -66,20 +66,16 @@ export function handleDeposit(event: Deposit): void {
   let entity = UserStakingPosition.load(id);
   if (entity == null) {
     entity = new UserStakingPosition(id);
-    entity.averagePrice = BigInt.fromI32(0);
     entity.owner = owner;
+    entity.shares = BigInt.fromI32(0);
     entity.stakingVaultAddress = vaultAddress;
+    entity.totalCostBasis = BigInt.fromI32(0);
   }
 
-  const vault = StakingVault.bind(vaultAddress);
-  const currentShares = vault.balanceOf(owner);
-  const newShares = event.params.shares;
-  const oldShares = currentShares.minus(newShares);
-
-  const calculatedAssets = oldShares
-    .times(entity.averagePrice)
-    .plus(event.params.assets.times(WAD));
-  entity.averagePrice = calculatedAssets.div(currentShares);
+  entity.shares = entity.shares.plus(event.params.shares);
+  entity.totalCostBasis = entity.totalCostBasis.plus(
+    event.params.assets.times(WAD),
+  );
 
   entity.save();
 }
@@ -89,39 +85,57 @@ export function handleTransfer(event: Transfer): void {
   if (event.params.from.equals(Address.zero())) {
     return;
   }
-  // Skip burns as those are not relevant.
-  if (event.params.to.equals(Address.zero())) {
-    return;
-  }
-  // Self-transfer will cause incorrect average price dilution. Skip those.
+  // Self-transfers do not affect balances.
   if (event.params.from.equals(event.params.to)) {
     return;
   }
-  // Zero-value transfer will also cause incorrect average price dilution.
+  // Zero-value transfers are no-ops.
   if (event.params.value.equals(BigInt.fromI32(0))) {
     return;
   }
 
   const vaultAddress = dataSource.address();
-  const to = event.params.to;
-  const id = buildId(vaultAddress, to.toHexString());
+  const value = event.params.value;
 
-  let entity = UserStakingPosition.load(id);
-  if (entity == null) {
-    entity = new UserStakingPosition(id);
-    entity.averagePrice = BigInt.fromI32(0);
-    entity.owner = to;
-    entity.stakingVaultAddress = vaultAddress;
+  // Update the sending party: decrement shares and totalCostBasis proportionally.
+  const fromId = buildId(vaultAddress, event.params.from.toHexString());
+  const fromEntity = UserStakingPosition.load(fromId)!;
+
+  if (fromEntity.shares.equals(value)) {
+    // All shares transferred out: reset to zero.
+    fromEntity.shares = BigInt.fromI32(0);
+    fromEntity.totalCostBasis = BigInt.fromI32(0);
+  } else {
+    // Decrement totalCostBasis proportionally before decrementing shares.
+    const newShares = fromEntity.shares.minus(value);
+    fromEntity.totalCostBasis = fromEntity.totalCostBasis
+      .times(newShares)
+      .div(fromEntity.shares);
+    fromEntity.shares = newShares;
   }
 
-  const vault = StakingVault.bind(vaultAddress);
-  const currentShares = vault.balanceOf(to);
-  const oldShares = currentShares.minus(event.params.value);
+  fromEntity.save();
 
-  // Transferred-in shares are valued at 0, diluting the average price proportionally.
-  entity.averagePrice = entity.averagePrice.times(oldShares).div(currentShares);
+  // Burns (to zero address) only affect the sending party.
+  if (event.params.to.equals(Address.zero())) {
+    return;
+  }
 
-  entity.save();
+  // Update the receiving party: increment shares, keep totalCostBasis unchanged.
+  // Received shares are valued at 0, diluting the average price proportionally.
+  const toId = buildId(vaultAddress, event.params.to.toHexString());
+  let toEntity = UserStakingPosition.load(toId);
+  if (toEntity == null) {
+    toEntity = new UserStakingPosition(toId);
+    toEntity.owner = event.params.to;
+    toEntity.shares = BigInt.fromI32(0);
+    toEntity.stakingVaultAddress = vaultAddress;
+    toEntity.totalCostBasis = BigInt.fromI32(0);
+  }
+
+  toEntity.shares = toEntity.shares.plus(value);
+
+  toEntity.save();
 }
 
 export function handleWithdrawRequested(event: WithdrawRequested): void {

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -8,7 +8,7 @@ dataSources:
     name: sVusdStakingVault
     network: mainnet
     source:
-      address: "0x476310E34D2810f7d79C43A74E4D79405bd7a925"
+      address: "0x476310E34D2810f7d79C43A74E4D79405bd7a925" # sVUSD
       abi: StakingVault
       startBlock: 24625396
     mapping:
@@ -41,7 +41,7 @@ dataSources:
     name: sVetBTCStakingVault
     network: mainnet
     source:
-      address: "0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e"
+      address: "0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e" # svetBTC
       abi: StakingVault
       startBlock: 24931128
     mapping:
@@ -51,11 +51,16 @@ dataSources:
       entities:
         - ExitTicket
         - ExitTicketQueueSummary
+        - UserStakingPosition
         - VaultHistory
       abis:
         - name: StakingVault
           file: ./abis/StakingVault.json
       eventHandlers:
+        - event: Deposit(indexed address,indexed address,uint256,uint256)
+          handler: handleDeposit
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
         - event: WithdrawCancelled(indexed address,indexed uint256,uint256,uint256)
           handler: handleWithdrawCancelled
         - event: WithdrawClaimed(indexed address,indexed address,indexed uint256,uint256)

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -26,6 +26,8 @@ dataSources:
       eventHandlers:
         - event: Deposit(indexed address,indexed address,uint256,uint256)
           handler: handleDeposit
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
         - event: WithdrawCancelled(indexed address,indexed uint256,uint256,uint256)
           handler: handleWithdrawCancelled
         - event: WithdrawClaimed(indexed address,indexed address,indexed uint256,uint256)

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -5,7 +5,7 @@ schema:
   file: ./schema.graphql
 dataSources:
   - kind: ethereum
-    name: StakingVault
+    name: sVusdStakingVault
     network: mainnet
     source:
       address: "0x476310E34D2810f7d79C43A74E4D79405bd7a925"
@@ -28,6 +28,34 @@ dataSources:
           handler: handleDeposit
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+        - event: WithdrawCancelled(indexed address,indexed uint256,uint256,uint256)
+          handler: handleWithdrawCancelled
+        - event: WithdrawClaimed(indexed address,indexed address,indexed uint256,uint256)
+          handler: handleWithdrawClaimed
+        - event: WithdrawRequested(indexed address,indexed uint256,uint256,uint256,uint256)
+          handler: handleWithdrawRequested
+      blockHandlers:
+        - handler: handleBlock
+      file: ./src/earn.ts
+  - kind: ethereum
+    name: sVetBTCStakingVault
+    network: mainnet
+    source:
+      address: "0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e"
+      abi: StakingVault
+      startBlock: 24931128
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - ExitTicket
+        - ExitTicketQueueSummary
+        - VaultHistory
+      abis:
+        - name: StakingVault
+          file: ./abis/StakingVault.json
+      eventHandlers:
         - event: WithdrawCancelled(indexed address,indexed uint256,uint256,uint256)
           handler: handleWithdrawCancelled
         - event: WithdrawClaimed(indexed address,indexed address,indexed uint256,uint256)

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -18,11 +18,14 @@ dataSources:
       entities:
         - ExitTicket
         - ExitTicketQueueSummary
+        - UserStakingPosition
         - VaultHistory
       abis:
         - name: StakingVault
           file: ./abis/StakingVault.json
       eventHandlers:
+        - event: Deposit(indexed address,indexed address,uint256,uint256)
+          handler: handleDeposit
         - event: WithdrawCancelled(indexed address,indexed uint256,uint256,uint256)
           handler: handleWithdrawCancelled
         - event: WithdrawClaimed(indexed address,indexed address,indexed uint256,uint256)

--- a/subgraph/tests/earn-utils.ts
+++ b/subgraph/tests/earn-utils.ts
@@ -7,7 +7,7 @@ import {
   WithdrawCancelled,
   WithdrawClaimed,
   WithdrawRequested,
-} from "../generated/StakingVault/StakingVault";
+} from "../generated/sVusdStakingVault/StakingVault";
 
 export function createDepositEvent(
   assets: BigInt,

--- a/subgraph/tests/earn-utils.ts
+++ b/subgraph/tests/earn-utils.ts
@@ -3,6 +3,7 @@ import { newMockEvent } from "matchstick-as";
 
 import {
   Deposit,
+  Transfer,
   WithdrawCancelled,
   WithdrawClaimed,
   WithdrawRequested,
@@ -46,6 +47,25 @@ export function createMockBlock(
   block.number = number;
   block.timestamp = timestamp;
   return block;
+}
+
+export function createTransferEvent(
+  from: Address,
+  to: Address,
+  value: BigInt,
+): Transfer {
+  const event = changetype<Transfer>(newMockEvent());
+  event.parameters = [];
+  event.parameters.push(
+    new ethereum.EventParam("from", ethereum.Value.fromAddress(from)),
+  );
+  event.parameters.push(
+    new ethereum.EventParam("to", ethereum.Value.fromAddress(to)),
+  );
+  event.parameters.push(
+    new ethereum.EventParam("value", ethereum.Value.fromUnsignedBigInt(value)),
+  );
+  return event;
 }
 
 export function createWithdrawCancelledEvent(

--- a/subgraph/tests/earn-utils.ts
+++ b/subgraph/tests/earn-utils.ts
@@ -2,10 +2,40 @@ import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { newMockEvent } from "matchstick-as";
 
 import {
+  Deposit,
   WithdrawCancelled,
   WithdrawClaimed,
   WithdrawRequested,
 } from "../generated/StakingVault/StakingVault";
+
+export function createDepositEvent(
+  assets: BigInt,
+  owner: Address,
+  sender: Address,
+  shares: BigInt,
+): Deposit {
+  const event = changetype<Deposit>(newMockEvent());
+  event.parameters = [];
+  event.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender)),
+  );
+  event.parameters.push(
+    new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner)),
+  );
+  event.parameters.push(
+    new ethereum.EventParam(
+      "assets",
+      ethereum.Value.fromUnsignedBigInt(assets),
+    ),
+  );
+  event.parameters.push(
+    new ethereum.EventParam(
+      "shares",
+      ethereum.Value.fromUnsignedBigInt(shares),
+    ),
+  );
+  return event;
+}
 
 export function createMockBlock(
   number: BigInt,

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -11,12 +11,14 @@ import {
 
 import {
   handleBlock,
+  handleDeposit,
   handleWithdrawCancelled,
   handleWithdrawClaimed,
   handleWithdrawRequested,
 } from "../src/earn";
 
 import {
+  createDepositEvent,
   createMockBlock,
   createWithdrawCancelledEvent,
   createWithdrawClaimedEvent,
@@ -45,6 +47,16 @@ function mockVaultCalls(decimals: i32, shareValue: BigInt): void {
   )
     .withArgs([ethereum.Value.fromUnsignedBigInt(oneShare)])
     .returns([ethereum.Value.fromUnsignedBigInt(shareValue)]);
+}
+
+function mockBalanceOf(balance: BigInt): void {
+  createMockedFunction(
+    vaultAddress,
+    "balanceOf",
+    "balanceOf(address):(uint256)",
+  )
+    .withArgs([ethereum.Value.fromAddress(ownerAddress)])
+    .returns([ethereum.Value.fromUnsignedBigInt(balance)]);
 }
 
 describe("handleBlock", function () {
@@ -116,6 +128,179 @@ describe("handleBlock", function () {
       id,
       "timestamp",
       dayTimestamp.toString(),
+    );
+  });
+});
+
+describe("handleDeposit", function () {
+  beforeEach(function () {
+    clearStore();
+    dataSourceMock.setAddress(vaultAddressString);
+  });
+
+  test("sets average price on first deposit", function () {
+    // t0: Deposit 100 VUSD, get 100 sVUSD. Price = 1.0
+    const assets = BigInt.fromString("100000000000000000000"); // 100e18
+    const shares = BigInt.fromString("100000000000000000000"); // 100e18
+    const balanceAfter = BigInt.fromString("100000000000000000000"); // 100e18
+
+    mockBalanceOf(balanceAfter);
+    const event = createDepositEvent(
+      assets,
+      ownerAddress,
+      ownerAddress,
+      shares,
+    );
+    handleDeposit(event);
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    assert.entityCount("UserStakingPosition", 1);
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "averagePrice",
+      "1000000000000000000",
+    );
+    assert.fieldEquals("UserStakingPosition", id, "owner", ownerAddressString);
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "stakingVaultAddress",
+      vaultAddressString,
+    );
+  });
+
+  test("updates average price on subsequent deposit", function () {
+    // t0: 100 VUSD -> 100 sVUSD, price = 1.0
+    mockBalanceOf(BigInt.fromString("100000000000000000000"));
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("100000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    // t1: 110 VUSD -> 100 sVUSD, balanceOf = 200, price = 1.05
+    mockBalanceOf(BigInt.fromString("200000000000000000000"));
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("110000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "averagePrice",
+      "1050000000000000000",
+    );
+  });
+
+  test("average price unchanged by withdrawal, updates on next deposit", function () {
+    // t0: 100 VUSD -> 100 sVUSD
+    mockBalanceOf(BigInt.fromString("100000000000000000000"));
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("100000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    // t1: 110 VUSD -> 100 sVUSD, balance = 200
+    mockBalanceOf(BigInt.fromString("200000000000000000000"));
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("110000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    // t2: withdrawal of 50 sVUSD happens on-chain (not handled by subgraph)
+    // t3: 120 VUSD -> 100 sVUSD, balanceOf = 250 (150 old + 100 new)
+    mockBalanceOf(BigInt.fromString("250000000000000000000"));
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("120000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    // (150 * 1.05 + 100 * 1.2) / 250 = 1.11
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "averagePrice",
+      "1110000000000000000",
+    );
+  });
+
+  test("tracks average price across multiple deposits and withdrawals", function () {
+    // Full sequence: t0, t1, t2 (withdrawal), t3, t4
+    // t0: 100 VUSD -> 100 sVUSD
+    mockBalanceOf(BigInt.fromString("100000000000000000000"));
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("100000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    // t1: 110 VUSD -> 100 sVUSD, balance = 200
+    mockBalanceOf(BigInt.fromString("200000000000000000000"));
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("110000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    // t2: withdrawal (not tracked), balance goes from 200 to 150
+    // t3: 120 VUSD -> 100 sVUSD, balance = 250
+    mockBalanceOf(BigInt.fromString("250000000000000000000"));
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("120000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    // t4: 75 VUSD -> 50 sVUSD, balance = 300
+    mockBalanceOf(BigInt.fromString("300000000000000000000"));
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("75000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("50000000000000000000"),
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    // (250 * 1.11 + 50 * 1.5) / 300 = 1.175
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "averagePrice",
+      "1175000000000000000",
     );
   });
 });

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   handleBlock,
   handleDeposit,
+  handleTransfer,
   handleWithdrawCancelled,
   handleWithdrawClaimed,
   handleWithdrawRequested,
@@ -20,6 +21,7 @@ import {
 import {
   createDepositEvent,
   createMockBlock,
+  createTransferEvent,
   createWithdrawCancelledEvent,
   createWithdrawClaimedEvent,
   createWithdrawRequestedEvent,
@@ -502,5 +504,119 @@ describe("handleWithdrawClaimed", function () {
     handleWithdrawClaimed(claimEvent);
 
     assert.entityCount("ExitTicket", 0);
+  });
+});
+
+describe("handleTransfer", function () {
+  beforeEach(function () {
+    clearStore();
+    dataSourceMock.setAddress(vaultAddressString);
+  });
+
+  test("updates average price on transfer-in", function () {
+    // t0: Deposit 120 VUSD -> 100 sVUSD, price = 1.2
+    mockBalanceOf(BigInt.fromString("100000000000000000000"));
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("120000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    // t1: Receive 50 sVUSD via transfer, balance = 150
+    mockBalanceOf(BigInt.fromString("150000000000000000000"));
+    handleTransfer(
+      createTransferEvent(
+        receiverAddress,
+        ownerAddress,
+        BigInt.fromString("50000000000000000000"),
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    // 1.2 * 100 / 150 = 0.8
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "averagePrice",
+      "800000000000000000",
+    );
+  });
+
+  test("handles two consecutive transfers", function () {
+    // t0: Deposit 120 VUSD -> 100 sVUSD, price = 1.2
+    mockBalanceOf(BigInt.fromString("100000000000000000000"));
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("120000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    // t1: Receive 50 sVUSD, balance = 150, price = 0.8
+    mockBalanceOf(BigInt.fromString("150000000000000000000"));
+    handleTransfer(
+      createTransferEvent(
+        receiverAddress,
+        ownerAddress,
+        BigInt.fromString("50000000000000000000"),
+      ),
+    );
+
+    // t2: Receive 150 sVUSD, balance = 300, price = 0.4
+    mockBalanceOf(BigInt.fromString("300000000000000000000"));
+    handleTransfer(
+      createTransferEvent(
+        receiverAddress,
+        ownerAddress,
+        BigInt.fromString("150000000000000000000"),
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    // 0.8 * 150 / 300 = 0.4
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "averagePrice",
+      "400000000000000000",
+    );
+  });
+
+  test("sets average price to 0 for new user receiving a transfer", function () {
+    // User with no prior position receives 100 sVUSD
+    mockBalanceOf(BigInt.fromString("100000000000000000000"));
+    handleTransfer(
+      createTransferEvent(
+        receiverAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    assert.entityCount("UserStakingPosition", 1);
+    assert.fieldEquals("UserStakingPosition", id, "averagePrice", "0");
+    assert.fieldEquals("UserStakingPosition", id, "owner", ownerAddressString);
+  });
+
+  test("skips mint transfers", function () {
+    const zeroAddress = Address.fromString(
+      "0x0000000000000000000000000000000000000000",
+    );
+    mockBalanceOf(BigInt.fromString("100000000000000000000"));
+    handleTransfer(
+      createTransferEvent(
+        zeroAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    assert.entityCount("UserStakingPosition", 0);
   });
 });

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -51,16 +51,6 @@ function mockVaultCalls(decimals: i32, shareValue: BigInt): void {
     .returns([ethereum.Value.fromUnsignedBigInt(shareValue)]);
 }
 
-function mockBalanceOf(balance: BigInt): void {
-  createMockedFunction(
-    vaultAddress,
-    "balanceOf",
-    "balanceOf(address):(uint256)",
-  )
-    .withArgs([ethereum.Value.fromAddress(ownerAddress)])
-    .returns([ethereum.Value.fromUnsignedBigInt(balance)]);
-}
-
 describe("handleBlock", function () {
   beforeEach(function () {
     clearStore();
@@ -140,41 +130,41 @@ describe("handleDeposit", function () {
     dataSourceMock.setAddress(vaultAddressString);
   });
 
-  test("sets average price on first deposit", function () {
-    // t0: Deposit 100 VUSD, get 100 sVUSD. Price = 1.0
+  test("creates position with shares and totalCostBasis on first deposit", function () {
+    // 100 VUSD -> 100 sVUSD. averagePrice = 100e36 / 100e18 = 1e18
     const assets = BigInt.fromString("100000000000000000000"); // 100e18
     const shares = BigInt.fromString("100000000000000000000"); // 100e18
-    const balanceAfter = BigInt.fromString("100000000000000000000"); // 100e18
 
-    mockBalanceOf(balanceAfter);
-    const event = createDepositEvent(
-      assets,
-      ownerAddress,
-      ownerAddress,
-      shares,
+    handleDeposit(
+      createDepositEvent(assets, ownerAddress, ownerAddress, shares),
     );
-    handleDeposit(event);
 
     const id = `${vaultAddressString}-${ownerAddressString}`;
     assert.entityCount("UserStakingPosition", 1);
+    assert.fieldEquals("UserStakingPosition", id, "owner", ownerAddressString);
     assert.fieldEquals(
       "UserStakingPosition",
       id,
-      "averagePrice",
-      "1000000000000000000",
+      "shares",
+      "100000000000000000000",
     );
-    assert.fieldEquals("UserStakingPosition", id, "owner", ownerAddressString);
     assert.fieldEquals(
       "UserStakingPosition",
       id,
       "stakingVaultAddress",
       vaultAddressString,
     );
+    // totalCostBasis = 100e18 * WAD = 100e36
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "totalCostBasis",
+      "100000000000000000000000000000000000000",
+    );
   });
 
-  test("updates average price on subsequent deposit", function () {
-    // t0: 100 VUSD -> 100 sVUSD, price = 1.0
-    mockBalanceOf(BigInt.fromString("100000000000000000000"));
+  test("accumulates shares and totalCostBasis on subsequent deposit", function () {
+    // t0: 100 VUSD -> 100 sVUSD
     handleDeposit(
       createDepositEvent(
         BigInt.fromString("100000000000000000000"),
@@ -184,8 +174,7 @@ describe("handleDeposit", function () {
       ),
     );
 
-    // t1: 110 VUSD -> 100 sVUSD, balanceOf = 200, price = 1.05
-    mockBalanceOf(BigInt.fromString("200000000000000000000"));
+    // t1: 110 VUSD -> 100 sVUSD
     handleDeposit(
       createDepositEvent(
         BigInt.fromString("110000000000000000000"),
@@ -196,17 +185,24 @@ describe("handleDeposit", function () {
     );
 
     const id = `${vaultAddressString}-${ownerAddressString}`;
+    // shares = 200e18, totalCostBasis = 210e36
+    // averagePrice = 210e36 / 200e18 = 1.05e18
     assert.fieldEquals(
       "UserStakingPosition",
       id,
-      "averagePrice",
-      "1050000000000000000",
+      "shares",
+      "200000000000000000000",
+    );
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "totalCostBasis",
+      "210000000000000000000000000000000000000",
     );
   });
 
-  test("average price unchanged by withdrawal, updates on next deposit", function () {
+  test("average price unchanged by burn, updates correctly on next deposit", function () {
     // t0: 100 VUSD -> 100 sVUSD
-    mockBalanceOf(BigInt.fromString("100000000000000000000"));
     handleDeposit(
       createDepositEvent(
         BigInt.fromString("100000000000000000000"),
@@ -216,8 +212,7 @@ describe("handleDeposit", function () {
       ),
     );
 
-    // t1: 110 VUSD -> 100 sVUSD, balance = 200
-    mockBalanceOf(BigInt.fromString("200000000000000000000"));
+    // t1: 110 VUSD -> 100 sVUSD. shares=200e18, totalCostBasis=210e36
     handleDeposit(
       createDepositEvent(
         BigInt.fromString("110000000000000000000"),
@@ -227,9 +222,19 @@ describe("handleDeposit", function () {
       ),
     );
 
-    // t2: withdrawal of 50 sVUSD happens on-chain (not handled by subgraph)
-    // t3: 120 VUSD -> 100 sVUSD, balanceOf = 250 (150 old + 100 new)
-    mockBalanceOf(BigInt.fromString("250000000000000000000"));
+    // t2: burn 50 sVUSD (Transfer to zero). totalCostBasis = 210e36 * 150/200 = 157.5e36, shares=150e18
+    const zeroAddress = Address.fromString(
+      "0x0000000000000000000000000000000000000000",
+    );
+    handleTransfer(
+      createTransferEvent(
+        ownerAddress,
+        zeroAddress,
+        BigInt.fromString("50000000000000000000"),
+      ),
+    );
+
+    // t3: 120 VUSD -> 100 sVUSD. shares=250e18, totalCostBasis=277.5e36
     handleDeposit(
       createDepositEvent(
         BigInt.fromString("120000000000000000000"),
@@ -240,19 +245,24 @@ describe("handleDeposit", function () {
     );
 
     const id = `${vaultAddressString}-${ownerAddressString}`;
-    // (150 * 1.05 + 100 * 1.2) / 250 = 1.11
+    // averagePrice = 277.5e36 / 250e18 = 1.11e18
     assert.fieldEquals(
       "UserStakingPosition",
       id,
-      "averagePrice",
-      "1110000000000000000",
+      "shares",
+      "250000000000000000000",
+    );
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "totalCostBasis",
+      "277500000000000000000000000000000000000",
     );
   });
 
-  test("tracks average price across multiple deposits and withdrawals", function () {
-    // Full sequence: t0, t1, t2 (withdrawal), t3, t4
+  test("tracks shares and totalCostBasis across multiple deposits and burns", function () {
+    // Full sequence from 336.md: t0, t1, t2 (burn), t3, t4
     // t0: 100 VUSD -> 100 sVUSD
-    mockBalanceOf(BigInt.fromString("100000000000000000000"));
     handleDeposit(
       createDepositEvent(
         BigInt.fromString("100000000000000000000"),
@@ -262,8 +272,7 @@ describe("handleDeposit", function () {
       ),
     );
 
-    // t1: 110 VUSD -> 100 sVUSD, balance = 200
-    mockBalanceOf(BigInt.fromString("200000000000000000000"));
+    // t1: 110 VUSD -> 100 sVUSD. shares=200e18, totalCostBasis=210e36
     handleDeposit(
       createDepositEvent(
         BigInt.fromString("110000000000000000000"),
@@ -273,9 +282,19 @@ describe("handleDeposit", function () {
       ),
     );
 
-    // t2: withdrawal (not tracked), balance goes from 200 to 150
-    // t3: 120 VUSD -> 100 sVUSD, balance = 250
-    mockBalanceOf(BigInt.fromString("250000000000000000000"));
+    // t2: burn 50 sVUSD. totalCostBasis=157.5e36, shares=150e18
+    const zeroAddress = Address.fromString(
+      "0x0000000000000000000000000000000000000000",
+    );
+    handleTransfer(
+      createTransferEvent(
+        ownerAddress,
+        zeroAddress,
+        BigInt.fromString("50000000000000000000"),
+      ),
+    );
+
+    // t3: 120 VUSD -> 100 sVUSD. shares=250e18, totalCostBasis=277.5e36
     handleDeposit(
       createDepositEvent(
         BigInt.fromString("120000000000000000000"),
@@ -285,8 +304,7 @@ describe("handleDeposit", function () {
       ),
     );
 
-    // t4: 75 VUSD -> 50 sVUSD, balance = 300
-    mockBalanceOf(BigInt.fromString("300000000000000000000"));
+    // t4: 75 VUSD -> 50 sVUSD. shares=300e18, totalCostBasis=352.5e36
     handleDeposit(
       createDepositEvent(
         BigInt.fromString("75000000000000000000"),
@@ -297,12 +315,18 @@ describe("handleDeposit", function () {
     );
 
     const id = `${vaultAddressString}-${ownerAddressString}`;
-    // (250 * 1.11 + 50 * 1.5) / 300 = 1.175
+    // averagePrice = 352.5e36 / 300e18 = 1.175e18
     assert.fieldEquals(
       "UserStakingPosition",
       id,
-      "averagePrice",
-      "1175000000000000000",
+      "shares",
+      "300000000000000000000",
+    );
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "totalCostBasis",
+      "352500000000000000000000000000000000000",
     );
   });
 });
@@ -513,9 +537,8 @@ describe("handleTransfer", function () {
     dataSourceMock.setAddress(vaultAddressString);
   });
 
-  test("updates average price on transfer-in", function () {
-    // t0: Deposit 120 VUSD -> 100 sVUSD, price = 1.2
-    mockBalanceOf(BigInt.fromString("100000000000000000000"));
+  test("updates shares on transfer-in, keeps totalCostBasis unchanged", function () {
+    // t0: Deposit 120 VUSD -> 100 sVUSD. shares=100e18, totalCostBasis=120e36
     handleDeposit(
       createDepositEvent(
         BigInt.fromString("120000000000000000000"),
@@ -525,8 +548,18 @@ describe("handleTransfer", function () {
       ),
     );
 
-    // t1: Receive 50 sVUSD via transfer, balance = 150
-    mockBalanceOf(BigInt.fromString("150000000000000000000"));
+    // Give receiverAddress shares so it can transfer them
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("50000000000000000000"),
+        receiverAddress,
+        receiverAddress,
+        BigInt.fromString("50000000000000000000"),
+      ),
+    );
+
+    // t1: Receive 50 sVUSD via transfer. shares=150e18, totalCostBasis=120e36 (unchanged)
+    // averagePrice = 120e36 / 150e18 = 0.8e18
     handleTransfer(
       createTransferEvent(
         receiverAddress,
@@ -536,18 +569,22 @@ describe("handleTransfer", function () {
     );
 
     const id = `${vaultAddressString}-${ownerAddressString}`;
-    // 1.2 * 100 / 150 = 0.8
     assert.fieldEquals(
       "UserStakingPosition",
       id,
-      "averagePrice",
-      "800000000000000000",
+      "shares",
+      "150000000000000000000",
+    );
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "totalCostBasis",
+      "120000000000000000000000000000000000000",
     );
   });
 
-  test("handles two consecutive transfers", function () {
-    // t0: Deposit 120 VUSD -> 100 sVUSD, price = 1.2
-    mockBalanceOf(BigInt.fromString("100000000000000000000"));
+  test("handles two consecutive transfers-in", function () {
+    // t0: Deposit 120 VUSD -> 100 sVUSD. shares=100e18, totalCostBasis=120e36
     handleDeposit(
       createDepositEvent(
         BigInt.fromString("120000000000000000000"),
@@ -557,8 +594,17 @@ describe("handleTransfer", function () {
       ),
     );
 
-    // t1: Receive 50 sVUSD, balance = 150, price = 0.8
-    mockBalanceOf(BigInt.fromString("150000000000000000000"));
+    // Give receiverAddress shares so it can transfer them
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("200000000000000000000"),
+        receiverAddress,
+        receiverAddress,
+        BigInt.fromString("200000000000000000000"),
+      ),
+    );
+
+    // t1: Receive 50 sVUSD. shares=150e18, totalCostBasis=120e36. avg=0.8e18
     handleTransfer(
       createTransferEvent(
         receiverAddress,
@@ -567,8 +613,7 @@ describe("handleTransfer", function () {
       ),
     );
 
-    // t2: Receive 150 sVUSD, balance = 300, price = 0.4
-    mockBalanceOf(BigInt.fromString("300000000000000000000"));
+    // t2: Receive 150 sVUSD. shares=300e18, totalCostBasis=120e36. avg=0.4e18
     handleTransfer(
       createTransferEvent(
         receiverAddress,
@@ -578,18 +623,32 @@ describe("handleTransfer", function () {
     );
 
     const id = `${vaultAddressString}-${ownerAddressString}`;
-    // 0.8 * 150 / 300 = 0.4
     assert.fieldEquals(
       "UserStakingPosition",
       id,
-      "averagePrice",
-      "400000000000000000",
+      "shares",
+      "300000000000000000000",
+    );
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "totalCostBasis",
+      "120000000000000000000000000000000000000",
     );
   });
 
-  test("sets average price to 0 for new user receiving a transfer", function () {
+  test("sets shares to transferred amount and totalCostBasis to 0 for new user", function () {
+    // Give receiverAddress shares so it can transfer them
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("100000000000000000000"),
+        receiverAddress,
+        receiverAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
     // User with no prior position receives 100 sVUSD
-    mockBalanceOf(BigInt.fromString("100000000000000000000"));
     handleTransfer(
       createTransferEvent(
         receiverAddress,
@@ -599,16 +658,164 @@ describe("handleTransfer", function () {
     );
 
     const id = `${vaultAddressString}-${ownerAddressString}`;
-    assert.entityCount("UserStakingPosition", 1);
-    assert.fieldEquals("UserStakingPosition", id, "averagePrice", "0");
+    assert.entityCount("UserStakingPosition", 2);
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "shares",
+      "100000000000000000000",
+    );
+    assert.fieldEquals("UserStakingPosition", id, "totalCostBasis", "0");
     assert.fieldEquals("UserStakingPosition", id, "owner", ownerAddressString);
+  });
+
+  test("decrements shares and totalCostBasis proportionally on transfer-out (invariant: average price unchanged)", function () {
+    // Setup: owner has 100e18 shares, totalCostBasis=120e36, avg=1.2e18
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("120000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    // Transfer 30 sVUSD out. Remaining: 70e18 shares.
+    // totalCostBasis = 120e36 * 70/100 = 84e36. avg = 84e36/70e18 = 1.2e18 (unchanged)
+    handleTransfer(
+      createTransferEvent(
+        ownerAddress,
+        receiverAddress,
+        BigInt.fromString("30000000000000000000"),
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "shares",
+      "70000000000000000000",
+    );
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "totalCostBasis",
+      "84000000000000000000000000000000000000",
+    );
+
+    // Receiver gets shares with totalCostBasis unchanged (0 for new user)
+    const receiverId = `${vaultAddressString}-${receiverAddressString}`;
+    assert.fieldEquals(
+      "UserStakingPosition",
+      receiverId,
+      "shares",
+      "30000000000000000000",
+    );
+    assert.fieldEquals(
+      "UserStakingPosition",
+      receiverId,
+      "totalCostBasis",
+      "0",
+    );
+  });
+
+  test("sets shares and totalCostBasis to 0 when all shares transferred out", function () {
+    // Setup: owner has 100e18 shares, totalCostBasis=120e36
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("120000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    // Transfer all 100 sVUSD out.
+    handleTransfer(
+      createTransferEvent(
+        ownerAddress,
+        receiverAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    assert.fieldEquals("UserStakingPosition", id, "shares", "0");
+    assert.fieldEquals("UserStakingPosition", id, "totalCostBasis", "0");
+  });
+
+  test("decrements shares and totalCostBasis proportionally on burn (invariant: average price unchanged)", function () {
+    // Setup: owner has 100e18 shares, totalCostBasis=120e36, avg=1.2e18
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("120000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    // Burn 40 sVUSD (Transfer to zero). Remaining: 60e18 shares.
+    // totalCostBasis = 120e36 * 60/100 = 72e36. avg = 72e36/60e18 = 1.2e18 (unchanged)
+    const zeroAddress = Address.fromString(
+      "0x0000000000000000000000000000000000000000",
+    );
+    handleTransfer(
+      createTransferEvent(
+        ownerAddress,
+        zeroAddress,
+        BigInt.fromString("40000000000000000000"),
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "shares",
+      "60000000000000000000",
+    );
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "totalCostBasis",
+      "72000000000000000000000000000000000000",
+    );
+  });
+
+  test("sets shares and totalCostBasis to 0 when all shares burned", function () {
+    // Setup: owner has 100e18 shares, totalCostBasis=120e36
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("120000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    // Burn all 100 sVUSD.
+    const zeroAddress = Address.fromString(
+      "0x0000000000000000000000000000000000000000",
+    );
+    handleTransfer(
+      createTransferEvent(
+        ownerAddress,
+        zeroAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    assert.fieldEquals("UserStakingPosition", id, "shares", "0");
+    assert.fieldEquals("UserStakingPosition", id, "totalCostBasis", "0");
   });
 
   test("skips mint transfers", function () {
     const zeroAddress = Address.fromString(
       "0x0000000000000000000000000000000000000000",
     );
-    mockBalanceOf(BigInt.fromString("100000000000000000000"));
     handleTransfer(
       createTransferEvent(
         zeroAddress,
@@ -618,5 +825,69 @@ describe("handleTransfer", function () {
     );
 
     assert.entityCount("UserStakingPosition", 0);
+  });
+
+  test("skips zero-value transfers", function () {
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("120000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    handleTransfer(
+      createTransferEvent(ownerAddress, receiverAddress, BigInt.fromI32(0)),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    // Shares and totalCostBasis unchanged
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "shares",
+      "100000000000000000000",
+    );
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "totalCostBasis",
+      "120000000000000000000000000000000000000",
+    );
+  });
+
+  test("skips self-transfers", function () {
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("120000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    handleTransfer(
+      createTransferEvent(
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("50000000000000000000"),
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    // Shares and totalCostBasis unchanged
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "shares",
+      "100000000000000000000",
+    );
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "totalCostBasis",
+      "120000000000000000000000000000000000000",
+    );
   });
 });


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This pull request introduces support for tracking users' average staking price in the subgraph by adding a new entity, event handlers, and comprehensive tests. The main changes include updating the `StakingVault` ABI to include relevant events and functions, implementing handlers for `Deposit` and `Transfer` events to maintain accurate average price data for each user, and extending the schema and tests accordingly.

**Subgraph logic and schema updates:**

* Added a new entity `UserStakingPosition` to the GraphQL schema to track each user's staking vault address, owner, and average price.
* Implemented `handleDeposit` and `handleTransfer` event handlers in `earn.ts` to update the `UserStakingPosition` entity, including logic for calculating and updating the average price per user on deposits and transfers.
* Registered the new entity and event handlers in `subgraph.yaml` to ensure the subgraph indexes `Deposit` and `Transfer` events.

**ABI and data model updates:**

* Updated `StakingVault.json` ABI to include the `balanceOf` function and `Deposit` and `Transfer` events, enabling the subgraph to query balances and react to relevant events. [[1]](diffhunk://#diff-24f9092cd36be19b8e39baa2b63b7d01c7bae3d13e008b2a353f0a67e8830b57R2-R20) [[2]](diffhunk://#diff-24f9092cd36be19b8e39baa2b63b7d01c7bae3d13e008b2a353f0a67e8830b57R53-R83) [[3]](diffhunk://#diff-24f9092cd36be19b8e39baa2b63b7d01c7bae3d13e008b2a353f0a67e8830b57R182-R206)

**Testing and utilities:**

* Added utility functions and comprehensive tests for deposit and transfer scenarios, ensuring correct average price tracking and handling of edge cases (e.g., transfers, mints, withdrawals). [[1]](diffhunk://#diff-f52af6cec58f2945e9daaad57e222833767a088481fc75a16da1d30669e17636R5-R40) [[2]](diffhunk://#diff-f52af6cec58f2945e9daaad57e222833767a088481fc75a16da1d30669e17636R52-R70) [[3]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2R14-R24) [[4]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2R54-R63) [[5]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2R137-R309) [[6]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2R509-R622)

**Other:**

* Bumped the subgraph package version to 1.3.0.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #336

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
