### PR TITLE
Support multiple pegged tokens (pt 11)

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -4,9 +4,10 @@ Service that provides data to the Vetro web application.
 
 ## Data endpoints
 
-### `GET /analytics/backing-vusd`
+### `GET /analytics/pegged-token-backing/:gatewayAddress`
 
-Get the total strategic reserves and the total surplus.
+Get the total strategic reserves and the total surplus for a given gateway's pegged token.
+`:gatewayAddress` must be a known gateway address. Returns `400` if malformed and `404` if the address is not a whitelisted gateway.
 
 #### Sample response
 
@@ -17,22 +18,10 @@ Get the total strategic reserves and the total surplus.
 }
 ```
 
-### `GET /analytics/totals`
+### `GET /analytics/treasury/:gatewayAddress`
 
-Get the total VUSD minted and staked to calculate the TVL in the protocol.
-
-#### Sample Response
-
-```json
-{
-  "vusdMinted": "3087191980362376717819",
-  "vusdStaked": "916500000000000000000"
-}
-```
-
-### `GET /analytics/treasury`
-
-Get the composition of the treasury by whitelisted token.
+Get the composition of the treasury by whitelisted token for a given gateway.
+`:gatewayAddress` must be a known gateway address. Returns `400` if malformed and `404` if the address is not a whitelisted gateway.
 
 #### Sample Response
 
@@ -146,30 +135,33 @@ Returns all user's rewards from the Merkl campaigns related to Vetro.
 ]
 ```
 
-### `GET /variable-stake/exit-queue`
+### `GET /variable-stake/exit-queue/:gatewayAddress`
 
-Returns a summary of the exit tickets queue: the total number of open exit tickets and their combined shares.
+Returns a summary of the exit tickets queue for the gateway's staking vault: the total number of open exit tickets and their combined value in the vault's underlying asset (shares are converted via the vault's exchange rate).
+`:gatewayAddress` must be a known gateway address. Returns `400` if malformed and `404` if the address is not a whitelisted gateway.
 
 #### Sample Response
 
 ```jsonc
 {
+  "assets": "4200000000000000000", // pegged token
   "openTickets": 1,
-  "shares": "4000000000000000000", // sVUSD
 }
 ```
 
 ### `GET /variable-stake/exit-tickets/:address`
 
-Returns all user's variable stake exit tickets to i.e. allow claiming the withdrawn VUSD.
+Returns all user's variable stake exit tickets to i.e. allow claiming the withdrawn pegged token.
 
 #### Sample Response
 
 ```jsonc
 [
   {
+    "id": "0x...",
     "requestId": "1",
     "requestTxHash": "0x0000000000000000000000000000000000000000000000000000000000000001",
+    "stakingVaultAddress": "0x0000000000000000000000000000000000000002",
     "owner": "0x0000000000000000000000000000000000000001",
     "assets": "1050000000000000000",
     "shares": "1000000000000000000",

--- a/api/src/analytics.ts
+++ b/api/src/analytics.ts
@@ -12,12 +12,7 @@ import {
   type PublicClient,
 } from "viem";
 import { mainnet } from "viem/chains";
-import {
-  balanceOf,
-  previewRedeem,
-  totalAssets,
-  totalSupply,
-} from "viem-erc4626/actions";
+import { balanceOf, previewRedeem } from "viem-erc4626/actions";
 
 import { getPrice } from "./chainlink.ts";
 import { findStakingVaultForPeggedToken } from "./staking-vault.ts";
@@ -32,38 +27,6 @@ import {
   vetroMultisigAddress,
   vusdMetaAddress,
 } from "./vusd.ts";
-
-/**
- * Get the total pegged token minted and staked for a given gateway, used to
- * calculate the TVL contributed by that pegged token to the protocol.
- */
-export async function getTotals({
-  gatewayAddress,
-  url,
-}: {
-  gatewayAddress: Address;
-  url: string | undefined;
-}) {
-  const client = createPublicClient({
-    chain: mainnet,
-    transport: http(url),
-  });
-  const peggedTokenAddress = await getPeggedToken(client, {
-    address: gatewayAddress,
-  });
-  const stakingVaultAddress = await findStakingVaultForPeggedToken({
-    client,
-    peggedTokenAddress,
-  });
-  const [minted, staked] = await Promise.all([
-    totalSupply(client, { address: peggedTokenAddress }),
-    totalAssets(client, { address: stakingVaultAddress }),
-  ]);
-  return {
-    minted,
-    staked,
-  };
-}
 
 /**
  * Get the composition of the treasury by whitelisted token. For each token, get

--- a/api/src/analytics.ts
+++ b/api/src/analytics.ts
@@ -1,4 +1,5 @@
 import { getYieldDistributor } from "@vetro-protocol/earn/actions";
+import { gatewayAddresses } from "@vetro-protocol/gateway";
 import { getPeggedToken, getTreasury } from "@vetro-protocol/gateway/actions";
 import {
   getTokenConfig,
@@ -97,11 +98,16 @@ export async function getTreasuryComposition({
 
 async function getStrategicReserves({
   client,
+  gatewayAddress,
   treasuryAddress,
 }: {
   client: PublicClient;
+  gatewayAddress: Address;
   treasuryAddress: Address;
 }) {
+  if (gatewayAddress !== gatewayAddresses[0]) {
+    return 0n;
+  }
   const strategicReserveAddresses = [
     treasuryAddress,
     ummRoleAddress,
@@ -173,7 +179,7 @@ export async function getPeggedTokenBacking({
   ]);
 
   const [strategicReserves, surplus] = await Promise.all([
-    getStrategicReserves({ client, treasuryAddress }),
+    getStrategicReserves({ client, gatewayAddress, treasuryAddress }),
     findStakingVaultForPeggedToken({
       client,
       peggedTokenAddress,

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -48,25 +48,6 @@ app.get(
 );
 
 app.get(
-  "/analytics/totals/:gatewayAddress",
-  validateGatewayAddress,
-  cache({
-    cacheControl: "max-age=15, stale-while-revalidate=45",
-    cacheName: "vetro-api",
-  }),
-  async function (c) {
-    try {
-      const url = c.env.CUSTOM_RPC_URL_MAINNET;
-      const gatewayAddress = c.get("gatewayAddress");
-      const data = await analytics.getTotals({ gatewayAddress, url });
-      return c.json(convertBigIntsToString(data));
-    } catch (error) {
-      throw new Error(`Failed to get totals: ${error.message}`);
-    }
-  },
-);
-
-app.get(
   "/analytics/treasury/:gatewayAddress",
   validateGatewayAddress,
   cache({

--- a/packages/earn/src/stakingVaultAddresses.ts
+++ b/packages/earn/src/stakingVaultAddresses.ts
@@ -1,5 +1,8 @@
 import type { Address } from "viem";
 
 export const stakingVaultAddresses: Address[] = [
+  // sVUSD
   "0x476310E34D2810f7d79C43A74E4D79405bd7a925",
+  // sVetBTC
+  "0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e",
 ];

--- a/packages/gateway/src/gatewayAddresses.ts
+++ b/packages/gateway/src/gatewayAddresses.ts
@@ -1,6 +1,8 @@
 import type { Address } from "viem";
 
 export const gatewayAddresses: Address[] = [
-  // VUSD Pegged token
+  // VUSD
   "0xDaD503f8B9d42bb7af3AfC588358D30163e4416F",
+  // vetBTC
+  "0xCBA2Ffa0AC52d7871a4221a871793Eb788013faB",
 ];

--- a/web/scripts/setup.ts
+++ b/web/scripts/setup.ts
@@ -17,7 +17,16 @@ import { balanceOf } from "viem-erc20/actions";
 
 import { knownTokens } from "../src/utils/tokenList.ts";
 
-const setupSymbols = ["hemiBTC", "USDC", "USDT", "VUSD", "WBTC", "WETH"];
+const setupSymbols = [
+  "cbBTC",
+  "hemiBTC",
+  "USDC",
+  "USDT",
+  "vetBTC",
+  "VUSD",
+  "WBTC",
+  "WETH",
+];
 
 const tokens = knownTokens
   .filter((t) => setupSymbols.includes(t.symbol))

--- a/web/src/fetchers/fetchAnalyticsTotals.ts
+++ b/web/src/fetchers/fetchAnalyticsTotals.ts
@@ -1,0 +1,35 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { poolDepositsOptions } from "hooks/usePoolDeposits";
+import { stakingVaultForPeggedTokenOptions } from "hooks/useStakingVaultForPeggedToken";
+import type { TokenWithGateway } from "types";
+import type { Client } from "viem";
+import { totalSupply } from "viem-erc20/actions";
+
+export const fetchAnalyticsTotals = async function ({
+  chainId,
+  client,
+  peggedToken,
+  queryClient,
+}: {
+  chainId: number;
+  client: Client;
+  peggedToken: TokenWithGateway;
+  queryClient: QueryClient;
+}) {
+  const mintedPromise = totalSupply(client, { address: peggedToken.address });
+  const stakingVaultAddress = await queryClient.ensureQueryData(
+    stakingVaultForPeggedTokenOptions({
+      chainId,
+      client,
+      peggedTokenAddress: peggedToken.address,
+      queryClient,
+    }),
+  );
+  const [minted, staked] = await Promise.all([
+    mintedPromise,
+    queryClient.ensureQueryData(
+      poolDepositsOptions({ client, stakingVaultAddress }),
+    ),
+  ]);
+  return { minted, staked };
+};

--- a/web/src/fetchers/fetchCollateralizationRatio.ts
+++ b/web/src/fetchers/fetchCollateralizationRatio.ts
@@ -70,7 +70,9 @@ export const fetchCollateralizationRatio = async function ({
         strategicReserves: BigInt(b.strategicReserves),
         surplus: BigInt(b.surplus),
       })),
-    queryClient.ensureQueryData(analyticsTotalsOptions({ gatewayAddress })),
+    queryClient.ensureQueryData(
+      analyticsTotalsOptions({ client, peggedToken, queryClient }),
+    ),
     fetchTreasuryTotal({
       chainId,
       client,
@@ -85,7 +87,7 @@ export const fetchCollateralizationRatio = async function ({
 
   return {
     strategicReserves: toNumber(backing.strategicReserves),
-    supply: toNumber(BigInt(minted)),
+    supply: toNumber(minted),
     surplus: toNumber(backing.surplus),
     total: toNumber(total),
     treasuryTotal: toNumber(treasuryTotal),

--- a/web/src/fetchers/fetchRedeemGasUnits.ts
+++ b/web/src/fetchers/fetchRedeemGasUnits.ts
@@ -106,7 +106,7 @@ export const fetchRedeemGasUnits = async function ({
     return operationGasPromise;
   }
 
-  // The user is whitelisted, so they need to approve vusd
+  // The user is whitelisted, so they need to approve pegged
   // tokens that will be redeemed.
   const [approvalGas, operationGas] = await Promise.all([
     estimateApprovalGasUnits({

--- a/web/src/fetchers/fetchStakingVaultForPeggedToken.ts
+++ b/web/src/fetchers/fetchStakingVaultForPeggedToken.ts
@@ -1,0 +1,29 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { stakingVaultAddresses } from "@vetro-protocol/earn";
+import { vaultAssetOptions } from "hooks/useVaultAsset";
+import { type Address, type Client, isAddressEqual } from "viem";
+
+export const fetchStakingVaultForPeggedToken = async function ({
+  client,
+  peggedTokenAddress,
+  queryClient,
+}: {
+  client: Client;
+  peggedTokenAddress: Address;
+  queryClient: QueryClient;
+}) {
+  const assets = await Promise.all(
+    stakingVaultAddresses.map((vaultAddress) =>
+      queryClient.ensureQueryData(vaultAssetOptions({ client, vaultAddress })),
+    ),
+  );
+  const stakingVaultAddress = stakingVaultAddresses.find((_, index) =>
+    isAddressEqual(assets[index], peggedTokenAddress),
+  );
+  if (!stakingVaultAddress) {
+    throw new Error(
+      `No staking vault found for pegged token ${peggedTokenAddress}`,
+    );
+  }
+  return stakingVaultAddress;
+};

--- a/web/src/fetchers/fetchVaultPeggedToken.ts
+++ b/web/src/fetchers/fetchVaultPeggedToken.ts
@@ -1,8 +1,9 @@
 import type { QueryClient } from "@tanstack/react-query";
+import { peggedTokensByGatewayQueryOptions } from "hooks/usePeggedTokensByGateway";
 import { tokenInfoOptions } from "hooks/useTokenInfo";
 import { vaultAssetOptions } from "hooks/useVaultAsset";
-import type { Token } from "types";
-import type { Address, Client } from "viem";
+import type { TokenWithGateway } from "types";
+import { type Address, type Client, isAddressEqual } from "viem";
 
 export const fetchVaultPeggedToken = async function ({
   client,
@@ -12,18 +13,32 @@ export const fetchVaultPeggedToken = async function ({
   client: Client;
   queryClient: QueryClient;
   stakingVaultAddress: Address;
-}): Promise<Token> {
-  // The Asset of the vault is the pegged token,
-  // as the vaults we use are for depositing pegged Tokens.
+}): Promise<TokenWithGateway> {
   const address = await queryClient.ensureQueryData(
     vaultAssetOptions({ client, vaultAddress: stakingVaultAddress }),
   );
 
-  return queryClient.ensureQueryData(
-    tokenInfoOptions({
-      address,
-      chainId: client.chain!.id,
-      client,
-    }),
+  const [token, peggedTokensByGateway] = await Promise.all([
+    queryClient.ensureQueryData(
+      tokenInfoOptions({
+        address,
+        chainId: client.chain!.id,
+        client,
+      }),
+    ),
+    queryClient.ensureQueryData(
+      peggedTokensByGatewayQueryOptions({ client, queryClient }),
+    ),
+  ]);
+
+  const match = Object.values(peggedTokensByGateway).find((t) =>
+    isAddressEqual(t.address, address),
   );
+  if (!match) {
+    throw new Error(
+      `No gateway found for pegged token ${address} of vault ${stakingVaultAddress}`,
+    );
+  }
+
+  return { ...token, gatewayAddress: match.gatewayAddress };
 };

--- a/web/src/fetchers/fetchVaultPeggedToken.ts
+++ b/web/src/fetchers/fetchVaultPeggedToken.ts
@@ -1,8 +1,8 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { tokenInfoOptions } from "hooks/useTokenInfo";
+import { vaultAssetOptions } from "hooks/useVaultAsset";
 import type { Token } from "types";
 import type { Address, Client } from "viem";
-import { asset } from "viem-erc4626/actions";
 
 export const fetchVaultPeggedToken = async function ({
   client,
@@ -15,7 +15,9 @@ export const fetchVaultPeggedToken = async function ({
 }): Promise<Token> {
   // The Asset of the vault is the pegged token,
   // as the vaults we use are for depositing pegged Tokens.
-  const address = await asset(client, { address: stakingVaultAddress });
+  const address = await queryClient.ensureQueryData(
+    vaultAssetOptions({ client, vaultAddress: stakingVaultAddress }),
+  );
 
   return queryClient.ensureQueryData(
     tokenInfoOptions({

--- a/web/src/hooks/useAnalyticsTotals.ts
+++ b/web/src/hooks/useAnalyticsTotals.ts
@@ -7,7 +7,15 @@ import {
 import { fetchAnalyticsTotals } from "fetchers/fetchAnalyticsTotals";
 import { useEthereumClient } from "hooks/useEthereumClient";
 import type { TokenWithGateway } from "types";
-import type { Client } from "viem";
+import type { Address, Client } from "viem";
+
+export const analyticsTotalsQueryKey = ({
+  chainId,
+  gatewayAddress,
+}: {
+  chainId: number | undefined;
+  gatewayAddress: Address | undefined;
+}) => ["analytics-totals", chainId, gatewayAddress];
 
 export const analyticsTotalsOptions = ({
   client,
@@ -27,11 +35,10 @@ export const analyticsTotalsOptions = ({
         peggedToken: peggedToken!,
         queryClient,
       }),
-    queryKey: [
-      "analytics-totals",
-      client?.chain?.id,
-      peggedToken?.gatewayAddress,
-    ],
+    queryKey: analyticsTotalsQueryKey({
+      chainId: client?.chain?.id,
+      gatewayAddress: peggedToken?.gatewayAddress,
+    }),
     refetchInterval: 5 * 60 * 1000, // 5 minutes
     retry: 2,
     staleTime: 5 * 60 * 1000, // 5 minutes

--- a/web/src/hooks/useAnalyticsTotals.ts
+++ b/web/src/hooks/useAnalyticsTotals.ts
@@ -1,34 +1,46 @@
-import { queryOptions, useQuery } from "@tanstack/react-query";
-import fetch from "fetch-plus-plus";
-import { isValidUrl } from "utils/url";
-import type { Address } from "viem";
-
-const apiUrl = import.meta.env.VITE_VETRO_API_URL;
-
-type AnalyticsTotals = {
-  minted: string;
-  staked: string;
-};
+import {
+  type QueryClient,
+  queryOptions,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { fetchAnalyticsTotals } from "fetchers/fetchAnalyticsTotals";
+import { useEthereumClient } from "hooks/useEthereumClient";
+import type { TokenWithGateway } from "types";
+import type { Client } from "viem";
 
 export const analyticsTotalsOptions = ({
-  gatewayAddress,
+  client,
+  peggedToken,
+  queryClient,
 }: {
-  gatewayAddress: Address | undefined;
+  client: Client | undefined;
+  peggedToken: TokenWithGateway | undefined;
+  queryClient: QueryClient;
 }) =>
   queryOptions({
-    enabled:
-      apiUrl !== undefined &&
-      isValidUrl(apiUrl) &&
-      gatewayAddress !== undefined,
+    enabled: !!client && !!peggedToken,
     queryFn: () =>
-      fetch(
-        `${apiUrl}/analytics/totals/${gatewayAddress}`,
-      ) as Promise<AnalyticsTotals>,
-    queryKey: ["analytics-totals", gatewayAddress],
+      fetchAnalyticsTotals({
+        chainId: client!.chain!.id,
+        client: client!,
+        peggedToken: peggedToken!,
+        queryClient,
+      }),
+    queryKey: [
+      "analytics-totals",
+      client?.chain?.id,
+      peggedToken?.gatewayAddress,
+    ],
     refetchInterval: 5 * 60 * 1000, // 5 minutes
     retry: 2,
     staleTime: 5 * 60 * 1000, // 5 minutes
   });
 
-export const useAnalyticsTotals = (gatewayAddress: Address | undefined) =>
-  useQuery(analyticsTotalsOptions({ gatewayAddress }));
+export const useAnalyticsTotals = function (
+  peggedToken: TokenWithGateway | undefined,
+) {
+  const client = useEthereumClient();
+  const queryClient = useQueryClient();
+  return useQuery(analyticsTotalsOptions({ client, peggedToken, queryClient }));
+};

--- a/web/src/hooks/useAnalyticsTreasury.ts
+++ b/web/src/hooks/useAnalyticsTreasury.ts
@@ -6,6 +6,10 @@ import type { Address } from "viem";
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
 
+export const analyticsTreasuryQueryKey = (
+  gatewayAddress: Address | undefined,
+) => ["analytics-treasury", gatewayAddress];
+
 export const analyticsTreasuryOptions = ({
   gatewayAddress,
 }: {
@@ -20,7 +24,7 @@ export const analyticsTreasuryOptions = ({
       fetch(`${apiUrl}/analytics/treasury/${gatewayAddress}`) as Promise<
         TreasuryToken[]
       >,
-    queryKey: ["analytics-treasury", gatewayAddress],
+    queryKey: analyticsTreasuryQueryKey(gatewayAddress),
     refetchInterval: 5 * 60 * 1000, // 5 minutes
     retry: 2,
     staleTime: 5 * 60 * 1000, // 5 minutes

--- a/web/src/hooks/useCancelWithdraw.ts
+++ b/web/src/hooks/useCancelWithdraw.ts
@@ -6,9 +6,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { cancelWithdraw } from "@vetro-protocol/earn/actions";
 import { exitTicketsQueryKey } from "pages/earn/hooks/useExitTickets";
 import type { ExitTicket } from "pages/earn/types";
+import type { TokenWithGateway } from "types";
 import type { Address } from "viem";
 import { useAccount } from "wagmi";
 
+import { analyticsTotalsQueryKey } from "./useAnalyticsTotals";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { poolDepositsQueryKey } from "./usePoolDeposits";
@@ -21,6 +23,7 @@ type Params = {
   assets: bigint;
   onStatusChange: (status: CancelWithdrawStatus) => void;
   onTransactionHash?: (hash: string) => void;
+  peggedToken: TokenWithGateway;
   requestId: bigint;
   stakingVaultAddress: Address;
 };
@@ -29,6 +32,7 @@ export const useCancelWithdraw = function ({
   assets,
   onStatusChange,
   onTransactionHash,
+  peggedToken,
   requestId,
   stakingVaultAddress,
 }: Params) {
@@ -56,6 +60,11 @@ export const useCancelWithdraw = function ({
   const poolDepositsKey = poolDepositsQueryKey({
     chainId: chain.id,
     stakingVaultAddress,
+  });
+
+  const analyticsTotalsKey = analyticsTotalsQueryKey({
+    chainId: chain.id,
+    gatewayAddress: peggedToken.gatewayAddress,
   });
 
   return useMutation({
@@ -131,10 +140,11 @@ export const useCancelWithdraw = function ({
       });
 
       queryClient.invalidateQueries({
-        queryKey: poolDepositsQueryKey({
-          chainId: chain.id,
-          stakingVaultAddress,
-        }),
+        queryKey: poolDepositsKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: analyticsTotalsKey,
       });
     },
   });

--- a/web/src/hooks/useDeposit.ts
+++ b/web/src/hooks/useDeposit.ts
@@ -6,10 +6,13 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { DepositEvents } from "@vetro-protocol/gateway";
 import { deposit } from "@vetro-protocol/gateway/actions";
 import type { EventEmitter } from "events";
+import type { TreasuryToken } from "pages/analytics/types";
 import type { TokenWithGateway } from "types";
 import { type Address, isAddressEqual } from "viem";
 import { useAccount } from "wagmi";
 
+import { analyticsTotalsQueryKey } from "./useAnalyticsTotals";
+import { analyticsTreasuryQueryKey } from "./useAnalyticsTreasury";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import {
@@ -60,6 +63,15 @@ export const useDeposit = function ({
     chainId: ethereumChain.id,
     gatewayAddress,
   });
+
+  const analyticsTotalsKey = analyticsTotalsQueryKey({
+    chainId: ethereumChain.id,
+    gatewayAddress: peggedToken.gatewayAddress,
+  });
+
+  const analyticsTreasuryKey = analyticsTreasuryQueryKey(
+    peggedToken.gatewayAddress,
+  );
 
   const peggedTokenBalanceQueryKey = tokenBalanceQueryKey(peggedToken, account);
 
@@ -129,6 +141,29 @@ export const useDeposit = function ({
                 : reserve,
             ),
         );
+        // optimistically bump the analytics TVL totals (minted pegged supply)
+        queryClient.setQueryData(
+          analyticsTotalsKey,
+          (old: { minted: bigint; staked: bigint } | undefined) =>
+            old ? { ...old, minted: old.minted + minPeggedTokenOut } : old,
+        );
+        // optimistically bump the analytics treasury allocation for tokenIn.
+        // The API is indexer-backed and may lag, so this keeps the UI in
+        // sync until the backend catches up.
+        queryClient.setQueryData(
+          analyticsTreasuryKey,
+          (old: TreasuryToken[] | undefined) =>
+            old?.map((item) =>
+              isAddressEqual(item.tokenAddress as Address, tokenIn)
+                ? {
+                    ...item,
+                    withdrawable: (
+                      BigInt(item.withdrawable) + amountIn
+                    ).toString(),
+                  }
+                : item,
+            ),
+        );
       });
 
       return promise;
@@ -148,6 +183,14 @@ export const useDeposit = function ({
 
       queryClient.invalidateQueries({
         queryKey: treasuryReservesKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: analyticsTotalsKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: analyticsTreasuryKey,
       });
 
       // Let's clear this query, as once the user inputs an amount

--- a/web/src/hooks/useInstantWithdraw.ts
+++ b/web/src/hooks/useInstantWithdraw.ts
@@ -3,12 +3,13 @@ import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type { Token } from "types";
+import type { TokenWithGateway } from "types";
 import type { Address } from "viem";
 import { waitForTransactionReceipt } from "viem/actions";
 import { withdraw } from "viem-erc4626/actions";
 import { useAccount } from "wagmi";
 
+import { analyticsTotalsQueryKey } from "./useAnalyticsTotals";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { poolDepositsQueryKey } from "./usePoolDeposits";
@@ -22,7 +23,7 @@ type Params = {
   onStatusChange?: (status: InstantWithdrawStatus) => void;
   onSuccess?: VoidFunction;
   onTransactionHash?: (hash: string) => void;
-  peggedToken: Token;
+  peggedToken: TokenWithGateway;
   stakingVaultAddress: Address;
 };
 
@@ -61,6 +62,11 @@ export const useInstantWithdraw = function ({
   const poolDepositsKey = poolDepositsQueryKey({
     chainId: chain.id,
     stakingVaultAddress,
+  });
+
+  const analyticsTotalsKey = analyticsTotalsQueryKey({
+    chainId: chain.id,
+    gatewayAddress: peggedToken.gatewayAddress,
   });
 
   return useMutation({
@@ -136,10 +142,11 @@ export const useInstantWithdraw = function ({
       });
 
       queryClient.invalidateQueries({
-        queryKey: poolDepositsQueryKey({
-          chainId: chain.id,
-          stakingVaultAddress,
-        }),
+        queryKey: poolDepositsKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: analyticsTotalsKey,
       });
     },
   });

--- a/web/src/hooks/usePeggedTokensByGateway.ts
+++ b/web/src/hooks/usePeggedTokensByGateway.ts
@@ -11,7 +11,7 @@ import type { Address, Client } from "viem";
 import { useEthereumClient } from "./useEthereumClient";
 import { peggedTokenQueryOptions } from "./usePeggedToken";
 
-const peggedTokensByGatewayQueryOptions = ({
+export const peggedTokensByGatewayQueryOptions = ({
   client,
   queryClient,
 }: {

--- a/web/src/hooks/usePoolDeposits.ts
+++ b/web/src/hooks/usePoolDeposits.ts
@@ -1,28 +1,35 @@
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import { useEthereumClient } from "hooks/useEthereumClient";
-import { useMainnet } from "hooks/useMainnet";
-import type { Address } from "viem";
+import type { Address, Client } from "viem";
 import { totalAssets } from "viem-erc4626/actions";
 
 export const poolDepositsQueryKey = ({
   chainId,
   stakingVaultAddress,
 }: {
-  chainId: number;
+  chainId: number | undefined;
   stakingVaultAddress: Address;
 }) => ["pool-deposits", chainId, stakingVaultAddress];
 
-export function usePoolDeposits(stakingVaultAddress: Address) {
-  const chain = useMainnet();
-  const client = useEthereumClient();
-
-  return useQuery({
+export const poolDepositsOptions = ({
+  client,
+  stakingVaultAddress,
+}: {
+  client: Client | undefined;
+  stakingVaultAddress: Address;
+}) =>
+  queryOptions({
     enabled: !!client,
     queryFn: () => totalAssets(client!, { address: stakingVaultAddress }),
     queryKey: poolDepositsQueryKey({
-      chainId: chain.id,
+      chainId: client?.chain?.id,
       stakingVaultAddress,
     }),
     refetchInterval: 5 * 60 * 1000, // 5 minutes
   });
+
+export function usePoolDeposits(stakingVaultAddress: Address) {
+  const client = useEthereumClient();
+
+  return useQuery(poolDepositsOptions({ client, stakingVaultAddress }));
 }

--- a/web/src/hooks/useStakeDeposit.ts
+++ b/web/src/hooks/useStakeDeposit.ts
@@ -5,10 +5,11 @@ import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deposit } from "@vetro-protocol/earn/actions";
-import type { Token } from "types";
+import type { TokenWithGateway } from "types";
 import type { Address, TransactionReceipt } from "viem";
 import { useAccount } from "wagmi";
 
+import { analyticsTotalsQueryKey } from "./useAnalyticsTotals";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { poolDepositsQueryKey } from "./usePoolDeposits";
@@ -29,7 +30,7 @@ type Params = {
   onStatusChange?: (status: DepositStatus) => void;
   onSuccess?: VoidFunction;
   onTransactionHash?: (hash: string) => void;
-  peggedToken: Token;
+  peggedToken: TokenWithGateway;
   stakingVaultAddress: Address;
 };
 
@@ -74,6 +75,11 @@ export const useStakeDeposit = function ({
   const poolDepositsKey = poolDepositsQueryKey({
     chainId: chain.id,
     stakingVaultAddress,
+  });
+
+  const analyticsTotalsKey = analyticsTotalsQueryKey({
+    chainId: chain.id,
+    gatewayAddress: peggedToken.gatewayAddress,
   });
 
   return useMutation({
@@ -196,10 +202,11 @@ export const useStakeDeposit = function ({
       });
 
       queryClient.invalidateQueries({
-        queryKey: poolDepositsQueryKey({
-          chainId: chain.id,
-          stakingVaultAddress,
-        }),
+        queryKey: poolDepositsKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: analyticsTotalsKey,
       });
     },
   });

--- a/web/src/hooks/useStakeWithdraw.ts
+++ b/web/src/hooks/useStakeWithdraw.ts
@@ -7,9 +7,11 @@ import { stakingVaultAbi } from "@vetro-protocol/earn";
 import { requestWithdraw } from "@vetro-protocol/earn/actions";
 import { exitTicketsQueryKey } from "pages/earn/hooks/useExitTickets";
 import type { ExitTicket } from "pages/earn/types";
+import type { TokenWithGateway } from "types";
 import { type Address, type TransactionReceipt, parseEventLogs } from "viem";
 import { useAccount } from "wagmi";
 
+import { analyticsTotalsQueryKey } from "./useAnalyticsTotals";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { poolDepositsQueryKey } from "./usePoolDeposits";
@@ -23,6 +25,7 @@ type Params = {
   onStatusChange?: (status: WithdrawStatus) => void;
   onSuccess?: VoidFunction;
   onTransactionHash?: (hash: string) => void;
+  peggedToken: TokenWithGateway;
   stakingVaultAddress: Address;
 };
 
@@ -31,6 +34,7 @@ export const useStakeWithdraw = function ({
   onStatusChange,
   onSuccess,
   onTransactionHash,
+  peggedToken,
   stakingVaultAddress,
 }: Params) {
   const { address: account } = useAccount();
@@ -58,6 +62,11 @@ export const useStakeWithdraw = function ({
   const poolDepositsKey = poolDepositsQueryKey({
     chainId: chain.id,
     stakingVaultAddress,
+  });
+
+  const analyticsTotalsKey = analyticsTotalsQueryKey({
+    chainId: chain.id,
+    gatewayAddress: peggedToken.gatewayAddress,
   });
 
   return useMutation({
@@ -161,10 +170,11 @@ export const useStakeWithdraw = function ({
       });
 
       queryClient.invalidateQueries({
-        queryKey: poolDepositsQueryKey({
-          chainId: chain.id,
-          stakingVaultAddress,
-        }),
+        queryKey: poolDepositsKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: analyticsTotalsKey,
       });
     },
   });

--- a/web/src/hooks/useStakingVaultForPeggedToken.ts
+++ b/web/src/hooks/useStakingVaultForPeggedToken.ts
@@ -1,0 +1,25 @@
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { fetchStakingVaultForPeggedToken } from "fetchers/fetchStakingVaultForPeggedToken";
+import type { Address, Client } from "viem";
+
+export const stakingVaultForPeggedTokenOptions = ({
+  chainId,
+  client,
+  peggedTokenAddress,
+  queryClient,
+}: {
+  chainId: number | undefined;
+  client: Client | undefined;
+  peggedTokenAddress: Address;
+  queryClient: QueryClient;
+}) =>
+  queryOptions({
+    enabled: !!client,
+    queryFn: () =>
+      fetchStakingVaultForPeggedToken({
+        client: client!,
+        peggedTokenAddress,
+        queryClient,
+      }),
+    queryKey: ["staking-vault-for-pegged-token", chainId, peggedTokenAddress],
+  });

--- a/web/src/hooks/useVaultAsset.ts
+++ b/web/src/hooks/useVaultAsset.ts
@@ -1,0 +1,16 @@
+import { queryOptions } from "@tanstack/react-query";
+import type { Address, Client } from "viem";
+import { asset } from "viem-erc4626/actions";
+
+export const vaultAssetOptions = ({
+  client,
+  vaultAddress,
+}: {
+  client: Client | undefined;
+  vaultAddress: Address;
+}) =>
+  queryOptions({
+    enabled: !!client,
+    queryFn: () => asset(client!, { address: vaultAddress }),
+    queryKey: ["vault-asset", client?.chain?.id, vaultAddress],
+  });

--- a/web/src/pages/analytics/components/stakedCard.tsx
+++ b/web/src/pages/analytics/components/stakedCard.tsx
@@ -20,16 +20,14 @@ export const StakedCard = function ({ peggedToken, peggedTokenError }: Props) {
     data: totals,
     isError: isTotalsError,
     isLoading: isTotalsLoading,
-  } = useAnalyticsTotals(peggedToken?.gatewayAddress);
+  } = useAnalyticsTotals(peggedToken);
 
   const isError = peggedTokenError || isTotalsError;
   const isLoading = !isError && (!peggedToken || isTotalsLoading);
 
   const value =
     peggedToken && totals
-      ? formatUsd(
-          Number(formatUnits(BigInt(totals.staked), peggedToken.decimals)),
-        )
+      ? formatUsd(Number(formatUnits(totals.staked, peggedToken.decimals)))
       : "";
 
   const label = peggedToken ? (

--- a/web/src/pages/analytics/components/tvlCard.tsx
+++ b/web/src/pages/analytics/components/tvlCard.tsx
@@ -30,7 +30,7 @@ export const TvlCard = function ({ peggedToken, peggedTokenError }: Props) {
     data: totals,
     isError: isTotalsError,
     isLoading: isTotalsLoading,
-  } = useAnalyticsTotals(peggedToken?.gatewayAddress);
+  } = useAnalyticsTotals(peggedToken);
 
   const isError =
     peggedTokenError ||
@@ -47,9 +47,7 @@ export const TvlCard = function ({ peggedToken, peggedTokenError }: Props) {
 
   const value =
     peggedToken && totals
-      ? formatUsd(
-          Number(formatUnits(BigInt(totals.minted), peggedToken.decimals)),
-        )
+      ? formatUsd(Number(formatUnits(totals.minted, peggedToken.decimals)))
       : "";
 
   return (

--- a/web/src/pages/analytics/index.tsx
+++ b/web/src/pages/analytics/index.tsx
@@ -2,10 +2,10 @@ import { gatewayAddresses } from "@vetro-protocol/gateway";
 import { PageTitle } from "components/base/pageTitle";
 import { StripedDivider } from "components/stripedDivider";
 import { usePeggedTokensByGateway } from "hooks/usePeggedTokensByGateway";
-import { type ReactNode, useState } from "react";
+import { parseAsStringLiteral, useQueryState } from "nuqs";
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import Skeleton from "react-loading-skeleton";
-import type { Address } from "viem";
 
 import { CollateralizationCard } from "./components/collateralizationCard";
 import { ExitQueueCard } from "./components/exitQueueCard";
@@ -50,8 +50,9 @@ export const Analytics = function () {
   const { t } = useTranslation();
   const { data: peggedTokensByGateway, isError: isPeggedTokensError } =
     usePeggedTokensByGateway();
-  const [selectedGatewayAddress, setSelectedGatewayAddress] = useState<Address>(
-    gatewayAddresses[0],
+  const [selectedGatewayAddress, setSelectedGatewayAddress] = useQueryState(
+    "gateway",
+    parseAsStringLiteral(gatewayAddresses).withDefault(gatewayAddresses[0]),
   );
 
   const tokens = peggedTokensByGateway

--- a/web/src/pages/earn/components/exitTickets/deleteTicketModal.tsx
+++ b/web/src/pages/earn/components/exitTickets/deleteTicketModal.tsx
@@ -5,7 +5,7 @@ import { useActivityTracking } from "hooks/useActivityTracking";
 import { useCancelWithdraw } from "hooks/useCancelWithdraw";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { Token } from "types";
+import type { TokenWithGateway } from "types";
 import { formatAmount } from "utils/token";
 import { useAccount } from "wagmi";
 
@@ -14,7 +14,7 @@ import type { ExitTicket } from "../../types";
 type Props = {
   onClose: VoidFunction;
   onSuccess?: VoidFunction;
-  peggedToken: Token;
+  peggedToken: TokenWithGateway;
   ticket: ExitTicket;
 };
 
@@ -67,6 +67,7 @@ export function DeleteTicketModal({
       handlers[status]?.();
     },
     onTransactionHash,
+    peggedToken,
     requestId: BigInt(ticket.requestId),
     stakingVaultAddress: ticket.stakingVaultAddress,
   });

--- a/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeDepositForm.tsx
@@ -20,7 +20,7 @@ import { useStakeDeposit } from "hooks/useStakeDeposit";
 import { useTotalDepositFees } from "pages/earn/hooks/useTotalDepositFees";
 import { type FormEvent, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import type { Token } from "types";
+import type { TokenWithGateway } from "types";
 import { formatAmount } from "utils/token";
 import { type Address, parseUnits, zeroAddress } from "viem";
 import { useAccount } from "wagmi";
@@ -37,7 +37,7 @@ type Props = {
   onDepositStepChange: (step: DepositStep) => void;
   onInputChange: (value: string) => void;
   onSuccess: (toast: { description: string; title: string }) => void;
-  peggedToken: Token;
+  peggedToken: TokenWithGateway;
   stakingVaultAddress: Address;
 };
 

--- a/web/src/pages/earn/components/stakeDrawer/stakeDrawerContent.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeDrawerContent.tsx
@@ -2,7 +2,7 @@ import { DrawerTitle } from "components/base/drawer/drawerTitle";
 import { SegmentedControl } from "components/base/segmentedControl";
 import { useReducer } from "react";
 import { useTranslation } from "react-i18next";
-import { type Token } from "types";
+import { type TokenWithGateway } from "types";
 import type { Address } from "viem";
 
 import { StakeDepositForm } from "./stakeDepositForm";
@@ -24,7 +24,7 @@ type Props = {
   mode: StakeMode;
   onModeChange: (mode: StakeMode) => void;
   onSuccess: (toast: ToastData) => void;
-  peggedToken: Token;
+  peggedToken: TokenWithGateway;
   stakingVaultAddress: Address;
 };
 

--- a/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeWithdrawForm.tsx
@@ -19,7 +19,7 @@ import { useTotalWithdrawFees } from "pages/earn/hooks/useTotalWithdrawFees";
 import { type FormEvent, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import Skeleton from "react-loading-skeleton";
-import type { Token } from "types";
+import type { TokenWithGateway } from "types";
 import { formatAmount } from "utils/token";
 import { type Address, parseUnits } from "viem";
 import { useAccount } from "wagmi";
@@ -32,7 +32,7 @@ type Props = {
   onInputChange: (value: string) => void;
   onSuccess: (toast: { description: string; title: string }) => void;
   onWithdrawStepChange: (step: WithdrawStep) => void;
-  peggedToken: Token;
+  peggedToken: TokenWithGateway;
   stakingVaultAddress: Address;
   withdrawStep: WithdrawStep;
 };
@@ -210,6 +210,7 @@ export function StakeWithdrawForm({
     onStatusChange: handleWithdrawStepChange,
     onSuccess: handleRequestWithdrawSuccess,
     onTransactionHash: tracking.onTransactionHash,
+    peggedToken,
     stakingVaultAddress,
   });
 

--- a/web/src/utils/tokenList.ts
+++ b/web/src/utils/tokenList.ts
@@ -75,6 +75,48 @@ export const knownTokens: Token[] = [
     name: "Wrapped Ether",
     symbol: "WETH",
   },
+  {
+    address: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+    chainId: mainnet.id,
+    decimals: 8,
+    extensions: {
+      allowanceSlot: 10n,
+      balanceSlot: 9,
+      priceSymbol: "BTC",
+    },
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/cbbtc.svg",
+    name: "Coinbase Wrapped BTC",
+    symbol: "cbBTC",
+  },
+  {
+    address: "0xf196C68233464A16CFDa319a47c21f4cECa62001",
+    chainId: mainnet.id,
+    decimals: 18,
+    extensions: {
+      allowanceSlot: 1n,
+      balanceSlot: 0,
+      priceSymbol: "BTC",
+    },
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/vetbtc.svg",
+    name: "Vetro BTC",
+    symbol: "vetBTC",
+  },
+  {
+    address: "0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e",
+    chainId: mainnet.id,
+    decimals: 18,
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/svetbtc.svg",
+    name: "Staked Vetro BTC",
+    symbol: "svetBTC",
+  },
+  {
+    address: "0x476310E34D2810f7d79C43A74E4D79405bd7a925",
+    chainId: mainnet.id,
+    decimals: 18,
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/svusd.svg",
+    name: "Staked Vetro USD",
+    symbol: "sVUSD",
+  },
 ];
 
 export const getTokenListParams = (tokens: Token[]) => ({

--- a/web/test/fetchers/fetchCollateralizationRatio.test.ts
+++ b/web/test/fetchers/fetchCollateralizationRatio.test.ts
@@ -36,12 +36,12 @@ const e18 = 10n ** 18n;
 const setupMocks = function ({
   backing = { strategicReserves: "0", surplus: "0" },
   previewRedeem,
-  totals = { minted: "0" },
+  totals = { minted: 0n },
   treasury = [],
 }: {
   backing?: { strategicReserves: string; surplus: string };
   previewRedeem?: (tokenAddress: string) => bigint;
-  totals?: { minted: string };
+  totals?: { minted: bigint };
   treasury?: { tokenAddress: string; withdrawable: string }[];
 }) {
   const mock = (fn: unknown, queryFn: () => unknown, queryKey: string[]) =>
@@ -70,7 +70,7 @@ describe("fetchCollateralizationRatio", function () {
         strategicReserves: (80n * e18).toString(),
         surplus: (20n * e18).toString(),
       },
-      totals: { minted: (100n * e18).toString() },
+      totals: { minted: 100n * e18 },
     });
 
     const result = await fetchCollateralizationRatio({
@@ -96,7 +96,7 @@ describe("fetchCollateralizationRatio", function () {
       },
       // 1 VUSD buys 1 USDC (6 decimals)
       previewRedeem: () => 1n * 10n ** 6n,
-      totals: { minted: (100n * e18).toString() },
+      totals: { minted: 100n * e18 },
       // 40 USDC
       treasury: [
         {
@@ -141,7 +141,7 @@ describe("fetchCollateralizationRatio", function () {
         strategicReserves: "10000000000000000001",
         surplus: "10000000000000000002",
       },
-      totals: { minted: (100n * e18).toString() },
+      totals: { minted: 100n * e18 },
     });
 
     const result = await fetchCollateralizationRatio({
@@ -166,7 +166,7 @@ describe("fetchCollateralizationRatio", function () {
       },
       // 1 VUSD buys 1 of each stablecoin (both 6 decimals)
       previewRedeem: () => 1n * 10n ** 6n,
-      totals: { minted: (100n * e18).toString() },
+      totals: { minted: 100n * e18 },
       treasury: [
         {
           tokenAddress: usdcAddress,
@@ -199,7 +199,7 @@ describe("fetchCollateralizationRatio", function () {
         surplus: (10n * e18).toString(),
       },
       previewRedeem: () => 0n,
-      totals: { minted: (100n * e18).toString() },
+      totals: { minted: 100n * e18 },
       treasury: [
         {
           tokenAddress: "0xToken",

--- a/web/test/fetchers/fetchStakingVaultForPeggedToken.test.ts
+++ b/web/test/fetchers/fetchStakingVaultForPeggedToken.test.ts
@@ -1,0 +1,85 @@
+import { stakingVaultAddresses } from "@vetro-protocol/earn";
+import { vaultAssetOptions } from "hooks/useVaultAsset";
+import type { Address, Client } from "viem";
+import { mainnet } from "viem/chains";
+import { describe, expect, it } from "vitest";
+
+import { fetchStakingVaultForPeggedToken } from "../../src/fetchers/fetchStakingVaultForPeggedToken";
+import { createTestQueryClient } from "../utils";
+
+const client = { chain: mainnet } as unknown as Client;
+
+const vusdAddress = "0xCa83DDE9c22254f58e771bE5E157773212AcBAc3" as Address;
+const vetBtcAddress = "0xf196C68233464A16CFDa319a47c21f4cECa62001" as Address;
+
+const seedVaultAssets = function (
+  queryClient: ReturnType<typeof createTestQueryClient>,
+  assets: Address[],
+) {
+  stakingVaultAddresses.forEach((vaultAddress, index) =>
+    queryClient.setQueryData(
+      vaultAssetOptions({ client, vaultAddress }).queryKey,
+      assets[index],
+    ),
+  );
+};
+
+describe("fetchStakingVaultForPeggedToken", function () {
+  it("returns the vault whose asset matches the pegged token", async function () {
+    const queryClient = createTestQueryClient();
+    seedVaultAssets(queryClient, [vusdAddress, vetBtcAddress]);
+
+    const result = await fetchStakingVaultForPeggedToken({
+      client,
+      peggedTokenAddress: vusdAddress,
+      queryClient,
+    });
+
+    expect(result).toBe(stakingVaultAddresses[0]);
+  });
+
+  it("finds the matching vault regardless of position", async function () {
+    const queryClient = createTestQueryClient();
+    seedVaultAssets(queryClient, [vusdAddress, vetBtcAddress]);
+
+    const result = await fetchStakingVaultForPeggedToken({
+      client,
+      peggedTokenAddress: vetBtcAddress,
+      queryClient,
+    });
+
+    expect(result).toBe(stakingVaultAddresses[1]);
+  });
+
+  it("compares addresses case-insensitively", async function () {
+    const queryClient = createTestQueryClient();
+    seedVaultAssets(queryClient, [
+      vusdAddress.toLowerCase() as Address,
+      vetBtcAddress,
+    ]);
+
+    const result = await fetchStakingVaultForPeggedToken({
+      client,
+      peggedTokenAddress: vusdAddress,
+      queryClient,
+    });
+
+    expect(result).toBe(stakingVaultAddresses[0]);
+  });
+
+  it("throws when no vault matches the pegged token", async function () {
+    const queryClient = createTestQueryClient();
+    seedVaultAssets(queryClient, [vusdAddress, vetBtcAddress]);
+
+    const unknownPeggedToken =
+      "0xdead000000000000000000000000000000000000" as Address;
+
+    await expect(
+      fetchStakingVaultForPeggedToken({
+        client,
+        peggedTokenAddress: unknownPeggedToken,
+        queryClient,
+      }),
+    ).rejects.toThrow(/No staking vault found for pegged token/);
+  });
+});

--- a/web/test/fetchers/fetchStakingVaultForPeggedToken.test.ts
+++ b/web/test/fetchers/fetchStakingVaultForPeggedToken.test.ts
@@ -10,6 +10,7 @@ import { createTestQueryClient } from "../utils";
 const client = { chain: mainnet } as unknown as Client;
 
 const vusdAddress = "0xCa83DDE9c22254f58e771bE5E157773212AcBAc3" as Address;
+const vetBtcAddress = "0xf196C68233464A16CFDa319a47c21f4cECa62001" as Address;
 
 const seedVaultAssets = function (
   queryClient: ReturnType<typeof createTestQueryClient>,
@@ -26,7 +27,7 @@ const seedVaultAssets = function (
 describe("fetchStakingVaultForPeggedToken", function () {
   it("returns the vault whose asset matches the pegged token", async function () {
     const queryClient = createTestQueryClient();
-    seedVaultAssets(queryClient, [vusdAddress]);
+    seedVaultAssets(queryClient, [vusdAddress, vetBtcAddress]);
 
     const result = await fetchStakingVaultForPeggedToken({
       client,
@@ -37,9 +38,25 @@ describe("fetchStakingVaultForPeggedToken", function () {
     expect(result).toBe(stakingVaultAddresses[0]);
   });
 
+  it("finds the matching vault regardless of position", async function () {
+    const queryClient = createTestQueryClient();
+    seedVaultAssets(queryClient, [vusdAddress, vetBtcAddress]);
+
+    const result = await fetchStakingVaultForPeggedToken({
+      client,
+      peggedTokenAddress: vetBtcAddress,
+      queryClient,
+    });
+
+    expect(result).toBe(stakingVaultAddresses[1]);
+  });
+
   it("compares addresses case-insensitively", async function () {
     const queryClient = createTestQueryClient();
-    seedVaultAssets(queryClient, [vusdAddress.toLowerCase() as Address]);
+    seedVaultAssets(queryClient, [
+      vusdAddress.toLowerCase() as Address,
+      vetBtcAddress,
+    ]);
 
     const result = await fetchStakingVaultForPeggedToken({
       client,
@@ -52,7 +69,7 @@ describe("fetchStakingVaultForPeggedToken", function () {
 
   it("throws when no vault matches the pegged token", async function () {
     const queryClient = createTestQueryClient();
-    seedVaultAssets(queryClient, [vusdAddress]);
+    seedVaultAssets(queryClient, [vusdAddress, vetBtcAddress]);
 
     const unknownPeggedToken =
       "0xdead000000000000000000000000000000000000" as Address;

--- a/web/test/fetchers/fetchStakingVaultForPeggedToken.test.ts
+++ b/web/test/fetchers/fetchStakingVaultForPeggedToken.test.ts
@@ -10,7 +10,6 @@ import { createTestQueryClient } from "../utils";
 const client = { chain: mainnet } as unknown as Client;
 
 const vusdAddress = "0xCa83DDE9c22254f58e771bE5E157773212AcBAc3" as Address;
-const vetBtcAddress = "0xf196C68233464A16CFDa319a47c21f4cECa62001" as Address;
 
 const seedVaultAssets = function (
   queryClient: ReturnType<typeof createTestQueryClient>,
@@ -27,7 +26,7 @@ const seedVaultAssets = function (
 describe("fetchStakingVaultForPeggedToken", function () {
   it("returns the vault whose asset matches the pegged token", async function () {
     const queryClient = createTestQueryClient();
-    seedVaultAssets(queryClient, [vusdAddress, vetBtcAddress]);
+    seedVaultAssets(queryClient, [vusdAddress]);
 
     const result = await fetchStakingVaultForPeggedToken({
       client,
@@ -38,25 +37,9 @@ describe("fetchStakingVaultForPeggedToken", function () {
     expect(result).toBe(stakingVaultAddresses[0]);
   });
 
-  it("finds the matching vault regardless of position", async function () {
-    const queryClient = createTestQueryClient();
-    seedVaultAssets(queryClient, [vusdAddress, vetBtcAddress]);
-
-    const result = await fetchStakingVaultForPeggedToken({
-      client,
-      peggedTokenAddress: vetBtcAddress,
-      queryClient,
-    });
-
-    expect(result).toBe(stakingVaultAddresses[1]);
-  });
-
   it("compares addresses case-insensitively", async function () {
     const queryClient = createTestQueryClient();
-    seedVaultAssets(queryClient, [
-      vusdAddress.toLowerCase() as Address,
-      vetBtcAddress,
-    ]);
+    seedVaultAssets(queryClient, [vusdAddress.toLowerCase() as Address]);
 
     const result = await fetchStakingVaultForPeggedToken({
       client,
@@ -69,7 +52,7 @@ describe("fetchStakingVaultForPeggedToken", function () {
 
   it("throws when no vault matches the pegged token", async function () {
     const queryClient = createTestQueryClient();
-    seedVaultAssets(queryClient, [vusdAddress, vetBtcAddress]);
+    seedVaultAssets(queryClient, [vusdAddress]);
 
     const unknownPeggedToken =
       "0xdead000000000000000000000000000000000000" as Address;

--- a/web/test/fetchers/fetchTotalStakedUsd.test.ts
+++ b/web/test/fetchers/fetchTotalStakedUsd.test.ts
@@ -15,8 +15,14 @@ const client = { chain: mainnet } as unknown as Client;
 const vault1 = "0x1111111111111111111111111111111111111111" as Address;
 const vault2 = "0x2222222222222222222222222222222222222222" as Address;
 
-const vusd = knownTokens.find((token) => token.symbol === "VUSD")!;
-const usdc = knownTokens.find((token) => token.symbol === "USDC")!;
+const vusd = {
+  ...knownTokens.find((token) => token.symbol === "VUSD")!,
+  gatewayAddress: "0x0000000000000000000000000000000000000001" as Address,
+};
+const usdc = {
+  ...knownTokens.find((token) => token.symbol === "USDC")!,
+  gatewayAddress: "0x0000000000000000000000000000000000000002" as Address,
+};
 
 describe("fetchTotalStakedUsd", function () {
   it("returns staked amount times price for a single vault", async function () {


### PR DESCRIPTION
### Description

Wraps up the analytics surface for multiple pegged tokens. The `/analytics/totals/:gatewayAddress` endpoint is removed and `{ minted, staked }` are now computed client-side from on-chain reads via React Query, with shared `useVaultAsset` / `useStakingVaultForPeggedToken` hooks. Stake and deposit mutations invalidate analytics-totals (and the deposit flow optimistically updates TVL) so the dashboard reflects swaps and stakes immediately instead of waiting up to 5 minutes for refetch. Strategic reserves are scoped to the VUSD gateway (returning 0 elsewhere) so the backing endpoint stays correct as more pegged tokens come online. The selected analytics token is persisted in a `gateway` URL param via nuqs, the API README is synced with the current endpoint shapes, and the redeem comment is generalized to pegged tokens.

Lastly, it adds `vetBTC` and `sVetBTC` to the page so they become enabled

**Commits:**

- 11f70ef Compute analytics totals client-side
- c22ff02 Generalize redeem comment to pegged tokens
- 02f5da8 Persist analytics token filter in URL
- 571ccd2 Sync api README with current endpoints
- e98ae17 Invalidate analytics totals on stake mutations
- af3277c Scope strategic reserves to VUSD gateway
- a992121 Refresh analytics TVL after deposit
- b2e33d8 Adds `vetBTC` and `sVetBTC` to the page

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img width="694" height="411" alt="image" src="https://github.com/user-attachments/assets/f235ef79-e5b0-46d4-870f-7687f6fb90a8" />

<img width="609" height="424" alt="image" src="https://github.com/user-attachments/assets/a1223a42-501c-4fde-8249-4e4d2f8211aa" />

<img width="460" height="848" alt="image" src="https://github.com/user-attachments/assets/1155203f-0c96-4b4a-821e-91daf66c6ed6" />

<img width="783" height="508" alt="image" src="https://github.com/user-attachments/assets/3678804d-efe7-481c-8828-4907abb62ce5" />

<img width="1246" height="333" alt="image" src="https://github.com/user-attachments/assets/7286453f-96b4-4c8d-b91c-020e174ccd74" />

<img width="1274" height="488" alt="image" src="https://github.com/user-attachments/assets/3f667466-f8f2-4ffa-9ca1-63e803cd4e4b" />

<img width="485" height="852" alt="image" src="https://github.com/user-attachments/assets/5995afd6-9c10-4f1f-83a6-dd01d81816e3" />

<img width="626" height="180" alt="image" src="https://github.com/user-attachments/assets/338e51d6-5362-4a59-8453-217636640e36" />

<img width="1218" height="356" alt="image" src="https://github.com/user-attachments/assets/6361e9d2-f596-47dc-a413-b2d0c6242491" />

<img width="1282" height="616" alt="image" src="https://github.com/user-attachments/assets/9fcfe4b9-7ae2-4127-9b66-2fcde2dff4cb" />

(Borrow page stays the same)

### Related issue(s)

Closes #239

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.