### PR TITLE
Tidy analytics layout and TokenFilter container

### DIFF
--- a/web/src/pages/analytics/index.tsx
+++ b/web/src/pages/analytics/index.tsx
@@ -74,7 +74,7 @@ export const Analytics = function () {
       <PageTitle value={t("pages.analytics.title")} />
       {/* only show the filter if there are 2 or more tokens to filter from */}
       {gatewayAddresses.length > 1 && !isPeggedTokensError && (
-        <div className="px-3 py-4 md:px-6">
+        <div className="border-y border-gray-200 bg-white px-3 py-4 md:px-6">
           <div className="mx-auto w-fit">
             {tokens && selectedToken ? (
               <TokenFilter

--- a/web/src/pages/analytics/index.tsx
+++ b/web/src/pages/analytics/index.tsx
@@ -17,9 +17,11 @@ import { YieldCard } from "./components/yieldCard";
 const AllocationRow = ({
   children,
   className = "",
+  isLast = false,
 }: {
   children: ReactNode;
   className?: string;
+  isLast?: boolean;
 }) => (
   <>
     <div
@@ -27,9 +29,11 @@ const AllocationRow = ({
     >
       {children}
     </div>
-    <div className="bg-gray-100">
-      <StripedDivider />
-    </div>
+    {!isLast && (
+      <div className="bg-gray-100">
+        <StripedDivider variant="small" />
+      </div>
+    )}
   </>
 );
 
@@ -91,7 +95,7 @@ export const Analytics = function () {
           peggedToken={selectedToken}
           peggedTokenError={isPeggedTokensError}
         />
-        <YieldCard
+        <CollateralizationCard
           peggedToken={selectedToken}
           peggedTokenError={isPeggedTokensError}
         />
@@ -106,9 +110,9 @@ export const Analytics = function () {
           peggedTokenError={isPeggedTokensError}
         />
       </AllocationRow>
-      <AllocationRow className="md:justify-center">
+      <AllocationRow className="md:justify-center" isLast>
         <div className="md:w-1/2">
-          <CollateralizationCard
+          <YieldCard
             peggedToken={selectedToken}
             peggedTokenError={isPeggedTokensError}
           />


### PR DESCRIPTION
### Description

Reordered the cards on the analytics page to match the new Figma distribution, and fixed a bug where an extra `StripedDivider` was rendered after the last `AllocationRow`. Additionally, applied the new style to the `TokenFilter` section.

**Commits:**

- 584c744 Style TokenFilter container per Figma
- 97e7244 Tidy analytics layout and trailing divider

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img width="1188" height="846" alt="image" src="https://github.com/user-attachments/assets/5907614a-211f-435d-a9b1-2c868031afa0" />

(bottom)

<img width="1172" height="658" alt="image" src="https://github.com/user-attachments/assets/1ae6ed99-cc89-4944-aa61-4ed2a9c66cef" />


Note: The Yield Performance card needs to be implemented, as well as the Peg Stability chart

### Related issue(s)

Related to #365

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.