### PR TITLE
Return APY per staking vault

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -102,7 +102,7 @@ Returns the APY for each supported staking vault, indexed by staking vault addre
 ```jsonc
 {
   "0x476310E34D2810f7d79C43A74E4D79405bd7a925": {
-    "7d": 100, // 100 = 1%
+    "7d": 4.21,
   },
   "0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e": {
     "7d": 0,

--- a/api/README.md
+++ b/api/README.md
@@ -95,13 +95,18 @@ Gets the amount of collateral assets in a given Morpho market.
 
 ### `GET /variable-stake/apy`
 
-Returns the APY of the Vetro vault calculated using the share value variations over the last 7 days.
+Returns the APY for each supported staking vault, indexed by staking vault address, calculated using the share value variations over the last 7 days. Each supported staking vault has an entry in the response; vaults with insufficient history return `{ "7d": 0 }`.
 
 #### Sample Response
 
 ```jsonc
 {
-  "7d": 100, // 100 = 1%
+  "0x476310E34D2810f7d79C43A74E4D79405bd7a925": {
+    "7d": 100, // 100 = 1%
+  },
+  "0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e": {
+    "7d": 0,
+  },
 }
 ```
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -168,7 +168,9 @@ app.get(
   async function (c) {
     try {
       const url = getSubgraphUrl(c.env);
-      const data = await variableStake.getApy({ url });
+      const data = await variableStake.getApy({
+        url,
+      });
       return c.json(data);
     } catch (error) {
       throw new Error(`Failed to get APY: ${error.message}`);

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -168,9 +168,7 @@ app.get(
   async function (c) {
     try {
       const url = getSubgraphUrl(c.env);
-      const data = await variableStake.getApy({
-        url,
-      });
+      const data = await variableStake.getApy({ url });
       return c.json(data);
     } catch (error) {
       throw new Error(`Failed to get APY: ${error.message}`);

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -19,6 +19,13 @@ import { findStakingVaultForPeggedToken } from "./staking-vault.ts";
 
 const secsPerDay = 86400;
 
+type VaultHistoryRow = {
+  shareValue: string;
+  stakingVaultAddress: Address;
+  timestamp: string;
+};
+type VaultHistoriesResponse = { vaultHistories: VaultHistoryRow[] };
+
 /**
  * Query the subgraph for the user's staking positions across all known vaults
  * and compute the average purchase price (totalCostBasis / shares) for each.
@@ -76,18 +83,26 @@ export async function getAveragePurchasePrice({
 }
 
 /**
- * Query the subgraph. Get the last 7 days of data. Compute the APY using a
- * linear regression and getting the slope.
+ * Query the subgraph. Get the last 7 days of data per configured staking
+ * vault. Compute the APY for each vault using a linear regression and getting
+ * the slope. Returns a record keyed by vault address; every configured vault
+ * is present in the response (with `{ "7d": 0 }` when there is not enough
+ * history to compute a slope).
  */
 export async function getApy({ url }: { url: string }) {
   const query = `
-    query ($end: BigInt!, $start: BigInt!) {
+    query ($end: BigInt!, $start: BigInt!, $vaults: [Bytes!]!) {
       vaultHistories(
         orderBy: timestamp
-        where: { timestamp_gte: $start, timestamp_lt: $end }
+        where: {
+          stakingVaultAddress_in: $vaults
+          timestamp_gte: $start
+          timestamp_lt: $end
+        }
       ) {
-        timestamp
         shareValue
+        stakingVaultAddress
+        timestamp
       }
     }`;
   const end = Math.floor(Date.now() / 1000);
@@ -95,36 +110,52 @@ export async function getApy({ url }: { url: string }) {
   const variables = {
     end: end.toString(),
     start: start.toString(),
+    vaults: stakingVaultAddresses.map((address) => address.toLowerCase()),
   };
-  const { vaultHistories } = await graphql.runQuery<{
-    vaultHistories: { timestamp: string; shareValue: string }[];
-  }>(url, query, variables);
+
+  const { vaultHistories } = await graphql.runQuery<VaultHistoriesResponse>(
+    url,
+    query,
+    variables,
+  );
   if (!Array.isArray(vaultHistories)) {
     throw new Error("Invalid subgraph response for vault history");
   }
-  if (!vaultHistories.length || vaultHistories.length < 2) {
-    return {
-      "7d": 0,
-    };
+
+  const historiesByVault = new Map<
+    string,
+    { shareValue: string; timestamp: string }[]
+  >();
+  for (const history of vaultHistories) {
+    const key = history.stakingVaultAddress.toLowerCase();
+    const existing = historiesByVault.get(key);
+    if (existing) {
+      existing.push(history);
+    } else {
+      historiesByVault.set(key, [history]);
+    }
   }
 
-  const days = vaultHistories.map((h) =>
-    Math.floor(Number.parseInt(h.timestamp) / secsPerDay),
-  );
-  const values = vaultHistories.map((h) =>
-    parseBigIntStringToNumber(h.shareValue, 18),
-  );
-  const delta = linearRegression(days, values).a;
-  if (Number.isNaN(delta)) {
-    return {
-      "7d": 0,
-    };
-  }
-
-  const apy = ((delta * 365) / values[values.length - 1]) * 100;
-  return {
-    "7d": apy,
-  };
+  return Object.fromEntries(
+    stakingVaultAddresses.map(function (vaultAddress) {
+      const histories = historiesByVault.get(vaultAddress.toLowerCase()) ?? [];
+      if (histories.length < 2) {
+        return [vaultAddress, { "7d": 0 }];
+      }
+      const days = histories.map((h) =>
+        Math.floor(Number.parseInt(h.timestamp) / secsPerDay),
+      );
+      const values = histories.map((h) =>
+        parseBigIntStringToNumber(h.shareValue, 18),
+      );
+      const delta = linearRegression(days, values).a;
+      if (Number.isNaN(delta)) {
+        return [vaultAddress, { "7d": 0 }];
+      }
+      const apy = ((delta * 365) / values[values.length - 1]) * 100;
+      return [vaultAddress, { "7d": apy }];
+    }),
+  ) as Record<Address, { "7d": number }>;
 }
 
 /**

--- a/api/test/variable-stake.test.ts
+++ b/api/test/variable-stake.test.ts
@@ -22,10 +22,6 @@ vi.mock("../src/merkl.ts", () => ({
   getUserRewards: vi.fn(),
 }));
 
-vi.mock("../src/graphql.ts", () => ({
-  runQuery: vi.fn(),
-}));
-
 describe("variable-stake/getApy", function () {
   const url = "https://subgraph.example/v1";
   const vaultA = sVusdAddress;

--- a/api/test/variable-stake.test.ts
+++ b/api/test/variable-stake.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import * as graphql from "../src/graphql.ts";
 import * as merkl from "../src/merkl.ts";
 import {
+  getApy,
   getAveragePurchasePrice,
   getUserRewards,
 } from "../src/variable-stake.ts";
@@ -20,6 +21,121 @@ vi.mock("../src/merkl.ts", () => ({
   getOpportunityCampaigns: vi.fn(),
   getUserRewards: vi.fn(),
 }));
+
+vi.mock("../src/graphql.ts", () => ({
+  runQuery: vi.fn(),
+}));
+
+describe("variable-stake/getApy", function () {
+  const url = "https://subgraph.example/v1";
+  const vaultA = sVusdAddress;
+  const vaultB = sVetBtcAddress;
+  const secsPerDay = 86400;
+
+  const buildHistory = ({
+    days,
+    shareValueWad,
+    stakingVaultAddress,
+  }: {
+    days: number[];
+    shareValueWad: bigint[];
+    stakingVaultAddress: string;
+  }) =>
+    days.map((d, i) => ({
+      shareValue: shareValueWad[i].toString(),
+      stakingVaultAddress: stakingVaultAddress.toLowerCase(),
+      timestamp: (d * secsPerDay).toString(),
+    }));
+
+  it("returns { '7d': 0 } for every configured vault when there is no history", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({ vaultHistories: [] });
+
+    const result = await getApy({
+      url,
+    });
+
+    expect(result).toEqual({
+      [vaultA]: { "7d": 0 },
+      [vaultB]: { "7d": 0 },
+    });
+  });
+
+  it("returns { '7d': 0 } for a vault with fewer than two history points", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultHistories: buildHistory({
+        days: [20000],
+        shareValueWad: [10n ** 18n],
+        stakingVaultAddress: vaultA,
+      }),
+    });
+
+    const result = await getApy({
+      url,
+    });
+
+    expect(result).toEqual({
+      [vaultA]: { "7d": 0 },
+      [vaultB]: { "7d": 0 },
+    });
+  });
+
+  it("computes APY independently for each vault from its own history", async function () {
+    // Vault A: shareValue grows by 0.001 per day on a base of 1.0 -> ~36.5% APY
+    // Vault B: shareValue grows by 0.0001 per day on a base of 1.0 -> ~3.65% APY
+    const day0 = 20000;
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultHistories: [
+        ...buildHistory({
+          days: [day0, day0 + 1, day0 + 2],
+          shareValueWad: [
+            10n ** 18n,
+            10n ** 18n + 10n ** 15n,
+            10n ** 18n + 2n * 10n ** 15n,
+          ],
+          stakingVaultAddress: vaultA,
+        }),
+        ...buildHistory({
+          days: [day0, day0 + 1, day0 + 2],
+          shareValueWad: [
+            10n ** 18n,
+            10n ** 18n + 10n ** 14n,
+            10n ** 18n + 2n * 10n ** 14n,
+          ],
+          stakingVaultAddress: vaultB,
+        }),
+      ],
+    });
+
+    const result = await getApy({
+      url,
+    });
+
+    expect(result[vaultA]["7d"]).toBeCloseTo(36.43, 1);
+    expect(result[vaultB]["7d"]).toBeCloseTo(3.649, 1);
+  });
+
+  it("filters the subgraph query by the configured vaults (lowercased)", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({ vaultHistories: [] });
+
+    await getApy({ url });
+
+    const variables = vi.mocked(graphql.runQuery).mock.calls.at(-1)?.[2] as
+      | { vaults: string[] }
+      | undefined;
+    expect(variables?.vaults).toEqual([
+      vaultA.toLowerCase(),
+      vaultB.toLowerCase(),
+    ]);
+  });
+
+  it("throws when the subgraph response is malformed", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultHistories: undefined,
+    } as never);
+
+    await expect(getApy({ url })).rejects.toThrow(/Invalid subgraph response/);
+  });
+});
 
 describe("variable-stake/getUserRewards", function () {
   const userAddress = "0x0000000000000000000000000000000000000001" as const;

--- a/web/src/hooks/useApy.ts
+++ b/web/src/hooks/useApy.ts
@@ -15,5 +15,5 @@ export const useApy = (stakingVaultAddress: Address) =>
     queryKey: ["variable-stake-apy"],
     refetchInterval: 5 * 60 * 1000, // 5 minutes
     retry: 2,
-    select: (data) => data[stakingVaultAddress]?.["7d"] ?? 0,
+    select: (data) => data[stakingVaultAddress]["7d"],
   });

--- a/web/src/hooks/useApy.ts
+++ b/web/src/hooks/useApy.ts
@@ -1,21 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
 import { isValidUrl } from "utils/url";
+import type { Address } from "viem";
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
 
-type ApyResponse = {
-  "7d": number;
-};
+type ApyResponse = Record<Address, { "7d": number }>;
 
-export const useApy = () =>
+export const useApy = (stakingVaultAddress: Address) =>
   useQuery({
     enabled: apiUrl !== undefined && isValidUrl(apiUrl),
     queryFn: () =>
-      fetch(`${apiUrl}/variable-stake/apy`).then(
-        (data: ApyResponse) => data["7d"],
-      ),
+      fetch(`${apiUrl}/variable-stake/apy`) as Promise<ApyResponse>,
     queryKey: ["variable-stake-apy"],
     refetchInterval: 5 * 60 * 1000, // 5 minutes
     retry: 2,
+    select: (data) => data[stakingVaultAddress]?.["7d"] ?? 0,
   });

--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -22,7 +22,7 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
   const { t } = useTranslation();
   const { data: peggedToken } = useVaultPeggedToken(stakingVaultAddress);
 
-  const { data: apy, isLoading: isLoadingApy } = useApy();
+  const { data: apy, isLoading: isLoadingApy } = useApy(stakingVaultAddress);
   const { data: poolDeposits, isLoading: isLoadingDeposits } =
     usePoolDeposits(stakingVaultAddress);
   const { data: prices, isError: isPricesError } = usePrices();


### PR DESCRIPTION
### Description

`/variable-stake/apy` previously aggregated `VaultHistory` records across all staking vaults and returned a single APY. With multiple vaults live (sVUSD, sVETBTC) and `PoolInfoBar` rendering one pool at a time, callers need APY per pool.

The endpoint now returns `Record<Address, { "7d": number }>` keyed by vault address, by filtering `vaultHistories` with `stakingVaultAddress_in` and grouping per vault. Every configured vault is always present in the response, with `{ "7d": 0 }` when there is not enough history to compute a slope. `useApy(stakingVaultAddress)` keeps a single shared cache and uses React Query's `select` to extract its slice — mirroring the pattern already used by `useUserRewards`.

### Screenshots

<img width="1156" height="249" alt="image" src="https://github.com/user-attachments/assets/f6d1e8e0-db38-4460-a176-4681740bb59d" />


(totally made up numbers)

### Related issue(s)

Closes #360

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.