### PR TITLE
Update vetBTC token container bg on earn page

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -16,6 +16,8 @@
   --color-blue-900: #1a2f95;
   --color-blue-950: #0f1957;
 
+  --color-vetbtc-logo: #ee4c01;
+
   --font-geist: "Geist", sans-serif;
   --font-size-xss: 0.688rem; /* 11px */
   --font-size-xsm: 0.8125rem; /* 13px */

--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -50,7 +50,13 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
     <div className="flex flex-col gap-6 border-b border-gray-200 bg-white p-4 sm:gap-4 md:flex-row md:items-center md:justify-between md:px-16 md:py-6">
       <div className="grid grid-cols-2 gap-4 sm:flex sm:items-center sm:justify-center sm:gap-6 md:justify-start md:gap-8">
         {peggedToken ? (
-          <div className="flex size-10 items-center justify-center rounded-lg bg-blue-800/10">
+          <div
+            className={`flex size-10 items-center justify-center rounded-lg ${
+              peggedToken.symbol === "vetBTC"
+                ? "bg-vetbtc-logo/10"
+                : "bg-blue-800/10"
+            }`}
+          >
             <TokenLogo {...peggedToken} />
           </div>
         ) : (


### PR DESCRIPTION
### Description

The vetBTC pool wraps its `<TokenLogo>` on the earn pool info bar in a 10%-opacity `#ee4c01` square (the vetBTC logo color); VUSD keeps the existing `bg-blue-800/10`. The orange is exposed as a Tailwind v4 theme color (`--color-vetbtc-logo`) so the `/10` opacity modifier composes.

### Screenshots

<img width="1130" height="343" alt="image" src="https://github.com/user-attachments/assets/2b5fb070-8a04-4be4-b584-e150d745e16c" />


### Related issue(s)

Closes #366

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.