### PR TITLE
Fix vetBTC pricing in fiat displays

### DIFF
--- a/packages/gateway/src/gatewayAddresses.ts
+++ b/packages/gateway/src/gatewayAddresses.ts
@@ -10,7 +10,7 @@ export type Gateway = {
 // Whitelisted-token oracles within a gateway are denominated in the gateway's
 // peg unit (e.g. WBTC/BTC for the vetBTC gateway, USDT/USD for the VUSD gateway),
 // so the USD price for any whitelisted token is `oracle × portal[pegBaseSymbol]`.
-// See `web/src/hooks/usePrices.ts` for the merge.
+// See `web/src/fetchers/fetchPrices.ts` for the merge.
 export const gateways: Gateway[] = [
   // VUSD
   {

--- a/packages/gateway/src/gatewayAddresses.ts
+++ b/packages/gateway/src/gatewayAddresses.ts
@@ -1,8 +1,27 @@
 import type { Address } from "viem";
 
-export const gatewayAddresses: Address[] = [
+export type Gateway = {
+  address: Address;
+  // Portal-API symbol used to convert this gateway's peg unit into USD.
+  // "USD" is treated as identity (no conversion needed).
+  pegBaseSymbol: string;
+};
+
+// Whitelisted-token oracles within a gateway are denominated in the gateway's
+// peg unit (e.g. WBTC/BTC for the vetBTC gateway, USDT/USD for the VUSD gateway),
+// so the USD price for any whitelisted token is `oracle × portal[pegBaseSymbol]`.
+// See `web/src/hooks/usePrices.ts` for the merge.
+export const gateways: Gateway[] = [
   // VUSD
-  "0xDaD503f8B9d42bb7af3AfC588358D30163e4416F",
+  {
+    address: "0xDaD503f8B9d42bb7af3AfC588358D30163e4416F",
+    pegBaseSymbol: "USD",
+  },
   // vetBTC
-  "0xCBA2Ffa0AC52d7871a4221a871793Eb788013faB",
+  {
+    address: "0xCBA2Ffa0AC52d7871a4221a871793Eb788013faB",
+    pegBaseSymbol: "BTC",
+  },
 ];
+
+export const gatewayAddresses: Address[] = gateways.map((g) => g.address);

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -26,8 +26,12 @@ import {
 
 // Export ABI
 export { gatewayAbi } from "./abi/gatewayAbi.js";
-// Export gateway addresses
-export { gatewayAddresses } from "./gatewayAddresses.js";
+// Export gateway addresses and per-gateway peg-base metadata
+export {
+  type Gateway,
+  gatewayAddresses,
+  gateways,
+} from "./gatewayAddresses.js";
 
 export type { CancelRedeemRequestParams };
 

--- a/web/src/fetchers/fetchOraclePrices.ts
+++ b/web/src/fetchers/fetchOraclePrices.ts
@@ -61,7 +61,12 @@ export const fetchOraclePrices = async function ({
         }),
       ]);
 
-      const key = (token.extensions?.priceSymbol ?? token.symbol).toUpperCase();
+      // Each whitelisted token's oracle is denominated in the gateway's peg
+      // unit (e.g. WBTC/BTC for the vetBTC gateway). Key by the token's symbol
+      // so each entry is unique within the gateway dict — `priceSymbol` is only
+      // a downstream lookup alias (used by `getTokenPrice`) and would cause
+      // collisions here when several whitelisted tokens share the same alias.
+      const key = token.symbol.toUpperCase();
       return [key, formatUnits(latestAnswer, decimals)] as const;
     }),
   );

--- a/web/src/fetchers/fetchPrices.ts
+++ b/web/src/fetchers/fetchPrices.ts
@@ -47,9 +47,11 @@ const oracleDictInUsd = ({
  * happens downstream in `utils/token.ts#getTokenPrice`.
  *
  * Failure mode: if `portal[pegBaseSymbol]` is missing, the corresponding
- * gateway's tokens resolve to `$0`. Callers (`RenderFiatValue`,
- * `liquidationPriceCell`) already guard on zero/error, so this degrades
- * gracefully rather than crashing.
+ * gateway's tokens resolve to `$0` in the merged dict. Consumers either
+ * render that as `$0` (e.g. `RenderFiatValue`, which only shows `-` on
+ * query errors, not on a zero price) or branch on it explicitly (e.g.
+ * `liquidationPriceCell` shows `-` when the price is non-positive). Not
+ * crash-prone, but visually misleading until the portal recovers.
  */
 export const fetchPrices = async function ({
   client,

--- a/web/src/fetchers/fetchPrices.ts
+++ b/web/src/fetchers/fetchPrices.ts
@@ -1,0 +1,93 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { Gateway } from "@vetro-protocol/gateway";
+import { oraclePricesOptions } from "hooks/useOraclePrices";
+import { tokenPricesOptions } from "hooks/useTokenPrices";
+import type { Client } from "viem";
+
+const pegToUsdRate = ({
+  pegBaseSymbol,
+  portal,
+}: {
+  pegBaseSymbol: string;
+  portal: Record<string, string>;
+}) => (pegBaseSymbol === "USD" ? 1 : Number(portal[pegBaseSymbol] ?? 0));
+
+const oracleDictInUsd = ({
+  oracle,
+  pegToUsd,
+}: {
+  oracle: Record<string, string>;
+  pegToUsd: number;
+}) =>
+  Object.entries(oracle).map(
+    ([symbol, peggedPrice]) =>
+      [symbol, String(Number(peggedPrice) * pegToUsd)] as const,
+  );
+
+/**
+ * Builds the merged USD price dictionary used by `usePrices`. The result is a
+ * flat `Record<symbol, USD price string>` composed from two sources:
+ *
+ *   1. The portal API (`tokenPricesOptions`) — USD prices for arbitrary tokens
+ *      keyed by uppercase symbol (BTC, WBTC, ETH, USDT, USDC, ...). This is
+ *      the only source equipped to convert a gateway's peg unit (BTC, ETH) to
+ *      USD. Portal entries seed the result; oracle entries override them on
+ *      key collision, since the oracle is the source the protocol itself uses
+ *      for mint/redeem and liquidations.
+ *
+ *   2. Per-gateway on-chain Chainlink oracles (`oraclePricesOptions`) — these
+ *      are denominated in the *gateway's peg unit*, NOT USD (e.g. WBTC/BTC for
+ *      the vetBTC gateway, USDT/USD for the VUSD gateway). Each oracle entry
+ *      is converted to USD by multiplying by `portal[gateway.pegBaseSymbol]`,
+ *      with `"USD"` treated as identity (×1).
+ *
+ * Pegged tokens themselves (vetBTC, VUSD, future vetETH) have no oracle of
+ * their own; they use `extensions.priceSymbol` to point at a whitelisted proxy
+ * in the same gateway (vetBTC→WBTC, VUSD→USDT, vetETH→WETH). The lookup
+ * happens downstream in `utils/token.ts#getTokenPrice`.
+ *
+ * Failure mode: if `portal[pegBaseSymbol]` is missing, the corresponding
+ * gateway's tokens resolve to `$0`. Callers (`RenderFiatValue`,
+ * `liquidationPriceCell`) already guard on zero/error, so this degrades
+ * gracefully rather than crashing.
+ */
+export const fetchPrices = async function ({
+  client,
+  gateways,
+  queryClient,
+}: {
+  client: Client;
+  gateways: readonly Gateway[];
+  queryClient: QueryClient;
+}): Promise<Record<string, string>> {
+  const [portal, gatewaysWithOracle] = await Promise.all([
+    queryClient.ensureQueryData(tokenPricesOptions()),
+    Promise.all(
+      gateways.map(async function (gateway) {
+        const oracle = await queryClient.ensureQueryData(
+          oraclePricesOptions({
+            client,
+            gatewayAddress: gateway.address,
+            queryClient,
+          }),
+        );
+        return { gateway, oracle };
+      }),
+    ),
+  ]);
+
+  return {
+    ...portal,
+    ...Object.fromEntries(
+      gatewaysWithOracle.flatMap(({ gateway, oracle }) =>
+        oracleDictInUsd({
+          oracle,
+          pegToUsd: pegToUsdRate({
+            pegBaseSymbol: gateway.pegBaseSymbol,
+            portal,
+          }),
+        }),
+      ),
+    ),
+  };
+};

--- a/web/src/hooks/usePrices.ts
+++ b/web/src/hooks/usePrices.ts
@@ -4,13 +4,17 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { gatewayAddresses } from "@vetro-protocol/gateway";
+import { gateways } from "@vetro-protocol/gateway";
+import { fetchPrices } from "fetchers/fetchPrices";
 import type { Client } from "viem";
 
 import { useEthereumClient } from "./useEthereumClient";
-import { oraclePricesOptions } from "./useOraclePrices";
-import { tokenPricesOptions } from "./useTokenPrices";
 
+/**
+ * USD prices for tokens used across the app. The merge logic lives in
+ * `fetchers/fetchPrices.ts` (with full architecture docs). This hook just
+ * wires the gateway list into the React Query cache.
+ */
 export const pricesOptions = ({
   client,
   queryClient,
@@ -20,19 +24,7 @@ export const pricesOptions = ({
 }) =>
   queryOptions({
     enabled: !!client && !!client.chain,
-    async queryFn() {
-      // Assumes whitelisted tokens are disjoint across gateways; if two
-      // gateways ever whitelist the same symbol, the later one wins on merge.
-      const [portalPrices, ...oraclePricesPerGateway] = await Promise.all([
-        queryClient.ensureQueryData(tokenPricesOptions()),
-        ...gatewayAddresses.map((gatewayAddress) =>
-          queryClient.ensureQueryData(
-            oraclePricesOptions({ client, gatewayAddress, queryClient }),
-          ),
-        ),
-      ]);
-      return Object.assign({}, portalPrices, ...oraclePricesPerGateway);
-    },
+    queryFn: () => fetchPrices({ client: client!, gateways, queryClient }),
     queryKey: ["prices", client?.chain?.id],
     refetchInterval: 60_000,
     staleTime: 30_000,

--- a/web/src/pages/analytics/components/exitQueueCard.tsx
+++ b/web/src/pages/analytics/components/exitQueueCard.tsx
@@ -25,9 +25,9 @@ export const ExitQueueCard = function ({
     isError: isExitQueueError,
     isLoading: isExitQueueLoading,
   } = useVariableStakeExitQueue(peggedToken?.gatewayAddress);
-  const { data: prices } = usePrices();
+  const { data: prices, isError: isPricesError } = usePrices();
 
-  const isError = peggedTokenError || isExitQueueError;
+  const isError = peggedTokenError || isExitQueueError || isPricesError;
   const isLoading = !isError && (!peggedToken || isExitQueueLoading || !prices);
 
   const value =

--- a/web/src/pages/analytics/components/exitQueueCard.tsx
+++ b/web/src/pages/analytics/components/exitQueueCard.tsx
@@ -1,9 +1,9 @@
+import { usePrices } from "hooks/usePrices";
 import { useVariableStakeExitQueue } from "hooks/useVariableStakeExitQueue";
 import { useTranslation } from "react-i18next";
 import Skeleton from "react-loading-skeleton";
 import type { TokenWithGateway } from "types";
-import { formatUsd } from "utils/currency";
-import { formatUnits } from "viem";
+import { formatTokenAmountUsd } from "utils/currency";
 
 import { ExitQueueIcon } from "../icons/exitQueueIcon";
 
@@ -25,15 +25,18 @@ export const ExitQueueCard = function ({
     isError: isExitQueueError,
     isLoading: isExitQueueLoading,
   } = useVariableStakeExitQueue(peggedToken?.gatewayAddress);
+  const { data: prices } = usePrices();
 
   const isError = peggedTokenError || isExitQueueError;
-  const isLoading = !isError && (!peggedToken || isExitQueueLoading);
+  const isLoading = !isError && (!peggedToken || isExitQueueLoading || !prices);
 
   const value =
-    peggedToken && exitQueue
-      ? formatUsd(
-          Number(formatUnits(exitQueue.assetsInCooldown, peggedToken.decimals)),
-        )
+    peggedToken && exitQueue && prices
+      ? formatTokenAmountUsd({
+          amount: exitQueue.assetsInCooldown,
+          prices,
+          token: peggedToken,
+        })
       : "";
 
   const label = peggedToken ? (

--- a/web/src/pages/analytics/components/stakedCard.tsx
+++ b/web/src/pages/analytics/components/stakedCard.tsx
@@ -1,9 +1,9 @@
 import { useAnalyticsTotals } from "hooks/useAnalyticsTotals";
+import { usePrices } from "hooks/usePrices";
 import { useTranslation } from "react-i18next";
 import Skeleton from "react-loading-skeleton";
 import type { TokenWithGateway } from "types";
-import { formatUsd } from "utils/currency";
-import { formatUnits } from "viem";
+import { formatTokenAmountUsd } from "utils/currency";
 
 import { StakingIcon } from "../icons/stakingIcon";
 
@@ -21,13 +21,18 @@ export const StakedCard = function ({ peggedToken, peggedTokenError }: Props) {
     isError: isTotalsError,
     isLoading: isTotalsLoading,
   } = useAnalyticsTotals(peggedToken);
+  const { data: prices } = usePrices();
 
   const isError = peggedTokenError || isTotalsError;
-  const isLoading = !isError && (!peggedToken || isTotalsLoading);
+  const isLoading = !isError && (!peggedToken || isTotalsLoading || !prices);
 
   const value =
-    peggedToken && totals
-      ? formatUsd(Number(formatUnits(totals.staked, peggedToken.decimals)))
+    peggedToken && totals && prices
+      ? formatTokenAmountUsd({
+          amount: totals.staked,
+          prices,
+          token: peggedToken,
+        })
       : "";
 
   const label = peggedToken ? (

--- a/web/src/pages/analytics/components/stakedCard.tsx
+++ b/web/src/pages/analytics/components/stakedCard.tsx
@@ -21,9 +21,9 @@ export const StakedCard = function ({ peggedToken, peggedTokenError }: Props) {
     isError: isTotalsError,
     isLoading: isTotalsLoading,
   } = useAnalyticsTotals(peggedToken);
-  const { data: prices } = usePrices();
+  const { data: prices, isError: isPricesError } = usePrices();
 
-  const isError = peggedTokenError || isTotalsError;
+  const isError = peggedTokenError || isTotalsError || isPricesError;
   const isLoading = !isError && (!peggedToken || isTotalsLoading || !prices);
 
   const value =

--- a/web/src/pages/analytics/components/tvlCard.tsx
+++ b/web/src/pages/analytics/components/tvlCard.tsx
@@ -64,7 +64,15 @@ export const TvlCard = function ({ peggedToken, peggedTokenError }: Props) {
       icon={<DatabaseIcon />}
       isError={isError}
       isLoading={isLoading}
-      items={toTvlItems({ treasuryTokens: treasury, whitelistedTokens })}
+      items={
+        prices && treasury && whitelistedTokens
+          ? toTvlItems({
+              prices,
+              treasuryTokens: treasury,
+              whitelistedTokens,
+            })
+          : undefined
+      }
       label={t("pages.analytics.tvl-label")}
       value={value}
     />

--- a/web/src/pages/analytics/components/tvlCard.tsx
+++ b/web/src/pages/analytics/components/tvlCard.tsx
@@ -31,13 +31,14 @@ export const TvlCard = function ({ peggedToken, peggedTokenError }: Props) {
     isError: isTotalsError,
     isLoading: isTotalsLoading,
   } = useAnalyticsTotals(peggedToken);
-  const { data: prices } = usePrices();
+  const { data: prices, isError: isPricesError } = usePrices();
 
   const isError = [
     peggedTokenError,
     isWhitelistedTokensError,
     isTreasuryError,
     isTotalsError,
+    isPricesError,
   ].some(Boolean);
 
   const isLoading =

--- a/web/src/pages/analytics/components/tvlCard.tsx
+++ b/web/src/pages/analytics/components/tvlCard.tsx
@@ -1,10 +1,10 @@
 import { useAnalyticsTotals } from "hooks/useAnalyticsTotals";
 import { useAnalyticsTreasury } from "hooks/useAnalyticsTreasury";
+import { usePrices } from "hooks/usePrices";
 import { useWhitelistedTokensByGateway } from "hooks/useWhitelistedTokensByGateway";
 import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
-import { formatUsd } from "utils/currency";
-import { formatUnits } from "viem";
+import { formatTokenAmountUsd } from "utils/currency";
 
 import { DatabaseIcon } from "../icons/databaseIcon";
 import { toTvlItems } from "../utils";
@@ -31,23 +31,32 @@ export const TvlCard = function ({ peggedToken, peggedTokenError }: Props) {
     isError: isTotalsError,
     isLoading: isTotalsLoading,
   } = useAnalyticsTotals(peggedToken);
+  const { data: prices } = usePrices();
 
-  const isError =
-    peggedTokenError ||
-    isWhitelistedTokensError ||
-    isTreasuryError ||
-    isTotalsError;
+  const isError = [
+    peggedTokenError,
+    isWhitelistedTokensError,
+    isTreasuryError,
+    isTotalsError,
+  ].some(Boolean);
 
   const isLoading =
     !isError &&
-    (!peggedToken ||
-      isTreasuryLoading ||
-      isTotalsLoading ||
-      !whitelistedTokens);
+    [
+      !peggedToken,
+      isTreasuryLoading,
+      isTotalsLoading,
+      !whitelistedTokens,
+      !prices,
+    ].some(Boolean);
 
   const value =
-    peggedToken && totals
-      ? formatUsd(Number(formatUnits(totals.minted, peggedToken.decimals)))
+    peggedToken && totals && prices
+      ? formatTokenAmountUsd({
+          amount: totals.minted,
+          prices,
+          token: peggedToken,
+        })
       : "";
 
   return (

--- a/web/src/pages/analytics/components/yieldCard.tsx
+++ b/web/src/pages/analytics/components/yieldCard.tsx
@@ -23,12 +23,13 @@ export const YieldCard = function ({ peggedToken, peggedTokenError }: Props) {
     isError: isTreasuryError,
     isLoading: isTreasuryLoading,
   } = useAnalyticsTreasury(peggedToken?.gatewayAddress);
-  const { data: prices } = usePrices();
+  const { data: prices, isError: isPricesError } = usePrices();
 
   const isError = [
     peggedTokenError,
     isWhitelistedTokensError,
     isTreasuryError,
+    isPricesError,
   ].some(Boolean);
   const isLoading =
     !isError &&

--- a/web/src/pages/analytics/components/yieldCard.tsx
+++ b/web/src/pages/analytics/components/yieldCard.tsx
@@ -1,4 +1,5 @@
 import { useAnalyticsTreasury } from "hooks/useAnalyticsTreasury";
+import { usePrices } from "hooks/usePrices";
 import { useWhitelistedTokensByGateway } from "hooks/useWhitelistedTokensByGateway";
 import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
@@ -22,34 +23,55 @@ export const YieldCard = function ({ peggedToken, peggedTokenError }: Props) {
     isError: isTreasuryError,
     isLoading: isTreasuryLoading,
   } = useAnalyticsTreasury(peggedToken?.gatewayAddress);
+  const { data: prices } = usePrices();
 
-  const isError =
-    peggedTokenError || isWhitelistedTokensError || isTreasuryError;
+  const isError = [
+    peggedTokenError,
+    isWhitelistedTokensError,
+    isTreasuryError,
+  ].some(Boolean);
   const isLoading =
-    !isError && (!peggedToken || isTreasuryLoading || !whitelistedTokens);
+    !isError &&
+    [!peggedToken, isTreasuryLoading, !whitelistedTokens, !prices].some(
+      Boolean,
+    );
 
-  const tokens = { treasuryTokens: treasury, whitelistedTokens };
-  const yieldItems = toYieldItems(tokens);
-  const bufferAmount = toReserveBufferAmount(tokens);
-  const bufferItem =
-    bufferAmount > 0
-      ? {
-          amount: bufferAmount,
-          color: assignColor(yieldItems.length),
-          label: t("pages.analytics.reserve-buffer-label"),
-        }
-      : null;
+  const ready = prices && treasury && whitelistedTokens;
+  const yieldItems = ready
+    ? toYieldItems({ prices, treasuryTokens: treasury, whitelistedTokens })
+    : undefined;
+  const bufferAmount = ready
+    ? toReserveBufferAmount({
+        prices,
+        treasuryTokens: treasury,
+        whitelistedTokens,
+      })
+    : 0;
 
-  const value = treasury
-    ? t("pages.analytics.yield-value", { count: yieldItems.length })
-    : "";
+  const items = !yieldItems
+    ? undefined
+    : bufferAmount > 0
+      ? [
+          ...yieldItems,
+          {
+            amount: bufferAmount,
+            color: assignColor(yieldItems.length),
+            label: t("pages.analytics.reserve-buffer-label"),
+          },
+        ]
+      : yieldItems;
+
+  const value =
+    yieldItems && treasury
+      ? t("pages.analytics.yield-value", { count: yieldItems.length })
+      : "";
 
   return (
     <AllocationCard
       icon={<PieChartIcon />}
       isError={isError}
       isLoading={isLoading}
-      items={bufferItem ? [...yieldItems, bufferItem] : yieldItems}
+      items={items}
       label={t("pages.analytics.yield-label")}
       value={value}
     />

--- a/web/src/pages/analytics/types.ts
+++ b/web/src/pages/analytics/types.ts
@@ -1,4 +1,5 @@
-// Represents a single item in an allocation card's chart and legend.
+import type { Address } from "viem";
+
 // `amount` is used for bar proportions (via CSS flex) and formatted by AllocationLegend.
 export type AllocationItem = {
   amount: number;
@@ -13,7 +14,7 @@ export type TreasuryToken = {
   activeStrategies: { name: string; totalDebt: string }[];
   latestPrice: string;
   priceDecimals: number;
-  tokenAddress: string;
+  tokenAddress: Address;
   totalDebt: string;
   withdrawable: string;
 };

--- a/web/src/pages/analytics/utils.ts
+++ b/web/src/pages/analytics/utils.ts
@@ -1,8 +1,11 @@
 import type { Token } from "types";
+import { tokenAmountToUsd } from "utils/currency";
 import { formatNumber } from "utils/format";
-import { formatUnits } from "viem";
+import { formatUnits, isAddressEqual, type Address } from "viem";
 
 import type { AllocationItem, TreasuryToken } from "./types";
+
+type Prices = Record<string, string>;
 
 const colorPalette = [
   "bg-blue-400",
@@ -18,64 +21,62 @@ const colorPalette = [
 export const assignColor = (index: number) =>
   colorPalette[index % colorPalette.length] ?? "bg-gray-400";
 
-const findToken = (tokenAddress: string, whitelistedTokens: Token[]) =>
-  whitelistedTokens.find(
-    (t) => t.address.toLowerCase() === tokenAddress.toLowerCase(),
+const findToken = function (tokenAddress: Address, whitelistedTokens: Token[]) {
+  const token = whitelistedTokens.find((t) =>
+    isAddressEqual(t.address, tokenAddress),
   );
+  if (!token) {
+    throw new Error(`Token not found in whitelist: ${tokenAddress}`);
+  }
+  return token;
+};
 
 // Transforms /analytics/treasury response into TVL allocation items.
-// amount: USD value = (withdrawable / 10^decimals) × (latestPrice / 10^priceDecimals)
 // withdrawable includes idle funds + deployed strategies (vs totalDebt = strategies only).
-// tokenDecimals sourced from whitelistedTokens; falls back to 18 for unknown tokens.
 export const toTvlItems = ({
-  treasuryTokens = [],
-  whitelistedTokens = [],
+  prices,
+  treasuryTokens,
+  whitelistedTokens,
 }: {
-  treasuryTokens?: TreasuryToken[];
-  whitelistedTokens?: Token[];
+  prices: Prices;
+  treasuryTokens: TreasuryToken[];
+  whitelistedTokens: Token[];
 }) =>
-  treasuryTokens.map(function (
-    { latestPrice, priceDecimals, tokenAddress, withdrawable },
-    index,
-  ) {
+  treasuryTokens.map(function ({ tokenAddress, withdrawable }, index) {
     const token = findToken(tokenAddress, whitelistedTokens);
-    const decimals = token?.decimals ?? 18;
-    const symbol = token?.symbol ?? tokenAddress.slice(0, 6);
+    const { decimals, symbol } = token;
+
     return {
-      amount:
-        Number(formatUnits(BigInt(withdrawable), decimals)) *
-        Number(formatUnits(BigInt(latestPrice), priceDecimals)),
+      amount: tokenAmountToUsd({ amount: BigInt(withdrawable), prices, token }),
       color: assignColor(index),
       label: symbol,
-      logoURI: token?.logoURI,
+      logoURI: token.logoURI,
       tooltip: `${formatNumber(formatUnits(BigInt(withdrawable), decimals))} ${symbol}`,
     };
   });
 
 // Transforms /analytics/treasury response into yield allocation items,
 // one item per active strategy across all tokens.
-// amount: USD value = (totalDebt / 10^decimals) × (latestPrice / 10^priceDecimals)
 export const toYieldItems = function ({
-  treasuryTokens = [],
-  whitelistedTokens = [],
+  prices,
+  treasuryTokens,
+  whitelistedTokens,
 }: {
-  treasuryTokens?: TreasuryToken[];
-  whitelistedTokens?: Token[];
+  prices: Prices;
+  treasuryTokens: TreasuryToken[];
+  whitelistedTokens: Token[];
 }) {
   const items: { amount: number; color: string; label: string }[] = [];
 
-  for (const {
-    activeStrategies,
-    latestPrice,
-    priceDecimals,
-    tokenAddress,
-  } of treasuryTokens) {
+  for (const { activeStrategies, tokenAddress } of treasuryTokens) {
     const token = findToken(tokenAddress, whitelistedTokens);
-    const decimals = token?.decimals ?? 18;
-    const price = Number(formatUnits(BigInt(latestPrice), priceDecimals));
 
     for (const { name, totalDebt } of activeStrategies) {
-      const amount = Number(formatUnits(BigInt(totalDebt), decimals)) * price;
+      const amount = tokenAmountToUsd({
+        amount: BigInt(totalDebt),
+        prices,
+        token,
+      });
       if (amount > 0) {
         items.push({ amount, color: assignColor(items.length), label: name });
       }
@@ -131,29 +132,24 @@ export const toCollateralizationItems = function (
 // Returns the reserve buffer amount in USD (idle funds not deployed to any strategy).
 // Returns 0 when there is no buffer. Color is intentionally omitted — callers assign it.
 export const toReserveBufferAmount = function ({
-  treasuryTokens = [],
-  whitelistedTokens = [],
+  prices,
+  treasuryTokens,
+  whitelistedTokens,
 }: {
-  treasuryTokens?: TreasuryToken[];
-  whitelistedTokens?: Token[];
+  prices: Prices;
+  treasuryTokens: TreasuryToken[];
+  whitelistedTokens: Token[];
 }) {
   let amount = 0;
 
-  for (const {
-    latestPrice,
-    priceDecimals,
-    tokenAddress,
-    totalDebt,
-    withdrawable,
-  } of treasuryTokens) {
+  for (const { tokenAddress, totalDebt, withdrawable } of treasuryTokens) {
     const token = findToken(tokenAddress, whitelistedTokens);
-    const decimals = token?.decimals ?? 18;
-    const price = Number(formatUnits(BigInt(latestPrice), priceDecimals));
 
-    amount +=
-      (Number(formatUnits(BigInt(withdrawable), decimals)) -
-        Number(formatUnits(BigInt(totalDebt), decimals))) *
-      price;
+    amount += tokenAmountToUsd({
+      amount: BigInt(withdrawable) - BigInt(totalDebt),
+      prices,
+      token,
+    });
   }
 
   return Math.max(0, amount);

--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -25,7 +25,7 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
   const { data: apy, isLoading: isLoadingApy } = useApy();
   const { data: poolDeposits, isLoading: isLoadingDeposits } =
     usePoolDeposits(stakingVaultAddress);
-  const { data: prices } = usePrices();
+  const { data: prices, isError: isPricesError } = usePrices();
   const { data: userRewards } = useUserRewards(stakingVaultAddress);
 
   const rewardTokens =
@@ -73,7 +73,7 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
           value={formatEvmAddress(stakingVaultAddress)}
         />
         <PoolInfoItem
-          isLoading={isLoadingDeposits || !prices}
+          isLoading={isLoadingDeposits || (!prices && !isPricesError)}
           label={t("pages.earn.pool-info.pool-deposits")}
           value={formatPoolDeposits()}
         />

--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -1,13 +1,14 @@
 import { TokenLogo } from "components/tokenLogo";
 import { useApy } from "hooks/useApy";
 import { usePoolDeposits } from "hooks/usePoolDeposits";
+import { usePrices } from "hooks/usePrices";
 import { useUserRewards } from "hooks/useUserRewards";
 import { useVaultPeggedToken } from "hooks/useVaultPeggedToken";
 import { useTranslation } from "react-i18next";
 import Skeleton from "react-loading-skeleton";
-import { formatUsd } from "utils/currency";
+import { formatTokenAmountUsd } from "utils/currency";
 import { formatEvmAddress } from "utils/format";
-import { type Address, formatUnits } from "viem";
+import type { Address } from "viem";
 
 import { PoolInfoButtons } from "./poolInfoButtons";
 import { PoolInfoItem } from "./poolInfoItem";
@@ -24,6 +25,7 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
   const { data: apy, isLoading: isLoadingApy } = useApy();
   const { data: poolDeposits, isLoading: isLoadingDeposits } =
     usePoolDeposits(stakingVaultAddress);
+  const { data: prices } = usePrices();
   const { data: userRewards } = useUserRewards(stakingVaultAddress);
 
   const rewardTokens =
@@ -32,9 +34,12 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
     })) ?? [];
 
   function formatPoolDeposits() {
-    if (poolDeposits !== undefined && peggedToken) {
-      const formatted = Number(formatUnits(poolDeposits, peggedToken.decimals));
-      return formatUsd(formatted);
+    if (poolDeposits !== undefined && peggedToken && prices) {
+      return formatTokenAmountUsd({
+        amount: poolDeposits,
+        prices,
+        token: peggedToken,
+      });
     }
     return undefined;
   }
@@ -68,7 +73,7 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
           value={formatEvmAddress(stakingVaultAddress)}
         />
         <PoolInfoItem
-          isLoading={isLoadingDeposits}
+          isLoading={isLoadingDeposits || !prices}
           label={t("pages.earn.pool-info.pool-deposits")}
           value={formatPoolDeposits()}
         />

--- a/web/src/utils/currency.ts
+++ b/web/src/utils/currency.ts
@@ -11,6 +11,23 @@ export const formatUsd = (value: number) =>
     style: "currency",
   }).format(value);
 
+type TokenAmountUsdArgs = {
+  amount: bigint;
+  prices: Record<string, string> | undefined;
+  token: Token;
+};
+
+// Multiplies a raw token amount (in smallest units) by the token's USD price
+// from `usePrices` / `getTokenPrice`. Returns a number, not a formatted string,
+// so callers can aggregate it (e.g. analytics chart proportions).
+export const tokenAmountToUsd = ({
+  amount,
+  prices,
+  token,
+}: TokenAmountUsdArgs) =>
+  Number(formatUnits(amount, token.decimals)) *
+  Number(getTokenPrice(token, prices));
+
 /**
  * Formats a raw token amount (in smallest units) as a compact USD string by
  * multiplying it by the token's USD price from `usePrices` / `getTokenPrice`.
@@ -19,19 +36,8 @@ export const formatUsd = (value: number) =>
  * notation of `formatUsd` is appropriate. For per-input fiat previews use
  * `RenderFiatValue` instead — it formats with full precision.
  */
-export const formatTokenAmountUsd = ({
-  amount,
-  prices,
-  token,
-}: {
-  amount: bigint;
-  prices: Record<string, string> | undefined;
-  token: Token;
-}) =>
-  formatUsd(
-    Number(formatUnits(amount, token.decimals)) *
-      Number(getTokenPrice(token, prices)),
-  );
+export const formatTokenAmountUsd = (args: TokenAmountUsdArgs) =>
+  formatUsd(tokenAmountToUsd(args));
 
 export function splitDecimalParts(value: number) {
   const formatted = new Intl.NumberFormat("en-US", {

--- a/web/src/utils/currency.ts
+++ b/web/src/utils/currency.ts
@@ -1,3 +1,8 @@
+import type { Token } from "types";
+import { formatUnits } from "viem";
+
+import { getTokenPrice } from "./token";
+
 export const formatUsd = (value: number) =>
   new Intl.NumberFormat("en-US", {
     currency: "USD",
@@ -5,6 +10,28 @@ export const formatUsd = (value: number) =>
     notation: "compact",
     style: "currency",
   }).format(value);
+
+/**
+ * Formats a raw token amount (in smallest units) as a compact USD string by
+ * multiplying it by the token's USD price from `usePrices` / `getTokenPrice`.
+ *
+ * Use this for aggregate displays (TVL, totals) where the compact `$1.2M`
+ * notation of `formatUsd` is appropriate. For per-input fiat previews use
+ * `RenderFiatValue` instead — it formats with full precision.
+ */
+export const formatTokenAmountUsd = ({
+  amount,
+  prices,
+  token,
+}: {
+  amount: bigint;
+  prices: Record<string, string> | undefined;
+  token: Token;
+}) =>
+  formatUsd(
+    Number(formatUnits(amount, token.decimals)) *
+      Number(getTokenPrice(token, prices)),
+  );
 
 export function splitDecimalParts(value: number) {
   const formatted = new Intl.NumberFormat("en-US", {

--- a/web/src/utils/tokenList.ts
+++ b/web/src/utils/tokenList.ts
@@ -138,7 +138,6 @@ export const knownTokens: Token[] = [
     extensions: {
       allowanceSlot: 10n,
       balanceSlot: 9,
-      priceSymbol: "BTC",
     },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/cbbtc.svg",
     name: "Coinbase Wrapped BTC",
@@ -151,7 +150,7 @@ export const knownTokens: Token[] = [
     extensions: {
       allowanceSlot: 1n,
       balanceSlot: 0,
-      priceSymbol: "BTC",
+      priceSymbol: "WBTC",
     },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/vetbtc.svg",
     name: "Vetro BTC",

--- a/web/test/fetchers/fetchOraclePrices.test.ts
+++ b/web/test/fetchers/fetchOraclePrices.test.ts
@@ -75,7 +75,7 @@ describe("fetchOraclePrices", function () {
     expect(result).toEqual({ USDC: "1" });
   });
 
-  it("uses priceSymbol from token extensions when available", async function () {
+  it("keys the oracle dict by token.symbol uppercased, ignoring priceSymbol", async function () {
     const hemiBtc = createMockToken(
       "hemiBTC",
       "0x3333333333333333333333333333333333333333",
@@ -91,18 +91,18 @@ describe("fetchOraclePrices", function () {
       queryFn: () => ({ oracle: oracleAddress }),
       queryKey: ["token-config"],
     } as never);
-    // BTC price: $60,000 with 8 decimals
+    // hemiBTC/BTC at 1.0 with 8 decimals
     vi.mocked(readContract)
-      .mockResolvedValueOnce(6000000000000n)
+      .mockResolvedValueOnce(100000000n)
       .mockResolvedValueOnce(8);
 
     const result = await fetchOraclePrices({
       client: mockClient,
-      gatewayAddress: "0xDaD503f8B9d42bb7af3AfC588358D30163e4416F",
+      gatewayAddress: "0xCBA2Ffa0AC52d7871a4221a871793Eb788013faB",
       queryClient,
     });
 
-    expect(result).toEqual({ BTC: "60000" });
+    expect(result).toEqual({ HEMIBTC: "1" });
   });
 
   it("returns prices for multiple tokens", async function () {

--- a/web/test/fetchers/fetchPrices.test.ts
+++ b/web/test/fetchers/fetchPrices.test.ts
@@ -1,0 +1,219 @@
+import type { Gateway } from "@vetro-protocol/gateway";
+import { oraclePricesOptions } from "hooks/useOraclePrices";
+import { tokenPricesOptions } from "hooks/useTokenPrices";
+import type { Address, Client } from "viem";
+import { mainnet } from "viem/chains";
+import { describe, expect, it } from "vitest";
+
+import { fetchPrices } from "../../src/fetchers/fetchPrices";
+import { createTestQueryClient } from "../utils";
+
+const client = { chain: mainnet } as unknown as Client;
+
+const vusdGateway: Gateway = {
+  address: "0x0000000000000000000000000000000000000001" as Address,
+  pegBaseSymbol: "USD",
+};
+const vetBtcGateway: Gateway = {
+  address: "0x0000000000000000000000000000000000000002" as Address,
+  pegBaseSymbol: "BTC",
+};
+const vetEthGateway: Gateway = {
+  address: "0x0000000000000000000000000000000000000003" as Address,
+  pegBaseSymbol: "ETH",
+};
+
+const seed = function (
+  queryClient: ReturnType<typeof createTestQueryClient>,
+  {
+    oraclesByGateway,
+    portal,
+  }: {
+    oraclesByGateway: Record<Address, Record<string, string>>;
+    portal: Record<string, string>;
+  },
+) {
+  queryClient.setQueryData(tokenPricesOptions().queryKey, portal);
+  Object.entries(oraclesByGateway).forEach(function ([gatewayAddress, dict]) {
+    queryClient.setQueryData(
+      oraclePricesOptions({
+        client,
+        gatewayAddress: gatewayAddress as Address,
+        queryClient,
+      }).queryKey,
+      dict,
+    );
+  });
+};
+
+describe("fetchPrices", function () {
+  it("returns portal-only entries when no gateways are provided", async function () {
+    const queryClient = createTestQueryClient();
+    seed(queryClient, {
+      oraclesByGateway: {},
+      portal: { BTC: "76800", ETH: "2288", USDT: "1" },
+    });
+
+    const result = await fetchPrices({
+      client,
+      gateways: [],
+      queryClient,
+    });
+
+    expect(result).toEqual({ BTC: "76800", ETH: "2288", USDT: "1" });
+  });
+
+  it("passes USD-pegged oracle entries through unchanged", async function () {
+    const queryClient = createTestQueryClient();
+    seed(queryClient, {
+      oraclesByGateway: {
+        [vusdGateway.address]: { USDC: "0.999", USDT: "1.001" },
+      },
+      portal: { USDC: "1", USDT: "1" },
+    });
+
+    const result = await fetchPrices({
+      client,
+      gateways: [vusdGateway],
+      queryClient,
+    });
+
+    // Oracle overrides portal for USDC/USDT, no multiplication for USD-pegged.
+    expect(result.USDC).toBe("0.999");
+    expect(result.USDT).toBe("1.001");
+  });
+
+  it("multiplies BTC-pegged oracle entries by portal['BTC']", async function () {
+    const queryClient = createTestQueryClient();
+    seed(queryClient, {
+      oraclesByGateway: {
+        // 1 WBTC = 0.998 BTC, 1 cbBTC = 1.0001 BTC
+        [vetBtcGateway.address]: { CBBTC: "1.0001", WBTC: "0.998" },
+      },
+      portal: { BTC: "76800", USDT: "1", WBTC: "76580" },
+    });
+
+    const result = await fetchPrices({
+      client,
+      gateways: [vetBtcGateway],
+      queryClient,
+    });
+
+    // WBTC is overwritten by oracle×BTC: 0.998 × 76800 = 76646.4
+    expect(Number(result.WBTC)).toBeCloseTo(76646.4, 4);
+    // cbBTC: 1.0001 × 76800 = 76807.68
+    expect(Number(result.CBBTC)).toBeCloseTo(76807.68, 4);
+    // Portal BTC entry survives untouched.
+    expect(result.BTC).toBe("76800");
+  });
+
+  it("multiplies ETH-pegged oracle entries by portal['ETH']", async function () {
+    const queryClient = createTestQueryClient();
+    seed(queryClient, {
+      oraclesByGateway: {
+        // 1 WETH = 1.0 ETH, 1 stETH = 1.005 ETH
+        [vetEthGateway.address]: { STETH: "1.005", WETH: "1" },
+      },
+      portal: { ETH: "2288", USDT: "1" },
+    });
+
+    const result = await fetchPrices({
+      client,
+      gateways: [vetEthGateway],
+      queryClient,
+    });
+
+    // WETH: 1 × 2288 = 2288
+    expect(Number(result.WETH)).toBeCloseTo(2288, 4);
+    // stETH: 1.005 × 2288 = 2299.44
+    expect(Number(result.STETH)).toBeCloseTo(2299.44, 4);
+    expect(result.ETH).toBe("2288");
+  });
+
+  it("composes multiple gateways simultaneously", async function () {
+    const queryClient = createTestQueryClient();
+    seed(queryClient, {
+      oraclesByGateway: {
+        [vetBtcGateway.address]: { WBTC: "0.998" },
+        [vusdGateway.address]: { USDC: "1.0001" },
+      },
+      portal: { BTC: "76800", HEMI: "0.0086", USDT: "1" },
+    });
+
+    const result = await fetchPrices({
+      client,
+      gateways: [vusdGateway, vetBtcGateway],
+      queryClient,
+    });
+
+    // VUSD gateway: USDC pass-through.
+    expect(result.USDC).toBe("1.0001");
+    // vetBTC gateway: WBTC × BTC.
+    expect(Number(result.WBTC)).toBeCloseTo(76646.4, 4);
+    // Portal-only entries survive.
+    expect(result.BTC).toBe("76800");
+    expect(result.HEMI).toBe("0.0086");
+  });
+
+  it("zeros out a gateway's tokens when its peg base is missing from portal", async function () {
+    const queryClient = createTestQueryClient();
+    seed(queryClient, {
+      oraclesByGateway: {
+        [vetBtcGateway.address]: { CBBTC: "1.0001", WBTC: "0.998" },
+      },
+      // Portal returned without BTC entry — degraded source.
+      portal: { ETH: "2288", USDT: "1" },
+    });
+
+    const result = await fetchPrices({
+      client,
+      gateways: [vetBtcGateway],
+      queryClient,
+    });
+
+    expect(result.WBTC).toBe("0");
+    expect(result.CBBTC).toBe("0");
+    // Other portal entries unaffected.
+    expect(result.ETH).toBe("2288");
+  });
+
+  it("handles a gateway with an empty oracle dict", async function () {
+    const queryClient = createTestQueryClient();
+    seed(queryClient, {
+      oraclesByGateway: {
+        [vetBtcGateway.address]: {},
+      },
+      portal: { BTC: "76800", WBTC: "76580" },
+    });
+
+    const result = await fetchPrices({
+      client,
+      gateways: [vetBtcGateway],
+      queryClient,
+    });
+
+    // Nothing to override; portal passes through.
+    expect(result).toEqual({ BTC: "76800", WBTC: "76580" });
+  });
+
+  it("oracle entries override portal entries on collision", async function () {
+    const queryClient = createTestQueryClient();
+    seed(queryClient, {
+      oraclesByGateway: {
+        // Oracle says 1 WBTC = 0.998 BTC → USD price 76646.4
+        [vetBtcGateway.address]: { WBTC: "0.998" },
+      },
+      // Portal disagrees on WBTC USD price.
+      portal: { BTC: "76800", WBTC: "99999" },
+    });
+
+    const result = await fetchPrices({
+      client,
+      gateways: [vetBtcGateway],
+      queryClient,
+    });
+
+    // Oracle wins.
+    expect(Number(result.WBTC)).toBeCloseTo(76646.4, 4);
+  });
+});

--- a/web/test/pages/analytics/utils.test.ts
+++ b/web/test/pages/analytics/utils.test.ts
@@ -26,6 +26,9 @@ const baseTreasuryToken: TreasuryToken = {
   withdrawable: "0",
 };
 
+// USD prices keyed by uppercase symbol (shape returned by `usePrices`).
+const prices = { USDC: "1", USDT: "1" };
+
 const usdtToken = {
   address: USDT_ADDRESS,
   chainId: 1,
@@ -58,11 +61,18 @@ describe("pages/analytics/utils", function () {
 
   describe("toReserveBufferAmount", function () {
     it("returns 0 when treasuryTokens is empty", function () {
-      expect(toReserveBufferAmount({})).toBe(0);
+      expect(
+        toReserveBufferAmount({
+          prices,
+          treasuryTokens: [],
+          whitelistedTokens: [],
+        }),
+      ).toBe(0);
     });
 
     it("returns 0 when withdrawable equals totalDebt", function () {
       const result = toReserveBufferAmount({
+        prices,
         treasuryTokens: [
           {
             ...baseTreasuryToken,
@@ -78,6 +88,7 @@ describe("pages/analytics/utils", function () {
 
     it("returns 0 when buffer is negative", function () {
       const result = toReserveBufferAmount({
+        prices,
         treasuryTokens: [
           {
             ...baseTreasuryToken,
@@ -94,6 +105,7 @@ describe("pages/analytics/utils", function () {
     it("computes correct amount for a single token", function () {
       // withdrawable: 1000 USDT, totalDebt: 900 USDT → buffer: 100 USDT @ $1 = $100
       const result = toReserveBufferAmount({
+        prices,
         treasuryTokens: [
           {
             ...baseTreasuryToken,
@@ -110,6 +122,7 @@ describe("pages/analytics/utils", function () {
     it("sums buffer across multiple tokens", function () {
       // USDT buffer: $100, USDC buffer: $50 → total: $150
       const result = toReserveBufferAmount({
+        prices,
         treasuryTokens: [
           {
             ...baseTreasuryToken,
@@ -132,6 +145,7 @@ describe("pages/analytics/utils", function () {
     it("uses decimals from whitelistedTokens", function () {
       // 1 token with 18 decimals @ $1 → buffer: $1
       const result = toReserveBufferAmount({
+        prices,
         treasuryTokens: [
           { ...baseTreasuryToken, withdrawable: "1000000000000000000" },
         ],
@@ -141,30 +155,30 @@ describe("pages/analytics/utils", function () {
       expect(result).toBeCloseTo(1);
     });
 
-    it("falls back to 18 decimals for unknown tokens", function () {
-      const result = toReserveBufferAmount({
-        treasuryTokens: [
-          {
-            ...baseTreasuryToken,
-            tokenAddress: "0xunknown",
-            withdrawable: "1000000000000000000",
-          },
-        ],
-        whitelistedTokens: [],
-      });
-
-      expect(result).toBeCloseTo(1);
+    it("throws when a treasury token's address isn't whitelisted", function () {
+      expect(() =>
+        toReserveBufferAmount({
+          prices,
+          treasuryTokens: [
+            { ...baseTreasuryToken, tokenAddress: USDC_ADDRESS },
+          ],
+          whitelistedTokens: [usdtToken],
+        }),
+      ).toThrow(`Token not found in whitelist: ${USDC_ADDRESS}`);
     });
   });
 
   describe("toTvlItems", function () {
     it("returns empty array when no treasury tokens", function () {
-      expect(toTvlItems({})).toEqual([]);
+      expect(
+        toTvlItems({ prices, treasuryTokens: [], whitelistedTokens: [] }),
+      ).toEqual([]);
     });
 
     it("computes correct USD amount per token", function () {
       // 1000 USDT (6 decimals) @ $1 = $1000
       const items = toTvlItems({
+        prices,
         treasuryTokens: [{ ...baseTreasuryToken, withdrawable: "1000000000" }],
         whitelistedTokens: [usdtToken],
       });
@@ -174,29 +188,29 @@ describe("pages/analytics/utils", function () {
       expect(items[0]?.label).toBe("USDT");
     });
 
-    it("falls back to token address prefix when token is unknown", function () {
-      const items = toTvlItems({
-        treasuryTokens: [
-          {
-            ...baseTreasuryToken,
-            tokenAddress: "0xABCDEF123456",
-            withdrawable: "1000000000000000000",
-          },
-        ],
-        whitelistedTokens: [],
-      });
-
-      expect(items[0]?.label).toBe("0xABCD");
+    it("throws when a treasury token's address isn't whitelisted", function () {
+      expect(() =>
+        toTvlItems({
+          prices,
+          treasuryTokens: [
+            { ...baseTreasuryToken, tokenAddress: USDC_ADDRESS },
+          ],
+          whitelistedTokens: [usdtToken],
+        }),
+      ).toThrow(`Token not found in whitelist: ${USDC_ADDRESS}`);
     });
   });
 
   describe("toYieldItems", function () {
     it("returns empty array when no treasury tokens", function () {
-      expect(toYieldItems({})).toEqual([]);
+      expect(
+        toYieldItems({ prices, treasuryTokens: [], whitelistedTokens: [] }),
+      ).toEqual([]);
     });
 
     it("excludes strategies with zero amount", function () {
       const items = toYieldItems({
+        prices,
         treasuryTokens: [
           {
             ...baseTreasuryToken,
@@ -217,6 +231,7 @@ describe("pages/analytics/utils", function () {
 
     it("flattens strategies across multiple tokens", function () {
       const items = toYieldItems({
+        prices,
         treasuryTokens: [
           {
             ...baseTreasuryToken,
@@ -247,6 +262,7 @@ describe("pages/analytics/utils", function () {
     it("computes correct USD amount per strategy", function () {
       // 500 USDT (6 decimals) @ $1 = $500
       const items = toYieldItems({
+        prices,
         treasuryTokens: [
           {
             ...baseTreasuryToken,
@@ -259,6 +275,18 @@ describe("pages/analytics/utils", function () {
       });
 
       expect(items[0]?.amount).toBeCloseTo(500);
+    });
+
+    it("throws when a treasury token's address isn't whitelisted", function () {
+      expect(() =>
+        toYieldItems({
+          prices,
+          treasuryTokens: [
+            { ...baseTreasuryToken, tokenAddress: USDC_ADDRESS },
+          ],
+          whitelistedTokens: [usdtToken],
+        }),
+      ).toThrow(`Token not found in whitelist: ${USDC_ADDRESS}`);
     });
   });
 


### PR DESCRIPTION
### Description

Fixes the vetBTC fiat-pricing bug. The root cause is that vetBTC's gateway oracles are denominated in **BTC**, not USD. The previous `usePrices` implementation merged those raw peg-denominated values into the portal-USD dict, so vetBTC (which uses `priceSymbol: "BTC"`) resolved to ~1 and rendered as `$1` everywhere.

The fix splits the two sources by their actual responsibility:

- **Portal API** converts a small set of peg-base symbols (USDT, USDC, BTC, ETH) to USD. That's all it's used for now.
- **On-chain Chainlink oracles** convert the rest of the whitelisted tokens into one of those peg bases — WBTC/cbBTC produce BTC values via the vetBTC gateway, USDT/USDC produce USD values via the VUSD gateway, and (future) WETH/stETH would produce ETH values via a vetETH gateway.

`fetchPrices` now composes them: portal entries seed the result; each gateway's oracle dict is multiplied by `portal[pegBaseSymbol]` (identity for USD-pegged) before being layered on top. Pegged tokens (vetBTC, VUSD, future vetETH) keep using `priceSymbol` as a proxy assumption — `vetBTC → WBTC`, `VUSD → USDT`. Architecture scales to vetETH without further changes.

A secondary key-collision bug also got fixed: `fetchOraclePrices` keyed its dict by `priceSymbol`, so WBTC/cbBTC/hemiBTC all writing to `"BTC"` collapsed into a single survivor. Now keyed by `token.symbol`, so each whitelisted token gets its own entry.

While auditing the same codepath, found and fixed a second display bug: `PoolInfoBar`, `TvlCard`, `StakedCard` and `ExitQueueCard` were doing `formatUsd(formatUnits(amount, peggedToken.decimals))`, which just prefixes `$` to the raw token count. Worked by accident for VUSD (1 VUSD ≈ $1) but vetBTC totals showed `$5` for 5 vetBTC instead of ~$380K. New `formatTokenAmountUsd` helper multiplies by the token's USD price before formatting.

Extracted the merge logic into `fetchers/fetchPrices.ts` with named helpers (`pegToUsdRate`, `oracleDictInUsd`) plus 8 unit tests covering USD/BTC/ETH peg cases, multi-gateway composition, oracle-overrides-portal collision, and the missing-peg-base degraded path.

**Commits:**

- 6118170 Add per-gateway peg base metadata
- d428384 Fix vetBTC pricing via oracle×peg merge

### Screenshots

<img width="1254" height="709" alt="image" src="https://github.com/user-attachments/assets/77ab30bf-ffdc-4d9b-b442-9f37311d8555" />

<img width="564" height="227" alt="image" src="https://github.com/user-attachments/assets/8846267a-cc3b-409c-a854-57637263320a" />

<img width="572" height="407" alt="image" src="https://github.com/user-attachments/assets/d954b609-e639-47ab-b53b-2d2237cc7d73" />


### Related issue(s)

Closes #358

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.