### PR TITLE
Add endpoint to get average purchase price

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -138,6 +138,28 @@ app.get(
 );
 
 app.get(
+  "/variable-stake/average-purchase-price/:address",
+  validateAddress,
+  cache({
+    cacheControl: "max-age=300",
+    cacheName: "vetro-api",
+  }),
+  async function (c) {
+    try {
+      const address = c.req.param("address") as `0x${string}`;
+      const url = getSubgraphUrl(c.env);
+      const data = await variableStake.getAveragePurchasePrice({
+        address,
+        url,
+      });
+      return c.json(convertBigIntsToString(data));
+    } catch (error) {
+      throw new Error(`Failed to get average purchase price: ${error.message}`);
+    }
+  },
+);
+
+app.get(
   "/variable-stake/apy",
   cache({
     cacheControl: "max-age=3600",

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -1,7 +1,14 @@
+import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { getPeggedToken } from "@vetro-protocol/gateway/actions";
 // @ts-expect-error Type declarations are not available for this dependency.
 import linearRegression from "simple-linear-regression";
-import { type Address, createPublicClient, type Hash, http } from "viem";
+import {
+  type Address,
+  createPublicClient,
+  checksumAddress,
+  type Hash,
+  http,
+} from "viem";
 import { mainnet } from "viem/chains";
 import { convertToAssets } from "viem-erc4626/actions";
 
@@ -11,6 +18,62 @@ import parseBigIntStringToNumber from "./parse-bigint-string-to-number.ts";
 import { findStakingVaultForPeggedToken } from "./staking-vault.ts";
 
 const secsPerDay = 86400;
+
+/**
+ * Query the subgraph for the user's staking positions across all known vaults
+ * and compute the average purchase price (totalCostBasis / shares) for each.
+ * Returns an object keyed by vault address with the price as a BigInt string
+ * in asset units (18 decimals). Defaults to "0" when the user has no position
+ * or zero shares.
+ */
+export async function getAveragePurchasePrice({
+  address,
+  url,
+}: {
+  address: string;
+  url: string;
+}) {
+  const query = `
+    query ($owner: Bytes!, $vaults: [Bytes!]!) {
+      userStakingPositions(
+        where: { owner: $owner, stakingVaultAddress_in: $vaults }
+      ) {
+        shares
+        stakingVaultAddress
+        totalCostBasis
+      }
+    }`;
+  const variables = {
+    owner: address.toLowerCase(),
+    vaults: stakingVaultAddresses.map((v) => v.toLowerCase()),
+  };
+  const { userStakingPositions } = await graphql.runQuery<{
+    userStakingPositions: {
+      shares: string;
+      stakingVaultAddress: `0x${string}`;
+      totalCostBasis: string;
+    }[];
+  }>(url, query, variables);
+  if (!Array.isArray(userStakingPositions)) {
+    throw new Error(
+      `Invalid subgraph response for staking positions of ${address}`,
+    );
+  }
+  // Pre-seed every known vault with "0" so the response shape is stable.
+  const result = Object.fromEntries(
+    stakingVaultAddresses.map((vault) => [vault, 0n]),
+  );
+  for (const position of userStakingPositions) {
+    const shares = BigInt(position.shares);
+    if (shares === 0n) {
+      continue;
+    }
+    const totalCostBasis = BigInt(position.totalCostBasis);
+    const averagePrice = totalCostBasis / shares;
+    result[checksumAddress(position.stakingVaultAddress)] = averagePrice;
+  }
+  return result;
+}
 
 /**
  * Query the subgraph. Get the last 7 days of data. Compute the APY using a

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -22,9 +22,9 @@ const secsPerDay = 86400;
 /**
  * Query the subgraph for the user's staking positions across all known vaults
  * and compute the average purchase price (totalCostBasis / shares) for each.
- * Returns an object keyed by vault address with the price as a BigInt string
- * in asset units (18 decimals). Defaults to "0" when the user has no position
- * or zero shares.
+ * Returns an object keyed by vault address with the price as a bigint in asset
+ * units (18 decimals). Defaults to 0n when the user has no position or zero
+ * shares.
  */
 export async function getAveragePurchasePrice({
   address,

--- a/api/test/variable-stake.test.ts
+++ b/api/test/variable-stake.test.ts
@@ -1,8 +1,16 @@
 import { sVetBtcAddress, sVusdAddress } from "@vetro-protocol/earn";
 import { describe, expect, it, vi } from "vitest";
 
+import * as graphql from "../src/graphql.ts";
 import * as merkl from "../src/merkl.ts";
-import { getUserRewards } from "../src/variable-stake.ts";
+import {
+  getAveragePurchasePrice,
+  getUserRewards,
+} from "../src/variable-stake.ts";
+
+vi.mock("../src/graphql.ts", () => ({
+  runQuery: vi.fn(),
+}));
 
 vi.mock("../src/merkl.ts", () => ({
   getOpportunityCampaigns: vi.fn(),
@@ -176,5 +184,98 @@ describe("variable-stake/getUserRewards", function () {
 
     expect(result[vaultA]).toEqual([reward]);
     expect(result[vaultB]).toEqual([reward]);
+  });
+});
+
+describe("variable-stake/getAveragePurchasePrice", function () {
+  const userAddress = "0x0000000000000000000000000000000000000001";
+  const subgraphUrl = "https://subgraph.test";
+
+  it("returns '0' for all vaults when user has no positions", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      userStakingPositions: [],
+    });
+
+    const result = await getAveragePurchasePrice({
+      address: userAddress,
+      url: subgraphUrl,
+    });
+
+    expect(result).toEqual({
+      [sVetBtcAddress]: 0n,
+      [sVusdAddress]: 0n,
+    });
+  });
+
+  it("returns '0' when shares is 0 (fully exited position)", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      userStakingPositions: [
+        {
+          shares: "0",
+          stakingVaultAddress: sVusdAddress.toLowerCase(),
+          totalCostBasis: "0",
+        },
+      ],
+    });
+
+    const result = await getAveragePurchasePrice({
+      address: userAddress,
+      url: subgraphUrl,
+    });
+
+    expect(result[sVusdAddress]).toBe(0n);
+  });
+
+  it("computes totalCostBasis / shares for a position", async function () {
+    // totalCostBasis is WAD-scaled (36 decimals), shares has 18 decimals.
+    // 2 shares at 1.5 asset-units each: totalCostBasis = 3e36, shares = 2e18
+    // result = 3e36 / 2e18 = 1.5e18
+    const shares = (2n * 10n ** 18n).toString();
+    const totalCostBasis = (3n * 10n ** 36n).toString();
+
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      userStakingPositions: [
+        {
+          shares,
+          stakingVaultAddress: sVusdAddress.toLowerCase(),
+          totalCostBasis,
+        },
+      ],
+    });
+
+    const result = await getAveragePurchasePrice({
+      address: userAddress,
+      url: subgraphUrl,
+    });
+
+    expect(result[sVusdAddress]).toBe(15n * 10n ** 17n);
+    expect(result[sVetBtcAddress]).toBe(0n);
+  });
+
+  it("returns prices for multiple vaults", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      userStakingPositions: [
+        {
+          shares: (10n ** 18n).toString(),
+          stakingVaultAddress: sVusdAddress.toLowerCase(),
+          totalCostBasis: (10n ** 36n).toString(),
+        },
+        {
+          shares: (4n * 10n ** 18n).toString(),
+          stakingVaultAddress: sVetBtcAddress.toLowerCase(),
+          totalCostBasis: (8n * 10n ** 36n).toString(),
+        },
+      ],
+    });
+
+    const result = await getAveragePurchasePrice({
+      address: userAddress,
+      url: subgraphUrl,
+    });
+
+    // 1e36 / 1e18 = 1e18
+    expect(result[sVusdAddress]).toBe(10n ** 18n);
+    // 8e36 / 4e18 = 2e18
+    expect(result[sVetBtcAddress]).toBe(2n * 10n ** 18n);
   });
 });

--- a/api/test/variable-stake.test.ts
+++ b/api/test/variable-stake.test.ts
@@ -1,4 +1,8 @@
-import { sVetBtcAddress, sVusdAddress } from "@vetro-protocol/earn";
+import {
+  stakingVaultAddresses,
+  sVetBtcAddress,
+  sVusdAddress,
+} from "@vetro-protocol/earn";
 import { describe, expect, it, vi } from "vitest";
 
 import * as graphql from "../src/graphql.ts";
@@ -201,10 +205,9 @@ describe("variable-stake/getAveragePurchasePrice", function () {
       url: subgraphUrl,
     });
 
-    expect(result).toEqual({
-      [sVetBtcAddress]: 0n,
-      [sVusdAddress]: 0n,
-    });
+    expect(result).toEqual(
+      Object.fromEntries(stakingVaultAddresses.map((vault) => [vault, 0n])),
+    );
   });
 
   it("returns '0' when shares is 0 (fully exited position)", async function () {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This pull request adds a new API endpoint to fetch the average purchase price for a user's staking positions across all known vaults, along with its implementation and comprehensive tests. The changes include the endpoint definition, the core logic to compute average purchase prices, and new unit tests to ensure correctness.

**New API endpoint and core logic:**

* Added a new GET endpoint `/variable-stake/average-purchase-price/:address` in `api/src/index.ts` to return the average purchase price per vault for a given user address, with input validation and caching.
* Implemented the `getAveragePurchasePrice` function in `api/src/variable-stake.ts`, which queries the subgraph for the user's staking positions and computes the average purchase price (totalCostBasis / shares) for each vault, returning a stable response shape.

**Testing and support:**

* Added unit tests for `getAveragePurchasePrice` in `api/test/variable-stake.test.ts`, covering scenarios such as no positions, fully exited positions, correct computation, and multiple vaults.
* Mocked the `graphql.runQuery` method in the test file to simulate subgraph responses for different test cases.

**Dependency and import updates:**

* Updated imports in `api/src/variable-stake.ts` to include `stakingVaultAddresses` and `checksumAddress` for vault address handling.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Resolves #373

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
