### PR TITLE
Compute earned amount as unrealized P&L

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -95,9 +95,9 @@ Gets the amount of collateral assets in a given Morpho market.
 }
 ```
 
-### `GET /variable-stake/average-purchase-price/:address`
+### `GET /variable-stake/cost-basis/:address`
 
-Returns the user's average purchase price (in the vault asset's native smallest unit; decimal precision depends on the underlying vault asset) for each known Vetro staking vault. Vaults where the user has no position return `"0"`.
+Returns the user's cost basis (in the vault asset's native smallest unit; decimal precision depends on the underlying vault asset) for each known Vetro staking vault. Vaults where the user has no position return `"0"`.
 `:address` must be a well-formed Ethereum address. Returns `404` if malformed.
 
 #### Sample Response

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -143,7 +143,7 @@ app.get(
 );
 
 app.get(
-  "/variable-stake/average-purchase-price/:address",
+  "/variable-stake/cost-basis/:address",
   validateAddress,
   cache({
     cacheControl: "max-age=300",
@@ -153,13 +153,13 @@ app.get(
     try {
       const address = c.req.param("address") as `0x${string}`;
       const url = getSubgraphUrl(c.env);
-      const data = await variableStake.getAveragePurchasePrice({
+      const data = await variableStake.getCostBasis({
         address,
         url,
       });
       return c.json(convertBigIntsToString(data));
     } catch (error) {
-      throw new Error(`Failed to get average purchase price: ${error.message}`);
+      throw new Error(`Failed to get cost basis: ${error.message}`);
     }
   },
 );

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -17,6 +17,7 @@ import parseBigIntStringToNumber from "./parse-bigint-string-to-number.ts";
 import { findStakingVaultForPeggedToken } from "./staking-vault.ts";
 
 const secsPerDay = 86400;
+const WAD = 10n ** 18n;
 
 type VaultHistoryRow = {
   shareValue: string;
@@ -27,13 +28,12 @@ type VaultHistoriesResponse = { vaultHistories: VaultHistoryRow[] };
 
 /**
  * Query the subgraph for the user's staking positions across all known vaults
- * and compute the average purchase price (totalCostBasis / shares) for each.
- * Returns an object keyed by vault address with the price as a bigint in the
- * underlying vault asset's native smallest unit (decimal precision depends on
- * the underlying asset). Defaults to 0n when the user has no position or zero
- * shares.
+ * and return the cost basis (in pegged-token asset units) for each. The
+ * subgraph stores `totalCostBasis` as a WAD-scaled sum of deposits, so this
+ * scales it back down to asset units. Defaults to 0n when the user has no
+ * position for a vault.
  */
-export async function getAveragePurchasePrice({
+export async function getCostBasis({
   address,
   url,
 }: {
@@ -45,7 +45,6 @@ export async function getAveragePurchasePrice({
       userStakingPositions(
         where: { owner: $owner, stakingVaultAddress_in: $vaults }
       ) {
-        shares
         stakingVaultAddress
         totalCostBasis
       }
@@ -56,7 +55,6 @@ export async function getAveragePurchasePrice({
   };
   const { userStakingPositions } = await graphql.runQuery<{
     userStakingPositions: {
-      shares: string;
       stakingVaultAddress: `0x${string}`;
       totalCostBasis: string;
     }[];
@@ -71,13 +69,9 @@ export async function getAveragePurchasePrice({
     stakingVaultAddresses.map((vault) => [vault, 0n]),
   );
   for (const position of userStakingPositions) {
-    const shares = BigInt(position.shares);
-    if (shares === 0n) {
-      continue;
-    }
     const totalCostBasis = BigInt(position.totalCostBasis);
-    const averagePrice = totalCostBasis / shares;
-    result[checksumAddress(position.stakingVaultAddress)] = averagePrice;
+    result[checksumAddress(position.stakingVaultAddress)] =
+      totalCostBasis / WAD;
   }
   return result;
 }

--- a/api/test/variable-stake.test.ts
+++ b/api/test/variable-stake.test.ts
@@ -7,11 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import * as graphql from "../src/graphql.ts";
 import * as merkl from "../src/merkl.ts";
-import {
-  getApy,
-  getAveragePurchasePrice,
-  getUserRewards,
-} from "../src/variable-stake.ts";
+import { getApy, getCostBasis, getUserRewards } from "../src/variable-stake.ts";
 
 vi.mock("../src/graphql.ts", () => ({
   runQuery: vi.fn(),
@@ -303,7 +299,7 @@ describe("variable-stake/getUserRewards", function () {
   });
 });
 
-describe("variable-stake/getAveragePurchasePrice", function () {
+describe("variable-stake/getCostBasis", function () {
   const userAddress = "0x0000000000000000000000000000000000000001";
   const subgraphUrl = "https://subgraph.test";
 
@@ -312,7 +308,7 @@ describe("variable-stake/getAveragePurchasePrice", function () {
       userStakingPositions: [],
     });
 
-    const result = await getAveragePurchasePrice({
+    const result = await getCostBasis({
       address: userAddress,
       url: subgraphUrl,
     });
@@ -322,18 +318,17 @@ describe("variable-stake/getAveragePurchasePrice", function () {
     );
   });
 
-  it("returns '0' when shares is 0 (fully exited position)", async function () {
+  it("returns '0' when totalCostBasis is 0 (fully exited position)", async function () {
     vi.mocked(graphql.runQuery).mockResolvedValue({
       userStakingPositions: [
         {
-          shares: "0",
           stakingVaultAddress: sVusdAddress.toLowerCase(),
           totalCostBasis: "0",
         },
       ],
     });
 
-    const result = await getAveragePurchasePrice({
+    const result = await getCostBasis({
       address: userAddress,
       url: subgraphUrl,
     });
@@ -341,56 +336,51 @@ describe("variable-stake/getAveragePurchasePrice", function () {
     expect(result[sVusdAddress]).toBe(0n);
   });
 
-  it("computes totalCostBasis / shares for a position", async function () {
-    // totalCostBasis is WAD-scaled (36 decimals), shares has 18 decimals.
-    // 2 shares at 1.5 asset-units each: totalCostBasis = 3e36, shares = 2e18
-    // result = 3e36 / 2e18 = 1.5e18
-    const shares = (2n * 10n ** 18n).toString();
+  it("scales totalCostBasis back to asset units", async function () {
+    // totalCostBasis is WAD-scaled (36 decimals when the asset has 18).
+    // 3e36 / 1e18 = 3e18 asset units.
     const totalCostBasis = (3n * 10n ** 36n).toString();
 
     vi.mocked(graphql.runQuery).mockResolvedValue({
       userStakingPositions: [
         {
-          shares,
           stakingVaultAddress: sVusdAddress.toLowerCase(),
           totalCostBasis,
         },
       ],
     });
 
-    const result = await getAveragePurchasePrice({
+    const result = await getCostBasis({
       address: userAddress,
       url: subgraphUrl,
     });
 
-    expect(result[sVusdAddress]).toBe(15n * 10n ** 17n);
+    expect(result[sVusdAddress]).toBe(3n * 10n ** 18n);
     expect(result[sVetBtcAddress]).toBe(0n);
   });
 
-  it("returns prices for multiple vaults", async function () {
+  it("returns cost basis for multiple vaults", async function () {
     vi.mocked(graphql.runQuery).mockResolvedValue({
       userStakingPositions: [
         {
-          shares: (10n ** 18n).toString(),
           stakingVaultAddress: sVusdAddress.toLowerCase(),
           totalCostBasis: (10n ** 36n).toString(),
         },
         {
-          shares: (4n * 10n ** 18n).toString(),
           stakingVaultAddress: sVetBtcAddress.toLowerCase(),
           totalCostBasis: (8n * 10n ** 36n).toString(),
         },
       ],
     });
 
-    const result = await getAveragePurchasePrice({
+    const result = await getCostBasis({
       address: userAddress,
       url: subgraphUrl,
     });
 
     // 1e36 / 1e18 = 1e18
     expect(result[sVusdAddress]).toBe(10n ** 18n);
-    // 8e36 / 4e18 = 2e18
-    expect(result[sVetBtcAddress]).toBe(2n * 10n ** 18n);
+    // 8e36 / 1e18 = 8e18
+    expect(result[sVetBtcAddress]).toBe(8n * 10n ** 18n);
   });
 });

--- a/web/src/fetchers/fetchEarnedAmountUsd.ts
+++ b/web/src/fetchers/fetchEarnedAmountUsd.ts
@@ -1,0 +1,83 @@
+import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
+import type { QueryClient } from "@tanstack/react-query";
+import { averagePurchasePriceQueryOptions } from "hooks/useAveragePurchasePrice";
+import { pricesOptions } from "hooks/usePrices";
+import { stakedBalanceQueryOptions } from "hooks/useStakedBalance";
+import { vaultPeggedTokenQueryOptions } from "hooks/useVaultPeggedToken";
+import { tokenAmountToUsd } from "utils/currency";
+import type { Address, Client } from "viem";
+
+const WAD = 10n ** 18n;
+
+export const fetchEarnedAmountUsd = async function ({
+  account,
+  client,
+  queryClient,
+  stakingVaultAddresses,
+}: {
+  account: Address;
+  client: Client;
+  queryClient: QueryClient;
+  stakingVaultAddresses: readonly Address[];
+}): Promise<number> {
+  const chainId = client.chain?.id;
+  if (chainId === undefined) {
+    throw new Error("Client is missing a chain");
+  }
+
+  const [prices, averagePurchasePrices] = await Promise.all([
+    queryClient.ensureQueryData(pricesOptions({ client, queryClient })),
+    queryClient.ensureQueryData(
+      averagePurchasePriceQueryOptions({ address: account }),
+    ),
+  ]);
+
+  const perVaultUsd = await Promise.all(
+    stakingVaultAddresses.map(async function (stakingVaultAddress) {
+      const [peggedToken, userStakedAssets, userShares] = await Promise.all([
+        queryClient.ensureQueryData(
+          vaultPeggedTokenQueryOptions({
+            client,
+            queryClient,
+            stakingVaultAddress,
+          }),
+        ),
+        queryClient.ensureQueryData(
+          stakedBalanceQueryOptions({
+            account,
+            chainId,
+            client,
+            queryClient,
+            stakingVaultAddress,
+          }),
+        ),
+        queryClient.ensureQueryData(
+          tokenBalanceQueryOptions({
+            account,
+            client,
+            token: { address: stakingVaultAddress, chainId },
+          }),
+        ),
+      ]);
+
+      if (userShares === 0n) {
+        return 0;
+      }
+
+      const averagePrice = averagePurchasePrices[stakingVaultAddress] ?? 0n;
+      if (averagePrice === 0n) {
+        return 0;
+      }
+
+      const costBasisAssets = (userShares * averagePrice) / WAD;
+      const earnedAssets = userStakedAssets - costBasisAssets;
+      return tokenAmountToUsd({
+        amount: earnedAssets,
+        prices,
+        token: peggedToken,
+      });
+    }),
+  );
+
+  return perVaultUsd.reduce((sum, value) => sum + value, 0);
+};

--- a/web/src/fetchers/fetchEarnedAmountUsd.ts
+++ b/web/src/fetchers/fetchEarnedAmountUsd.ts
@@ -1,13 +1,11 @@
 import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
 import type { QueryClient } from "@tanstack/react-query";
-import { averagePurchasePriceQueryOptions } from "hooks/useAveragePurchasePrice";
+import { costBasisQueryOptions } from "hooks/useCostBasis";
 import { pricesOptions } from "hooks/usePrices";
 import { stakedBalanceQueryOptions } from "hooks/useStakedBalance";
 import { vaultPeggedTokenQueryOptions } from "hooks/useVaultPeggedToken";
 import { tokenAmountToUsd } from "utils/currency";
 import type { Address, Client } from "viem";
-
-const WAD = 10n ** 18n;
 
 export const fetchEarnedAmountUsd = async function ({
   account,
@@ -25,11 +23,9 @@ export const fetchEarnedAmountUsd = async function ({
     throw new Error("Client is missing a chain");
   }
 
-  const [prices, averagePurchasePrices] = await Promise.all([
+  const [prices, costBases] = await Promise.all([
     queryClient.ensureQueryData(pricesOptions({ client, queryClient })),
-    queryClient.ensureQueryData(
-      averagePurchasePriceQueryOptions({ address: account }),
-    ),
+    queryClient.ensureQueryData(costBasisQueryOptions({ address: account })),
   ]);
 
   const perVaultUsd = await Promise.all(
@@ -64,13 +60,12 @@ export const fetchEarnedAmountUsd = async function ({
         return 0;
       }
 
-      const averagePrice = averagePurchasePrices[stakingVaultAddress] ?? 0n;
-      if (averagePrice === 0n) {
+      const costBasis = costBases[stakingVaultAddress] ?? 0n;
+      if (costBasis === 0n) {
         return 0;
       }
 
-      const costBasisAssets = (userShares * averagePrice) / WAD;
-      const earnedAssets = userStakedAssets - costBasisAssets;
+      const earnedAssets = userStakedAssets - costBasis;
       return tokenAmountToUsd({
         amount: earnedAssets,
         prices,

--- a/web/src/hooks/useAveragePurchasePrice.ts
+++ b/web/src/hooks/useAveragePurchasePrice.ts
@@ -1,0 +1,32 @@
+import { queryOptions } from "@tanstack/react-query";
+import fetch from "fetch-plus-plus";
+import { isValidUrl } from "utils/url";
+import type { Address } from "viem";
+
+const apiUrl = import.meta.env.VITE_VETRO_API_URL;
+
+export const averagePurchasePriceQueryKey = (address: Address | undefined) => [
+  "average-purchase-price",
+  address,
+];
+
+export const averagePurchasePriceQueryOptions = ({
+  address,
+}: {
+  address: Address | undefined;
+}) =>
+  queryOptions({
+    enabled:
+      apiUrl !== undefined && isValidUrl(apiUrl) && address !== undefined,
+    async queryFn() {
+      const data = (await fetch(
+        `${apiUrl}/variable-stake/average-purchase-price/${address}`,
+      )) as Record<Address, string>;
+      return Object.fromEntries(
+        Object.entries(data).map(
+          ([vault, price]) => [vault as Address, BigInt(price)] as const,
+        ),
+      ) as Record<Address, bigint>;
+    },
+    queryKey: averagePurchasePriceQueryKey(address),
+  });

--- a/web/src/hooks/useCancelWithdraw.ts
+++ b/web/src/hooks/useCancelWithdraw.ts
@@ -11,7 +11,7 @@ import type { Address } from "viem";
 import { useAccount } from "wagmi";
 
 import { analyticsTotalsQueryKey } from "./useAnalyticsTotals";
-import { averagePurchasePriceQueryKey } from "./useAveragePurchasePrice";
+import { costBasisQueryKey } from "./useCostBasis";
 import { earnedAmountUsdQueryKey } from "./useEarnedAmountUsd";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
@@ -125,13 +125,13 @@ export const useCancelWithdraw = function ({
       });
 
       // Refetch (not just invalidate) the queries that downstream fetchers
-      // read via ensureQueryData: shares feed useStakedBalance, and avg
-      // purchase price feeds fetchEarnedAmountUsd. Neither has a mounted
-      // observer, so invalidation alone would leave them stale.
+      // read via ensureQueryData: shares feed useStakedBalance, and cost
+      // basis feeds fetchEarnedAmountUsd. Neither has a mounted observer,
+      // so invalidation alone would leave them stale.
       await Promise.all([
         queryClient.refetchQueries({ queryKey: sharesBalanceKey }),
         queryClient.refetchQueries({
-          queryKey: averagePurchasePriceQueryKey(account),
+          queryKey: costBasisQueryKey(account),
         }),
       ]);
 

--- a/web/src/hooks/useCancelWithdraw.ts
+++ b/web/src/hooks/useCancelWithdraw.ts
@@ -11,6 +11,8 @@ import type { Address } from "viem";
 import { useAccount } from "wagmi";
 
 import { analyticsTotalsQueryKey } from "./useAnalyticsTotals";
+import { averagePurchasePriceQueryKey } from "./useAveragePurchasePrice";
+import { earnedAmountUsdQueryKey } from "./useEarnedAmountUsd";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { poolDepositsQueryKey } from "./usePoolDeposits";
@@ -122,14 +124,16 @@ export const useCancelWithdraw = function ({
         queryKey: nativeBalanceKey,
       });
 
-      // Shares must be refetched before staked balance, because
-      // useStakedBalance uses ensureQueryData to read shares from cache.
-      // refetchQueries (not invalidateQueries) is required because the
-      // shares query has no mounted observer — invalidation alone would
-      // only mark it stale, and ensureQueryData returns stale cached data.
-      await queryClient.refetchQueries({
-        queryKey: sharesBalanceKey,
-      });
+      // Refetch (not just invalidate) the queries that downstream fetchers
+      // read via ensureQueryData: shares feed useStakedBalance, and avg
+      // purchase price feeds fetchEarnedAmountUsd. Neither has a mounted
+      // observer, so invalidation alone would leave them stale.
+      await Promise.all([
+        queryClient.refetchQueries({ queryKey: sharesBalanceKey }),
+        queryClient.refetchQueries({
+          queryKey: averagePurchasePriceQueryKey(account),
+        }),
+      ]);
 
       queryClient.invalidateQueries({
         queryKey: stakedKey,
@@ -137,6 +141,10 @@ export const useCancelWithdraw = function ({
 
       queryClient.invalidateQueries({
         queryKey: totalStakedUsdQueryKey({ account, chainId: chain.id }),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: earnedAmountUsdQueryKey({ account, chainId: chain.id }),
       });
 
       queryClient.invalidateQueries({

--- a/web/src/hooks/useCostBasis.ts
+++ b/web/src/hooks/useCostBasis.ts
@@ -5,12 +5,12 @@ import type { Address } from "viem";
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
 
-export const averagePurchasePriceQueryKey = (address: Address | undefined) => [
-  "average-purchase-price",
+export const costBasisQueryKey = (address: Address | undefined) => [
+  "cost-basis",
   address,
 ];
 
-export const averagePurchasePriceQueryOptions = ({
+export const costBasisQueryOptions = ({
   address,
 }: {
   address: Address | undefined;
@@ -20,13 +20,14 @@ export const averagePurchasePriceQueryOptions = ({
       apiUrl !== undefined && isValidUrl(apiUrl) && address !== undefined,
     async queryFn() {
       const data = (await fetch(
-        `${apiUrl}/variable-stake/average-purchase-price/${address}`,
+        `${apiUrl}/variable-stake/cost-basis/${address}`,
       )) as Record<Address, string>;
       return Object.fromEntries(
         Object.entries(data).map(
-          ([vault, price]) => [vault as Address, BigInt(price)] as const,
+          ([vault, costBasis]) =>
+            [vault as Address, BigInt(costBasis)] as const,
         ),
       ) as Record<Address, bigint>;
     },
-    queryKey: averagePurchasePriceQueryKey(address),
+    queryKey: costBasisQueryKey(address),
   });

--- a/web/src/hooks/useEarnedAmountUsd.ts
+++ b/web/src/hooks/useEarnedAmountUsd.ts
@@ -1,0 +1,32 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { stakingVaultAddresses } from "@vetro-protocol/earn";
+import { fetchEarnedAmountUsd } from "fetchers/fetchEarnedAmountUsd";
+import { useEthereumClient } from "hooks/useEthereumClient";
+import type { Address } from "viem";
+import { useAccount } from "wagmi";
+
+export const earnedAmountUsdQueryKey = ({
+  account,
+  chainId,
+}: {
+  account: Address | undefined;
+  chainId: number | undefined;
+}) => ["earned-amount-usd", chainId, account];
+
+export function useEarnedAmountUsd() {
+  const { address: account } = useAccount();
+  const client = useEthereumClient();
+  const queryClient = useQueryClient();
+
+  return useQuery({
+    enabled: !!client && !!account,
+    queryFn: () =>
+      fetchEarnedAmountUsd({
+        account: account!,
+        client: client!,
+        queryClient,
+        stakingVaultAddresses,
+      }),
+    queryKey: earnedAmountUsdQueryKey({ account, chainId: client?.chain?.id }),
+  });
+}

--- a/web/src/hooks/useEarnedAmountUsd.ts
+++ b/web/src/hooks/useEarnedAmountUsd.ts
@@ -2,8 +2,11 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { fetchEarnedAmountUsd } from "fetchers/fetchEarnedAmountUsd";
 import { useEthereumClient } from "hooks/useEthereumClient";
+import { isValidUrl } from "utils/url";
 import type { Address } from "viem";
 import { useAccount } from "wagmi";
+
+const apiUrl = import.meta.env.VITE_VETRO_API_URL;
 
 export const earnedAmountUsdQueryKey = ({
   account,
@@ -19,7 +22,8 @@ export function useEarnedAmountUsd() {
   const queryClient = useQueryClient();
 
   return useQuery({
-    enabled: !!client && !!account,
+    enabled:
+      apiUrl !== undefined && isValidUrl(apiUrl) && !!client && !!account,
     queryFn: () =>
       fetchEarnedAmountUsd({
         account: account!,

--- a/web/src/hooks/useInstantWithdraw.ts
+++ b/web/src/hooks/useInstantWithdraw.ts
@@ -10,7 +10,7 @@ import { withdraw } from "viem-erc4626/actions";
 import { useAccount } from "wagmi";
 
 import { analyticsTotalsQueryKey } from "./useAnalyticsTotals";
-import { averagePurchasePriceQueryKey } from "./useAveragePurchasePrice";
+import { costBasisQueryKey } from "./useCostBasis";
 import { earnedAmountUsdQueryKey } from "./useEarnedAmountUsd";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
@@ -127,13 +127,13 @@ export const useInstantWithdraw = function ({
       });
 
       // Refetch (not just invalidate) the queries that downstream fetchers
-      // read via ensureQueryData: shares feed useStakedBalance, and avg
-      // purchase price feeds fetchEarnedAmountUsd. Neither has a mounted
-      // observer, so invalidation alone would leave them stale.
+      // read via ensureQueryData: shares feed useStakedBalance, and cost
+      // basis feeds fetchEarnedAmountUsd. Neither has a mounted observer,
+      // so invalidation alone would leave them stale.
       await Promise.all([
         queryClient.refetchQueries({ queryKey: sharesBalanceKey }),
         queryClient.refetchQueries({
-          queryKey: averagePurchasePriceQueryKey(account),
+          queryKey: costBasisQueryKey(account),
         }),
       ]);
 

--- a/web/src/hooks/useInstantWithdraw.ts
+++ b/web/src/hooks/useInstantWithdraw.ts
@@ -10,6 +10,8 @@ import { withdraw } from "viem-erc4626/actions";
 import { useAccount } from "wagmi";
 
 import { analyticsTotalsQueryKey } from "./useAnalyticsTotals";
+import { averagePurchasePriceQueryKey } from "./useAveragePurchasePrice";
+import { earnedAmountUsdQueryKey } from "./useEarnedAmountUsd";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { poolDepositsQueryKey } from "./usePoolDeposits";
@@ -124,14 +126,16 @@ export const useInstantWithdraw = function ({
         queryKey: peggedTokenBalanceKey,
       });
 
-      // Shares must be refetched before staked balance, because
-      // useStakedBalance uses ensureQueryData to read shares from cache.
-      // refetchQueries (not invalidateQueries) is required because the
-      // shares query has no mounted observer — invalidation alone would
-      // only mark it stale, and ensureQueryData returns stale cached data.
-      await queryClient.refetchQueries({
-        queryKey: sharesBalanceKey,
-      });
+      // Refetch (not just invalidate) the queries that downstream fetchers
+      // read via ensureQueryData: shares feed useStakedBalance, and avg
+      // purchase price feeds fetchEarnedAmountUsd. Neither has a mounted
+      // observer, so invalidation alone would leave them stale.
+      await Promise.all([
+        queryClient.refetchQueries({ queryKey: sharesBalanceKey }),
+        queryClient.refetchQueries({
+          queryKey: averagePurchasePriceQueryKey(account),
+        }),
+      ]);
 
       queryClient.invalidateQueries({
         queryKey: stakedKey,
@@ -139,6 +143,10 @@ export const useInstantWithdraw = function ({
 
       queryClient.invalidateQueries({
         queryKey: totalStakedUsdQueryKey({ account, chainId: chain.id }),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: earnedAmountUsdQueryKey({ account, chainId: chain.id }),
       });
 
       queryClient.invalidateQueries({

--- a/web/src/hooks/useStakeDeposit.ts
+++ b/web/src/hooks/useStakeDeposit.ts
@@ -10,6 +10,8 @@ import type { Address, TransactionReceipt } from "viem";
 import { useAccount } from "wagmi";
 
 import { analyticsTotalsQueryKey } from "./useAnalyticsTotals";
+import { averagePurchasePriceQueryKey } from "./useAveragePurchasePrice";
+import { earnedAmountUsdQueryKey } from "./useEarnedAmountUsd";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { poolDepositsQueryKey } from "./usePoolDeposits";
@@ -184,14 +186,16 @@ export const useStakeDeposit = function ({
         queryKey: peggedTokenBalanceKey,
       });
 
-      // Shares must be refetched before staked balance, because
-      // useStakedBalance uses ensureQueryData to read shares from cache.
-      // refetchQueries (not invalidateQueries) is required because the
-      // shares query has no mounted observer — invalidation alone would
-      // only mark it stale, and ensureQueryData returns stale cached data.
-      await queryClient.refetchQueries({
-        queryKey: sharesBalanceKey,
-      });
+      // Refetch (not just invalidate) the queries that downstream fetchers
+      // read via ensureQueryData: shares feed useStakedBalance, and avg
+      // purchase price feeds fetchEarnedAmountUsd. Neither has a mounted
+      // observer, so invalidation alone would leave them stale.
+      await Promise.all([
+        queryClient.refetchQueries({ queryKey: sharesBalanceKey }),
+        queryClient.refetchQueries({
+          queryKey: averagePurchasePriceQueryKey(account),
+        }),
+      ]);
 
       queryClient.invalidateQueries({
         queryKey: stakedKey,
@@ -199,6 +203,10 @@ export const useStakeDeposit = function ({
 
       queryClient.invalidateQueries({
         queryKey: totalStakedUsdQueryKey({ account, chainId: chain.id }),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: earnedAmountUsdQueryKey({ account, chainId: chain.id }),
       });
 
       queryClient.invalidateQueries({

--- a/web/src/hooks/useStakeDeposit.ts
+++ b/web/src/hooks/useStakeDeposit.ts
@@ -10,7 +10,7 @@ import type { Address, TransactionReceipt } from "viem";
 import { useAccount } from "wagmi";
 
 import { analyticsTotalsQueryKey } from "./useAnalyticsTotals";
-import { averagePurchasePriceQueryKey } from "./useAveragePurchasePrice";
+import { costBasisQueryKey } from "./useCostBasis";
 import { earnedAmountUsdQueryKey } from "./useEarnedAmountUsd";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
@@ -187,13 +187,13 @@ export const useStakeDeposit = function ({
       });
 
       // Refetch (not just invalidate) the queries that downstream fetchers
-      // read via ensureQueryData: shares feed useStakedBalance, and avg
-      // purchase price feeds fetchEarnedAmountUsd. Neither has a mounted
-      // observer, so invalidation alone would leave them stale.
+      // read via ensureQueryData: shares feed useStakedBalance, and cost
+      // basis feeds fetchEarnedAmountUsd. Neither has a mounted observer,
+      // so invalidation alone would leave them stale.
       await Promise.all([
         queryClient.refetchQueries({ queryKey: sharesBalanceKey }),
         queryClient.refetchQueries({
-          queryKey: averagePurchasePriceQueryKey(account),
+          queryKey: costBasisQueryKey(account),
         }),
       ]);
 

--- a/web/src/hooks/useStakeWithdraw.ts
+++ b/web/src/hooks/useStakeWithdraw.ts
@@ -12,6 +12,8 @@ import { type Address, type TransactionReceipt, parseEventLogs } from "viem";
 import { useAccount } from "wagmi";
 
 import { analyticsTotalsQueryKey } from "./useAnalyticsTotals";
+import { averagePurchasePriceQueryKey } from "./useAveragePurchasePrice";
+import { earnedAmountUsdQueryKey } from "./useEarnedAmountUsd";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { poolDepositsQueryKey } from "./usePoolDeposits";
@@ -152,14 +154,16 @@ export const useStakeWithdraw = function ({
         queryKey: nativeBalanceKey,
       });
 
-      // Shares must be refetched before staked balance, because
-      // useStakedBalance uses ensureQueryData to read shares from cache.
-      // refetchQueries (not invalidateQueries) is required because the
-      // shares query has no mounted observer — invalidation alone would
-      // only mark it stale, and ensureQueryData returns stale cached data.
-      await queryClient.refetchQueries({
-        queryKey: sharesBalanceKey,
-      });
+      // Refetch (not just invalidate) the queries that downstream fetchers
+      // read via ensureQueryData: shares feed useStakedBalance, and avg
+      // purchase price feeds fetchEarnedAmountUsd. Neither has a mounted
+      // observer, so invalidation alone would leave them stale.
+      await Promise.all([
+        queryClient.refetchQueries({ queryKey: sharesBalanceKey }),
+        queryClient.refetchQueries({
+          queryKey: averagePurchasePriceQueryKey(account),
+        }),
+      ]);
 
       queryClient.invalidateQueries({
         queryKey: stakedKey,
@@ -167,6 +171,10 @@ export const useStakeWithdraw = function ({
 
       queryClient.invalidateQueries({
         queryKey: totalStakedUsdQueryKey({ account, chainId: chain.id }),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: earnedAmountUsdQueryKey({ account, chainId: chain.id }),
       });
 
       queryClient.invalidateQueries({

--- a/web/src/hooks/useStakeWithdraw.ts
+++ b/web/src/hooks/useStakeWithdraw.ts
@@ -12,7 +12,7 @@ import { type Address, type TransactionReceipt, parseEventLogs } from "viem";
 import { useAccount } from "wagmi";
 
 import { analyticsTotalsQueryKey } from "./useAnalyticsTotals";
-import { averagePurchasePriceQueryKey } from "./useAveragePurchasePrice";
+import { costBasisQueryKey } from "./useCostBasis";
 import { earnedAmountUsdQueryKey } from "./useEarnedAmountUsd";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
@@ -155,13 +155,13 @@ export const useStakeWithdraw = function ({
       });
 
       // Refetch (not just invalidate) the queries that downstream fetchers
-      // read via ensureQueryData: shares feed useStakedBalance, and avg
-      // purchase price feeds fetchEarnedAmountUsd. Neither has a mounted
-      // observer, so invalidation alone would leave them stale.
+      // read via ensureQueryData: shares feed useStakedBalance, and cost
+      // basis feeds fetchEarnedAmountUsd. Neither has a mounted observer,
+      // so invalidation alone would leave them stale.
       await Promise.all([
         queryClient.refetchQueries({ queryKey: sharesBalanceKey }),
         queryClient.refetchQueries({
-          queryKey: averagePurchasePriceQueryKey(account),
+          queryKey: costBasisQueryKey(account),
         }),
       ]);
 

--- a/web/src/pages/earn/components/earnedAmountStat/index.tsx
+++ b/web/src/pages/earn/components/earnedAmountStat/index.tsx
@@ -1,16 +1,13 @@
-import { useTotalStakedUsd } from "hooks/useTotalStakedUsd";
+import { useEarnedAmountUsd } from "hooks/useEarnedAmountUsd";
 import { useTranslation } from "react-i18next";
 import { formatUsd } from "utils/currency";
 
 import { TrendingUpIcon } from "../../icons/trendingUpIcon";
 import { StatCard } from "../statCard";
 
-// TODO earned amount should sum yield across all staking vaults in USD;
-// temporarily mirroring the staked balance until the proper calculation lands.
-// See https://github.com/vetro-protocol/vetro-monorepo/issues/333
 export function EarnedAmountStat() {
   const { t } = useTranslation();
-  const { data, isLoading } = useTotalStakedUsd();
+  const { data, isLoading } = useEarnedAmountUsd();
 
   return (
     <StatCard

--- a/web/test/fetchers/fetchEarnedAmountUsd.test.ts
+++ b/web/test/fetchers/fetchEarnedAmountUsd.test.ts
@@ -1,5 +1,5 @@
 import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
-import { averagePurchasePriceQueryOptions } from "hooks/useAveragePurchasePrice";
+import { costBasisQueryOptions } from "hooks/useCostBasis";
 import { pricesOptions } from "hooks/usePrices";
 import { stakedBalanceQueryOptions } from "hooks/useStakedBalance";
 import { vaultPeggedTokenQueryOptions } from "hooks/useVaultPeggedToken";
@@ -57,10 +57,10 @@ describe("fetchEarnedAmountUsd", function () {
       }).queryKey,
       12n * 10n ** 18n,
     );
-    // avgPrice = 1 vUSD per share → costBasis = 10 vUSD → earned = 2 vUSD.
+    // costBasis = 10 vUSD → earned = 2 vUSD.
     queryClient.setQueryData(
-      averagePurchasePriceQueryOptions({ address: account }).queryKey,
-      { [vault1]: 10n ** 18n } as Record<Address, bigint>,
+      costBasisQueryOptions({ address: account }).queryKey,
+      { [vault1]: 10n * 10n ** 18n } as Record<Address, bigint>,
     );
     queryClient.setQueryData(pricesOptions({ client, queryClient }).queryKey, {
       USDT: "1",
@@ -106,8 +106,8 @@ describe("fetchEarnedAmountUsd", function () {
       8n * 10n ** 18n,
     );
     queryClient.setQueryData(
-      averagePurchasePriceQueryOptions({ address: account }).queryKey,
-      { [vault1]: 10n ** 18n } as Record<Address, bigint>,
+      costBasisQueryOptions({ address: account }).queryKey,
+      { [vault1]: 10n * 10n ** 18n } as Record<Address, bigint>,
     );
     queryClient.setQueryData(pricesOptions({ client, queryClient }).queryKey, {
       USDT: "1",
@@ -178,10 +178,10 @@ describe("fetchEarnedAmountUsd", function () {
       (21n * 10n ** 18n) / 10n,
     );
     queryClient.setQueryData(
-      averagePurchasePriceQueryOptions({ address: account }).queryKey,
+      costBasisQueryOptions({ address: account }).queryKey,
       {
-        [vault1]: 10n ** 18n,
-        [vault2]: 10n ** 18n,
+        [vault1]: 5n * 10n ** 18n,
+        [vault2]: 2n * 10n ** 18n,
       } as Record<Address, bigint>,
     );
     queryClient.setQueryData(pricesOptions({ client, queryClient }).queryKey, {
@@ -230,7 +230,7 @@ describe("fetchEarnedAmountUsd", function () {
       0n,
     );
     queryClient.setQueryData(
-      averagePurchasePriceQueryOptions({ address: account }).queryKey,
+      costBasisQueryOptions({ address: account }).queryKey,
       { [vault1]: 0n } as Record<Address, bigint>,
     );
     queryClient.setQueryData(pricesOptions({ client, queryClient }).queryKey, {
@@ -247,7 +247,7 @@ describe("fetchEarnedAmountUsd", function () {
     expect(result).toBe(0);
   });
 
-  it("contributes 0 when avg purchase price is missing for a vault with shares", async function () {
+  it("contributes 0 when cost basis is missing for a vault with shares", async function () {
     const queryClient = createTestQueryClient();
     queryClient.setQueryData(
       vaultPeggedTokenQueryOptions({
@@ -277,7 +277,7 @@ describe("fetchEarnedAmountUsd", function () {
     );
     // Subgraph not yet synced — API returns 0n for the vault.
     queryClient.setQueryData(
-      averagePurchasePriceQueryOptions({ address: account }).queryKey,
+      costBasisQueryOptions({ address: account }).queryKey,
       { [vault1]: 0n } as Record<Address, bigint>,
     );
     queryClient.setQueryData(pricesOptions({ client, queryClient }).queryKey, {

--- a/web/test/fetchers/fetchEarnedAmountUsd.test.ts
+++ b/web/test/fetchers/fetchEarnedAmountUsd.test.ts
@@ -1,0 +1,309 @@
+import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
+import { averagePurchasePriceQueryOptions } from "hooks/useAveragePurchasePrice";
+import { pricesOptions } from "hooks/usePrices";
+import { stakedBalanceQueryOptions } from "hooks/useStakedBalance";
+import { vaultPeggedTokenQueryOptions } from "hooks/useVaultPeggedToken";
+import { knownTokens } from "utils/tokenList";
+import type { Address, Client } from "viem";
+import { mainnet } from "viem/chains";
+import { describe, expect, it } from "vitest";
+
+import { fetchEarnedAmountUsd } from "../../src/fetchers/fetchEarnedAmountUsd";
+import { createTestQueryClient } from "../utils";
+
+const account = "0x0000000000000000000000000000000000000abc" as Address;
+const client = { chain: mainnet } as unknown as Client;
+
+const vault1 = "0x1111111111111111111111111111111111111111" as Address;
+const vault2 = "0x2222222222222222222222222222222222222222" as Address;
+
+const vusd = {
+  ...knownTokens.find((token) => token.symbol === "VUSD")!,
+  gatewayAddress: "0x0000000000000000000000000000000000000001" as Address,
+};
+const vetBtc = {
+  ...knownTokens.find((token) => token.symbol === "vetBTC")!,
+  gatewayAddress: "0x0000000000000000000000000000000000000002" as Address,
+};
+
+describe("fetchEarnedAmountUsd", function () {
+  it("returns the unrealized P&L (current - cost basis) times price", async function () {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      vaultPeggedTokenQueryOptions({
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      vusd,
+    );
+    // 10 shares.
+    queryClient.setQueryData(
+      tokenBalanceQueryOptions({
+        account,
+        client,
+        token: { address: vault1, chainId: mainnet.id },
+      }).queryKey,
+      10n * 10n ** 18n,
+    );
+    // currentAssets = 12 vUSD (price went up).
+    queryClient.setQueryData(
+      stakedBalanceQueryOptions({
+        account,
+        chainId: mainnet.id,
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      12n * 10n ** 18n,
+    );
+    // avgPrice = 1 vUSD per share → costBasis = 10 vUSD → earned = 2 vUSD.
+    queryClient.setQueryData(
+      averagePurchasePriceQueryOptions({ address: account }).queryKey,
+      { [vault1]: 10n ** 18n } as Record<Address, bigint>,
+    );
+    queryClient.setQueryData(pricesOptions({ client, queryClient }).queryKey, {
+      USDT: "1",
+    });
+
+    const result = await fetchEarnedAmountUsd({
+      account,
+      client,
+      queryClient,
+      stakingVaultAddresses: [vault1],
+    });
+
+    expect(result).toBe(2);
+  });
+
+  it("returns a negative number when current value is below cost basis", async function () {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      vaultPeggedTokenQueryOptions({
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      vusd,
+    );
+    queryClient.setQueryData(
+      tokenBalanceQueryOptions({
+        account,
+        client,
+        token: { address: vault1, chainId: mainnet.id },
+      }).queryKey,
+      10n * 10n ** 18n,
+    );
+    // currentAssets = 8 vUSD, costBasis = 10 vUSD → loss of 2 vUSD.
+    queryClient.setQueryData(
+      stakedBalanceQueryOptions({
+        account,
+        chainId: mainnet.id,
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      8n * 10n ** 18n,
+    );
+    queryClient.setQueryData(
+      averagePurchasePriceQueryOptions({ address: account }).queryKey,
+      { [vault1]: 10n ** 18n } as Record<Address, bigint>,
+    );
+    queryClient.setQueryData(pricesOptions({ client, queryClient }).queryKey, {
+      USDT: "1",
+    });
+
+    const result = await fetchEarnedAmountUsd({
+      account,
+      client,
+      queryClient,
+      stakingVaultAddresses: [vault1],
+    });
+
+    expect(result).toBe(-2);
+  });
+
+  it("sums P&L across multiple vaults", async function () {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      vaultPeggedTokenQueryOptions({
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      vusd,
+    );
+    queryClient.setQueryData(
+      vaultPeggedTokenQueryOptions({
+        client,
+        queryClient,
+        stakingVaultAddress: vault2,
+      }).queryKey,
+      vetBtc,
+    );
+    queryClient.setQueryData(
+      tokenBalanceQueryOptions({
+        account,
+        client,
+        token: { address: vault1, chainId: mainnet.id },
+      }).queryKey,
+      5n * 10n ** 18n,
+    );
+    queryClient.setQueryData(
+      tokenBalanceQueryOptions({
+        account,
+        client,
+        token: { address: vault2, chainId: mainnet.id },
+      }).queryKey,
+      2n * 10n ** 18n,
+    );
+    queryClient.setQueryData(
+      stakedBalanceQueryOptions({
+        account,
+        chainId: mainnet.id,
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      6n * 10n ** 18n,
+    );
+    queryClient.setQueryData(
+      stakedBalanceQueryOptions({
+        account,
+        chainId: mainnet.id,
+        client,
+        queryClient,
+        stakingVaultAddress: vault2,
+      }).queryKey,
+      (21n * 10n ** 18n) / 10n,
+    );
+    queryClient.setQueryData(
+      averagePurchasePriceQueryOptions({ address: account }).queryKey,
+      {
+        [vault1]: 10n ** 18n,
+        [vault2]: 10n ** 18n,
+      } as Record<Address, bigint>,
+    );
+    queryClient.setQueryData(pricesOptions({ client, queryClient }).queryKey, {
+      USDT: "1",
+      WBTC: "60000",
+    } as Record<string, string>);
+
+    const result = await fetchEarnedAmountUsd({
+      account,
+      client,
+      queryClient,
+      stakingVaultAddresses: [vault1, vault2],
+    });
+
+    // vault1: 6 - 5 = 1 vUSD * $1 = $1
+    // vault2: 2.1 - 2 = 0.1 vetBTC * $60_000 = $6000
+    expect(result).toBeCloseTo(6001, 6);
+  });
+
+  it("contributes 0 when shares are 0", async function () {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      vaultPeggedTokenQueryOptions({
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      vusd,
+    );
+    queryClient.setQueryData(
+      tokenBalanceQueryOptions({
+        account,
+        client,
+        token: { address: vault1, chainId: mainnet.id },
+      }).queryKey,
+      0n,
+    );
+    queryClient.setQueryData(
+      stakedBalanceQueryOptions({
+        account,
+        chainId: mainnet.id,
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      0n,
+    );
+    queryClient.setQueryData(
+      averagePurchasePriceQueryOptions({ address: account }).queryKey,
+      { [vault1]: 0n } as Record<Address, bigint>,
+    );
+    queryClient.setQueryData(pricesOptions({ client, queryClient }).queryKey, {
+      USDT: "1",
+    });
+
+    const result = await fetchEarnedAmountUsd({
+      account,
+      client,
+      queryClient,
+      stakingVaultAddresses: [vault1],
+    });
+
+    expect(result).toBe(0);
+  });
+
+  it("contributes 0 when avg purchase price is missing for a vault with shares", async function () {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      vaultPeggedTokenQueryOptions({
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      vusd,
+    );
+    queryClient.setQueryData(
+      tokenBalanceQueryOptions({
+        account,
+        client,
+        token: { address: vault1, chainId: mainnet.id },
+      }).queryKey,
+      10n * 10n ** 18n,
+    );
+    queryClient.setQueryData(
+      stakedBalanceQueryOptions({
+        account,
+        chainId: mainnet.id,
+        client,
+        queryClient,
+        stakingVaultAddress: vault1,
+      }).queryKey,
+      12n * 10n ** 18n,
+    );
+    // Subgraph not yet synced — API returns 0n for the vault.
+    queryClient.setQueryData(
+      averagePurchasePriceQueryOptions({ address: account }).queryKey,
+      { [vault1]: 0n } as Record<Address, bigint>,
+    );
+    queryClient.setQueryData(pricesOptions({ client, queryClient }).queryKey, {
+      USDT: "1",
+    });
+
+    const result = await fetchEarnedAmountUsd({
+      account,
+      client,
+      queryClient,
+      stakingVaultAddresses: [vault1],
+    });
+
+    expect(result).toBe(0);
+  });
+
+  it("throws when the client has no chain", async function () {
+    const clientWithoutChain = {} as Client;
+
+    await expect(
+      fetchEarnedAmountUsd({
+        account,
+        client: clientWithoutChain,
+        queryClient: createTestQueryClient(),
+        stakingVaultAddresses: [vault1],
+      }),
+    ).rejects.toThrow(/Client is missing a chain/);
+  });
+});


### PR DESCRIPTION
### Description

Replace the placeholder that mirrored staked balance with a real earned-amount calculation. Per vault, take `userStakedAssets - costBasis` (both in pegged-token asset units) to get unrealized assets, convert to USD, and sum across vaults.

Adds:
- `useCostBasis` — fetches per-vault cost basis from the API
- `fetchEarnedAmountUsd` — composes the calculation
- `useEarnedAmountUsd` — exposes it to the UI

Wires cache refresh into deposit, withdraw, cancel-withdraw and instant-withdraw flows so the stat updates after each action. The cost basis query must be refetched (not just invalidated) since `fetchEarnedAmountUsd` reads it via `ensureQueryData` with no mounted observer.

### Screenshots

<!-- TODO: add screenshot of the Earned Amount stat -->

### Related issue(s)

Closes #333

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.