### PR TITLE
Document missing API endpoint and add doc-sync rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,7 @@
 - **Type vs Interface**: Prefer `type` over `interface`, except for module augmentation
 - **Running TypeScript files**: Use `node <path/to/file>.ts` directly — Node natively supports TypeScript execution
 - **Component Props naming**: When creating a type for component props, use generic name `Props` if they're the only props defined in the file. Otherwise, use `<ComponentName>Props`
+
+## API project
+
+When changing the API in `api/src/` in a way that affects external behavior — adding, removing, or modifying an endpoint's URL, params, response shape, sample data, or error semantics — review and update `api/README.md` in the same change. Code is the source of truth; the README must reflect it.

--- a/api/README.md
+++ b/api/README.md
@@ -60,6 +60,7 @@ Get the composition of the treasury by whitelisted token for a given gateway.
 
 Returns the historical borrow APR for a given market and period.
 Valid periods are: "1w", "1m", "3m" and "1y".
+`:marketId` must be a known market id. Returns `400` if malformed and `404` if the market is unsupported.
 
 #### Sample Response for "1m"
 
@@ -84,12 +85,27 @@ Valid periods are: "1w", "1m", "3m" and "1y".
 ### `GET /borrow/:marketId/collateral-assets`
 
 Gets the amount of collateral assets in a given Morpho market.
+`:marketId` must be a known market id. Returns `400` if malformed and `404` if the market is unsupported.
 
 #### Sample Response
 
 ```json
 {
   "collateralAssets": 219819281899
+}
+```
+
+### `GET /variable-stake/average-purchase-price/:address`
+
+Returns the user's average purchase price (in the vault asset's smallest unit, 18 decimals) for each known Vetro staking vault. Vaults where the user has no position return `"0"`.
+`:address` must be a well-formed Ethereum address. Returns `404` if malformed.
+
+#### Sample Response
+
+```jsonc
+{
+  "0x476310E34D2810f7d79C43A74E4D79405bd7a925": "1500000000000000000", // sVUSD
+  "0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e": "0", // sVetBTC, no position
 }
 ```
 

--- a/api/README.md
+++ b/api/README.md
@@ -97,7 +97,7 @@ Gets the amount of collateral assets in a given Morpho market.
 
 ### `GET /variable-stake/average-purchase-price/:address`
 
-Returns the user's average purchase price (in the vault asset's smallest unit, 18 decimals) for each known Vetro staking vault. Vaults where the user has no position return `"0"`.
+Returns the user's average purchase price (in the vault asset's native smallest unit; decimal precision depends on the underlying vault asset) for each known Vetro staking vault. Vaults where the user has no position return `"0"`.
 `:address` must be a well-formed Ethereum address. Returns `404` if malformed.
 
 #### Sample Response

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -22,8 +22,9 @@ const secsPerDay = 86400;
 /**
  * Query the subgraph for the user's staking positions across all known vaults
  * and compute the average purchase price (totalCostBasis / shares) for each.
- * Returns an object keyed by vault address with the price as a bigint in asset
- * units (18 decimals). Defaults to 0n when the user has no position or zero
+ * Returns an object keyed by vault address with the price as a bigint in the
+ * underlying vault asset's native smallest unit (decimal precision depends on
+ * the underlying asset). Defaults to 0n when the user has no position or zero
  * shares.
  */
 export async function getAveragePurchasePrice({


### PR DESCRIPTION
### Description

Follow-up to #375 — that PR added the `/variable-stake/average-purchase-price/:address` endpoint but did not include a section in `api/README.md`. This PR documents that endpoint, takes the opportunity to align the two `/borrow/:marketId/*` sections with the wording used elsewhere (explicit `400`/`404` validation behavior), and adds a project-level rule in `CLAUDE.md` so future API changes always trigger a README review.

**Commits:**

- 1819c5d Sync api/README endpoints with source code
- bb5d432 Add API project doc-sync rule to CLAUDE.md

### Screenshots

N/A

### Related issue(s)

Related to #375

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.