### PR TITLE
Remove Sepolia network support

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -13,7 +13,6 @@ Vite only exposes variables prefixed with `VITE_` to the client bundle. Set thes
 | `VITE_FEATURE_BRIDGE_ENABLED` | No       | When `"true"`, the `/bridge` route and its nav entry are rendered. Defaults to false. |
 | `VITE_PORTAL_API_URL`         | Yes      | Hemi Portal API base URL (used for token prices).                                     |
 | `VITE_RPC_URL_MAINNET`        | No       | RPC URL for Ethereum mainnet. Falls back to viem's default when unset.                |
-| `VITE_RPC_URL_SEPOLIA`        | No       | RPC URL for Ethereum Sepolia. Falls back to viem's default when unset.                |
 | `VITE_VETRO_API_URL`          | Yes      | Vetro backend API base URL (analytics, APR history, exit tickets, rewards, etc.).     |
 
 ## Scripts

--- a/web/src/networks/index.ts
+++ b/web/src/networks/index.ts
@@ -1,2 +1,1 @@
 export { mainnet } from "./mainnet";
-export { sepolia } from "./sepolia";

--- a/web/src/networks/sepolia.ts
+++ b/web/src/networks/sepolia.ts
@@ -1,8 +1,0 @@
-import { sepolia as sepoliaDefinition } from "viem/chains";
-
-import { updateRpcUrls } from "./updateRpcUrls";
-
-export const sepolia = updateRpcUrls(
-  sepoliaDefinition,
-  import.meta.env.VITE_RPC_URL_SEPOLIA,
-);

--- a/web/src/providers/web3Provider.tsx
+++ b/web/src/providers/web3Provider.tsx
@@ -2,16 +2,15 @@ import { getDefaultConfig, RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { http, WagmiProvider } from "wagmi";
 
-import { mainnet, sepolia } from "../networks";
+import { mainnet } from "../networks";
 
 export const config = getDefaultConfig({
   appName: "Vetro",
-  chains: [mainnet, sepolia],
+  chains: [mainnet],
   // TODO add project id for wallet connect
   projectId: "YOUR_PROJECT_ID_HERE",
   transports: {
     [mainnet.id]: http(),
-    [sepolia.id]: http(),
   },
 });
 


### PR DESCRIPTION
### Description

We're not using testnet in Vetro, and as more chains are added for the bridge, keeping Sepolia around is unnecessary baggage. Dropping it — removing the network definition, its export, its wagmi transport, and the `VITE_RPC_URL_SEPOLIA` env var from the README.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #338

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.