### PR TITLE
Replace simple-linear-regression with internal package

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -12,9 +12,9 @@
   "dependencies": {
     "@vetro-protocol/earn": "workspace:*",
     "@vetro-protocol/gateway": "workspace:*",
+    "@vetro-protocol/linear-least-squares-regression": "workspace:*",
     "@vetro-protocol/treasury": "workspace:*",
     "hono": "4.11.9",
-    "simple-linear-regression": "1.0.3",
     "tiny-fetch-json": "2.0.1",
     "tiny-post-json": "1.0.0",
     "viem": "2.44.4",

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -1,7 +1,6 @@
 import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { getPeggedToken } from "@vetro-protocol/gateway/actions";
-// @ts-expect-error Type declarations are not available for this dependency.
-import linearRegression from "simple-linear-regression";
+import { linearRegression } from "@vetro-protocol/linear-least-squares-regression";
 import {
   type Address,
   createPublicClient,
@@ -148,7 +147,7 @@ export async function getApy({ url }: { url: string }) {
       const values = histories.map((h) =>
         parseBigIntStringToNumber(h.shareValue, 18),
       );
-      const delta = linearRegression(days, values).a;
+      const delta = linearRegression({ x: days, y: values }).a;
       if (Number.isNaN(delta)) {
         return [vaultAddress, { "7d": 0 }];
       }

--- a/packages/linear-least-squares-regression/package.json
+++ b/packages/linear-least-squares-regression/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@vetro-protocol/linear-least-squares-regression",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@tsconfig/node24": "24.0.4",
+    "@vitest/coverage-v8": "4.0.18",
+    "typescript": "5.9.3",
+    "vitest": "4.0.18"
+  },
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/packages/linear-least-squares-regression/src/correlation-coefficient.ts
+++ b/packages/linear-least-squares-regression/src/correlation-coefficient.ts
@@ -1,0 +1,25 @@
+export function correlationCoefficient({
+  x,
+  y,
+}: {
+  x: number[];
+  y: number[];
+}): number {
+  const n = x.length;
+  let sumX = 0;
+  let sumXX = 0;
+  let sumXY = 0;
+  let sumY = 0;
+  let sumYY = 0;
+  for (let i = 0; i < n; i++) {
+    sumX += x[i];
+    sumXX += x[i] * x[i];
+    sumXY += x[i] * y[i];
+    sumY += y[i];
+    sumYY += y[i] * y[i];
+  }
+  return (
+    (n * sumXY - sumX * sumY) /
+    Math.sqrt((n * sumXX - sumX * sumX) * (n * sumYY - sumY * sumY))
+  );
+}

--- a/packages/linear-least-squares-regression/src/index.ts
+++ b/packages/linear-least-squares-regression/src/index.ts
@@ -1,0 +1,1 @@
+export { linearRegression } from "./linear-regression.js";

--- a/packages/linear-least-squares-regression/src/linear-regression.ts
+++ b/packages/linear-least-squares-regression/src/linear-regression.ts
@@ -1,0 +1,15 @@
+import { correlationCoefficient } from "./correlation-coefficient.js";
+import { mean } from "./mean.js";
+import { standardDeviation } from "./standard-deviation.js";
+
+// Reimplementation of simple-linear-regression@1.0.3.
+// Reference: https://github.com/diversen/simple-linear-regression/blob/283f1d67aeb2fcf38d69a35fb37f466147e8fedc/index.js
+export function linearRegression({ x, y }: { x: number[]; y: number[] }): {
+  a: number;
+  b: number;
+} {
+  const r = correlationCoefficient({ x, y });
+  const a = r * (standardDeviation(y) / standardDeviation(x));
+  const b = mean(y) - mean(x) * a;
+  return { a, b };
+}

--- a/packages/linear-least-squares-regression/src/linear-regression.ts
+++ b/packages/linear-least-squares-regression/src/linear-regression.ts
@@ -8,6 +8,16 @@ export function linearRegression({ x, y }: { x: number[]; y: number[] }): {
   a: number;
   b: number;
 } {
+  if (x.length !== y.length) {
+    throw new Error(
+      "Cannot compute linear regression: x and y must have the same length",
+    );
+  }
+  if (x.length < 2) {
+    throw new Error(
+      "Cannot compute linear regression: at least 2 data points are required",
+    );
+  }
   const r = correlationCoefficient({ x, y });
   const a = r * (standardDeviation(y) / standardDeviation(x));
   const b = mean(y) - mean(x) * a;

--- a/packages/linear-least-squares-regression/src/mean.ts
+++ b/packages/linear-least-squares-regression/src/mean.ts
@@ -1,0 +1,6 @@
+export function mean(dataset: number[]) {
+  if (dataset.length === 0) {
+    throw new Error("Cannot compute mean of an empty dataset");
+  }
+  return dataset.reduce((sum, value) => sum + value, 0) / dataset.length;
+}

--- a/packages/linear-least-squares-regression/src/population-standard-deviation.ts
+++ b/packages/linear-least-squares-regression/src/population-standard-deviation.ts
@@ -1,0 +1,10 @@
+import { mean } from "./mean.js";
+
+export function populationStandardDeviation(dataset: number[]): number {
+  const m = mean(dataset);
+  const sumSquaredDeviations = dataset.reduce(
+    (acc, value) => acc + (value - m) ** 2,
+    0,
+  );
+  return Math.sqrt(sumSquaredDeviations / dataset.length);
+}

--- a/packages/linear-least-squares-regression/src/standard-deviation.ts
+++ b/packages/linear-least-squares-regression/src/standard-deviation.ts
@@ -1,0 +1,10 @@
+import { mean } from "./mean.js";
+
+export function standardDeviation(dataset: number[]): number {
+  const m = mean(dataset);
+  const sumSquaredDeviations = dataset.reduce(
+    (acc, value) => acc + (value - m) ** 2,
+    0,
+  );
+  return Math.sqrt(sumSquaredDeviations / (dataset.length - 1));
+}

--- a/packages/linear-least-squares-regression/test/correlation-coefficient.test.ts
+++ b/packages/linear-least-squares-regression/test/correlation-coefficient.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { correlationCoefficient } from "../src/correlation-coefficient.js";
+
+describe("correlationCoefficient", function () {
+  it("returns 1 for a perfectly positive linear relationship", function () {
+    expect(
+      correlationCoefficient({ x: [1, 2, 3, 4, 5], y: [2, 4, 6, 8, 10] }),
+    ).toBeCloseTo(1, 15);
+  });
+
+  it("returns -1 for a perfectly negative linear relationship", function () {
+    expect(
+      correlationCoefficient({ x: [1, 2, 3, 4, 5], y: [10, 8, 6, 4, 2] }),
+    ).toBeCloseTo(-1, 15);
+  });
+
+  it("returns the expected Pearson r for a hand-computed example", function () {
+    // n=5, ΣX=15, ΣY=20, ΣXY=66, ΣX²=55, ΣY²=86
+    // r = (5·66 - 15·20) / sqrt((5·55 - 225)(5·86 - 400))
+    //   = 30 / sqrt(50·30) = 30 / sqrt(1500)
+    expect(
+      correlationCoefficient({ x: [1, 2, 3, 4, 5], y: [2, 4, 5, 4, 5] }),
+    ).toBeCloseTo(30 / Math.sqrt(1500), 15);
+  });
+
+  it("returns NaN when one variable has zero variance", function () {
+    expect(
+      correlationCoefficient({ x: [1, 2, 3, 4, 5], y: [5, 5, 5, 5, 5] }),
+    ).toBeNaN();
+  });
+});

--- a/packages/linear-least-squares-regression/test/linear-regression.test.ts
+++ b/packages/linear-least-squares-regression/test/linear-regression.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { linearRegression } from "../src/linear-regression.js";
+
+describe("linearRegression", function () {
+  it("recovers the slope and intercept of a perfect line", function () {
+    // y = 2x + 1
+    const result = linearRegression({
+      x: [0, 1, 2, 3, 4, 5, 6],
+      y: [1, 3, 5, 7, 9, 11, 13],
+    });
+    expect(result.a).toBeCloseTo(2, 15);
+    expect(result.b).toBeCloseTo(1, 15);
+  });
+
+  it("returns the expected slope for a non-perfect dataset", function () {
+    // Hand-computed: cov(x, y) / var(x) = 1.5 / 2.5 = 0.6
+    // intercept = mean(y) - mean(x) * slope = 4 - 3 * 0.6 = 2.2
+    const result = linearRegression({
+      x: [1, 2, 3, 4, 5],
+      y: [2, 4, 5, 4, 5],
+    });
+    expect(result.a).toBeCloseTo(0.6, 15);
+    expect(result.b).toBeCloseTo(2.2, 15);
+  });
+
+  it("recovers a negative slope", function () {
+    // y = -x + 10
+    const result = linearRegression({
+      x: [0, 1, 2, 3, 4],
+      y: [10, 9, 8, 7, 6],
+    });
+    expect(result.a).toBeCloseTo(-1, 15);
+    expect(result.b).toBeCloseTo(10, 15);
+  });
+
+  // The next three tests mirror the upstream simple-linear-regression@1.0.3
+  // README examples. They lock the package's behavior to what callers were
+  // getting from the old dependency.
+
+  it("matches the Khan Academy regression line example", function () {
+    // https://www.khanacademy.org/math/statistics-probability/describing-relationships-quantitative-data/modal/v/calculating-the-equation-of-a-regression-line
+    const result = linearRegression({
+      x: [1, 2, 2, 3],
+      y: [1, 2, 3, 6],
+    });
+    expect(result.a).toBeCloseTo(2.5, 12);
+    expect(result.b).toBeCloseTo(-2, 12);
+  });
+
+  it("matches the Wikipedia simple linear regression numerical example", function () {
+    // https://en.wikipedia.org/wiki/Simple_linear_regression#Numerical_example
+    const result = linearRegression({
+      x: [
+        1.47, 1.5, 1.52, 1.55, 1.57, 1.6, 1.63, 1.65, 1.68, 1.7, 1.73, 1.75,
+        1.78, 1.8, 1.83,
+      ],
+      y: [
+        52.21, 53.12, 54.48, 55.84, 57.2, 58.57, 59.93, 61.29, 63.11, 64.47,
+        66.28, 68.1, 69.92, 72.19, 74.46,
+      ],
+    });
+    expect(result.a).toBeCloseTo(61.27218654211061, 10);
+    expect(result.b).toBeCloseTo(-39.06195591884391, 10);
+  });
+
+  it("matches the Wikipedia linear least squares example", function () {
+    // https://en.wikipedia.org/wiki/Linear_least_squares_(mathematics)
+    const result = linearRegression({
+      x: [1, 2, 3, 4],
+      y: [6, 5, 7, 10],
+    });
+    expect(result.a).toBeCloseTo(1.4, 12);
+    expect(result.b).toBeCloseTo(3.5, 12);
+  });
+
+  it("returns NaN slope when x has zero variance", function () {
+    const result = linearRegression({
+      x: [3, 3, 3, 3],
+      y: [1, 2, 3, 4],
+    });
+    expect(result.a).toBeNaN();
+  });
+});

--- a/packages/linear-least-squares-regression/test/linear-regression.test.ts
+++ b/packages/linear-least-squares-regression/test/linear-regression.test.ts
@@ -81,4 +81,19 @@ describe("linearRegression", function () {
     });
     expect(result.a).toBeNaN();
   });
+
+  it("throws when x and y have different lengths", function () {
+    expect(() => linearRegression({ x: [1, 2, 3], y: [1, 2] })).toThrow(
+      "Cannot compute linear regression: x and y must have the same length",
+    );
+  });
+
+  it("throws when fewer than 2 data points are provided", function () {
+    expect(() => linearRegression({ x: [1], y: [2] })).toThrow(
+      "Cannot compute linear regression: at least 2 data points are required",
+    );
+    expect(() => linearRegression({ x: [], y: [] })).toThrow(
+      "Cannot compute linear regression: at least 2 data points are required",
+    );
+  });
 });

--- a/packages/linear-least-squares-regression/test/mean.test.ts
+++ b/packages/linear-least-squares-regression/test/mean.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { mean } from "../src/mean.js";
+
+describe("mean", function () {
+  it("returns the arithmetic mean of the dataset", function () {
+    expect(mean([1, 2, 3, 4, 5])).toBe(3);
+  });
+
+  it("handles negative values", function () {
+    expect(mean([-2, -1, 0, 1, 2])).toBe(0);
+  });
+
+  it("handles a single-element dataset", function () {
+    expect(mean([42])).toBe(42);
+  });
+
+  it("throws when the dataset is empty", function () {
+    expect(() => mean([])).toThrow("Cannot compute mean of an empty dataset");
+  });
+});

--- a/packages/linear-least-squares-regression/test/population-standard-deviation.test.ts
+++ b/packages/linear-least-squares-regression/test/population-standard-deviation.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { populationStandardDeviation } from "../src/population-standard-deviation.js";
+
+describe("populationStandardDeviation", function () {
+  it("returns the population standard deviation (divides by n)", function () {
+    expect(populationStandardDeviation([1, 2, 3, 4, 5])).toBeCloseTo(
+      Math.sqrt(2),
+      15,
+    );
+  });
+
+  it("returns 0 for a constant dataset", function () {
+    expect(populationStandardDeviation([5, 5, 5, 5])).toBe(0);
+  });
+});

--- a/packages/linear-least-squares-regression/test/standard-deviation.test.ts
+++ b/packages/linear-least-squares-regression/test/standard-deviation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { standardDeviation } from "../src/standard-deviation.js";
+
+describe("standardDeviation", function () {
+  it("returns the sample standard deviation (divides by n - 1)", function () {
+    expect(standardDeviation([1, 2, 3, 4, 5])).toBeCloseTo(Math.sqrt(2.5), 15);
+  });
+
+  it("returns 0 for a constant dataset", function () {
+    expect(standardDeviation([5, 5, 5, 5])).toBe(0);
+  });
+
+  it("returns NaN for a single-element dataset (division by zero)", function () {
+    expect(standardDeviation([42])).toBeNaN();
+  });
+});

--- a/packages/linear-least-squares-regression/tsconfig.json
+++ b/packages/linear-least-squares-regression/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "erasableSyntaxOnly": true,
+    "noEmit": true
+  },
+  "exclude": ["node_modules", "test/*"],
+  "extends": "@tsconfig/node24/tsconfig.json",
+  "include": ["**/*.ts"]
+}

--- a/packages/linear-least-squares-regression/vitest.config.ts
+++ b/packages/linear-least-squares-regression/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    clearMocks: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,15 +55,15 @@ importers:
       '@vetro-protocol/gateway':
         specifier: workspace:*
         version: link:../packages/gateway
+      '@vetro-protocol/linear-least-squares-regression':
+        specifier: workspace:*
+        version: link:../packages/linear-least-squares-regression
       '@vetro-protocol/treasury':
         specifier: workspace:*
         version: link:../packages/treasury
       hono:
         specifier: 4.11.9
         version: 4.11.9
-      simple-linear-regression:
-        specifier: 1.0.3
-        version: 1.0.3
       tiny-fetch-json:
         specifier: 2.0.1
         version: 2.0.1
@@ -160,6 +160,21 @@ importers:
       viem:
         specifier: 2.44.4
         version: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      vitest:
+        specifier: 4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+
+  packages/linear-least-squares-regression:
+    devDependencies:
+      '@tsconfig/node24':
+        specifier: 24.0.4
+        version: 24.0.4
+      '@vitest/coverage-v8':
+        specifier: 4.0.18
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
       vitest:
         specifier: 4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
@@ -4048,9 +4063,6 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  correlation-coefficient-r@1.0.0:
-    resolution: {integrity: sha512-q6nDV0KlQ/RPqncRYbG+2DW9eiARrA6SXlkq6sLluPRcBcugLqiTO+DyDeXW/gdmNrnwBic1sfptsJiG8DxQaQ==}
-
   cosmiconfig-typescript-loader@6.2.0:
     resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
     engines: {node: '>=v18'}
@@ -5992,9 +6004,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  math-standard-deviation@1.0.1:
-    resolution: {integrity: sha512-t9fugSSrlz6VVYg5EJDeqNkNjaNIBFWrGEdykkoT3iOfXn1t6Y63j6YVwFQAbyT9rJQf7royquyY/Rz/Od9SyA==}
-
   md5.js@1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
 
@@ -7104,9 +7113,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  simple-linear-regression@1.0.3:
-    resolution: {integrity: sha512-sEfJPNevHaHSSVhjTaJNsUPyUNVqNfRqY6pv4qlUKZ5mgXVbiKTFLCbGiy9wjbEYhvFmWI06ALcCP/LrEkQUpw==}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -12885,10 +12891,6 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  correlation-coefficient-r@1.0.0:
-    dependencies:
-      math-standard-deviation: 1.0.1
-
   cosmiconfig-typescript-loader@6.2.0(@types/node@25.0.9)(cosmiconfig@9.0.0(typescript@6.0.2))(typescript@6.0.2):
     dependencies:
       '@types/node': 25.0.9
@@ -13640,13 +13642,14 @@ snapshots:
       esquery: 1.7.0
       jsonc-eslint-parser: 2.4.2
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.1(eslint@8.57.0)(typescript@6.0.2)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@6.0.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13667,7 +13670,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15152,8 +15155,6 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  math-standard-deviation@1.0.1: {}
-
   md5.js@1.3.5:
     dependencies:
       hash-base: 3.0.5
@@ -16334,11 +16335,6 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
-
-  simple-linear-regression@1.0.3:
-    dependencies:
-      correlation-coefficient-r: 1.0.0
-      math-standard-deviation: 1.0.1
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
### Description

Replaces the unmaintained `simple-linear-regression@1.0.3` (and its transitive deps `correlation-coefficient-r` and `math-standard-deviation`, all by the same unmaintained author) with an internal `@vetro-protocol/linear-least-squares-regression` workspace package.

The new package consolidates the three upstream packages into one: `linearRegression` is the only public entry point, with `mean`, `standardDeviation`, `populationStandardDeviation`, and `correlationCoefficient` kept package-internal. Zero runtime deps, full TypeScript types — which also lets us drop the `@ts-expect-error` on the import in `api/src/variable-stake.ts`.

Tests include the upstream README examples (Khan Academy + two from Wikipedia) so behavior stays locked to what callers were getting from the old package.

**Note on the package scope:** I prepended `@vetro-protocol/` to the package name for consistency with the other workspace packages. If we ever publish this externally we can drop or repoint the scope without affecting the API.

**Local-only parity check (not committed):** during development I A/B-tested the new `linearRegression` against the upstream package across 50 randomized seeded datasets. The upstream sources were vendored verbatim into the test (so we didn't have to add `simple-linear-regression` back to the workspace), and all 50 seeds matched to ≥10 decimal places. The file is not committed; pasted below for the record.

<details>
<summary><code>packages/linear-least-squares-regression/test/parity.test.ts</code> (local-only, not committed)</summary>

```ts
// Throwaway parity check vs simple-linear-regression@1.0.3.
// Drop this file once we trust the internal implementation.
//
// We A/B-test our linearRegression against the upstream package on 50 random
// datasets. To avoid adding the upstream to the workspace, the upstream code
// (plus its transitive deps `correlation-coefficient-r` and
// `math-standard-deviation`) is vendored verbatim below.
//
// Sources:
//   https://github.com/diversen/simple-linear-regression/blob/283f1d67aeb2fcf38d69a35fb37f466147e8fedc/index.js
//   https://github.com/diversen/correlation-coefficient-r/blob/master/index.js
//   https://github.com/diversen/math-standard-deviation/blob/master/index.js

import { describe, expect, it } from "vitest";

import { linearRegression } from "../src/linear-regression.js";

function upstreamMean(dataset: number[]) {
  const sum = dataset.reduce((a, b) => a + b, 0);
  return sum / dataset.length;
}

function upstreamDeviation(dataset: number[], unbiased: boolean) {
  const m = upstreamMean(dataset);
  let total = 0;
  dataset.forEach(function (val) {
    total += Math.pow(val - m, 2);
  });
  const n = unbiased ? dataset.length - 1 : dataset.length;
  return Math.sqrt(total / n);
}

const upstreamStandardDeviation = (dataset: number[]) => upstreamDeviation(dataset, true);

function upstreamCorrelationCoefficient(x: number[], y: number[]) {
  const xMean = upstreamMean(x);
  const yMean = upstreamMean(y);
  const xDeviation = upstreamStandardDeviation(x);
  const yDeviation = upstreamStandardDeviation(y);
  let sum = 0;
  for (let i = 0; i < x.length; i++) {
    sum += ((x[i] - xMean) / xDeviation) * ((y[i] - yMean) / yDeviation);
  }
  return sum / (x.length - 1);
}

function upstreamLinearRegression(x: number[], y: number[]) {
  const xMean = upstreamMean(x);
  const yMean = upstreamMean(y);
  const xDeviation = upstreamStandardDeviation(x);
  const yDeviation = upstreamStandardDeviation(y);
  const slope = yDeviation / xDeviation;
  const a = upstreamCorrelationCoefficient(x, y) * slope;
  const b = yMean - xMean * a;
  return { a, b };
}

// Seeded PRNG so a failing seed reproduces deterministically.
const mulberry32 = (seed: number) => function () {
    seed = (seed + 0x6d2b79f5) | 0;
    let t = seed;
    t = Math.imul(t ^ (t >>> 15), t | 1);
    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
  };

function generateDataset(rng: () => number) {
  while (true) {
    const n = 2 + Math.floor(rng() * 29);
    const x: number[] = [];
    const y: number[] = [];
    for (let i = 0; i < n; i++) {
      x.push((rng() - 0.5) * 200);
      y.push((rng() - 0.5) * 200);
    }
    if (new Set(x).size > 1 && new Set(y).size > 1) {
      return { x, y };
    }
  }
}

const seeds = Array.from({ length: 50 }, (_, i) => i + 1);

describe("linearRegression parity with simple-linear-regression@1.0.3", function () {
  it.each(seeds)(
    "matches upstream output for random seed %d",
    function (seed) {
      const rng = mulberry32(seed);
      const { x, y } = generateDataset(rng);
      const ours = linearRegression({ x, y });
      const theirs = upstreamLinearRegression(x, y);
      expect(ours.a).toBeCloseTo(theirs.a, 10);
      expect(ours.b).toBeCloseTo(theirs.b, 10);
    },
  );
});
```

</details>

### Screenshots

N/A — no UI changes.

### Related issue(s)

Closes #372

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.