### PR TITLE
Add peg-stability chart to /analytics

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -126,6 +126,23 @@ Returns the APY for each supported staking vault, indexed by staking vault addre
 }
 ```
 
+### `GET /variable-stake/share-value-history/:stakingVaultAddress/:period`
+
+Returns the historical share value for a staking vault over the given period (Earn token vs underlying pegged token, e.g. sVUSD per VUSD). One entry per UTC day. Results across multiple subgraph pages are concatenated, so long windows return their full history (e.g. `"1y"` may include up to ~366 entries).
+Valid periods are: `"1w"`, `"1m"`, `"3m"` and `"1y"`.
+`:stakingVaultAddress` must be a known staking vault. Returns `400` if malformed and `404` if the address is not a known staking vault.
+`shareValue` is a number with the 18-decimal wad already pre-scaled (e.g. `1.000412938421`). `timestamp` is the UTC day-start in milliseconds.
+
+#### Sample Response for "1w"
+
+```jsonc
+[
+  { "shareValue": 1.000412938421, "timestamp": 1707782400000 },
+  { "shareValue": 1.000506129482, "timestamp": 1707868800000 },
+  // ...more records...
+]
+```
+
 ### `GET /variable-stake/rewards/:address`
 
 Returns all user's rewards from the Merkl campaigns related to Vetro, indexed by staking vault address. Each supported staking vault has an entry in the response, with an empty array if the user has no rewards for that vault.

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -12,8 +12,13 @@ import {
   validateAddress,
   validateGatewayAddress,
   validateParam,
+  validateStakingVaultAddress,
 } from "./param-validators.ts";
 import { securityHeaders } from "./security-headers.ts";
+import {
+  getShareValueHistory,
+  validPeriods as shareValueHistoryValidPeriods,
+} from "./share-value-history.ts";
 import { createOriginFn, parseOrigins } from "./validate-origin.ts";
 import * as variableStake from "./variable-stake.ts";
 
@@ -222,6 +227,31 @@ app.get(
     } catch (error) {
       console.log(error.stack);
       throw new Error(`Failed to get exit queue data: ${error.message}`);
+    }
+  },
+);
+
+app.get(
+  "/variable-stake/share-value-history/:stakingVaultAddress/:period",
+  validateStakingVaultAddress,
+  validateParam("period", shareValueHistoryValidPeriods),
+  cache({
+    cacheControl: "max-age=3600",
+    cacheName: "vetro-api",
+  }),
+  async function (c) {
+    try {
+      const stakingVaultAddress = c.get("stakingVaultAddress");
+      const url = getSubgraphUrl(c.env);
+      const period = c.req.param("period");
+      const data = await getShareValueHistory({
+        period,
+        stakingVaultAddress,
+        url,
+      });
+      return c.json(data);
+    } catch (error) {
+      throw new Error(`Failed to get share value history: ${error.message}`);
     }
   },
 );

--- a/api/src/param-validators.ts
+++ b/api/src/param-validators.ts
@@ -1,3 +1,4 @@
+import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { gatewayAddresses } from "@vetro-protocol/gateway";
 import type { Context, Next } from "hono";
 import { type Address, checksumAddress, isAddress } from "viem";
@@ -5,9 +6,17 @@ import { type Address, checksumAddress, isAddress } from "viem";
 declare module "hono" {
   interface ContextVariableMap {
     gatewayAddress: Address;
+    stakingVaultAddress: Address;
   }
 }
 
+// validateAddress is intentionally not built on top of validateWhitelistedAddress
+// below: it validates arbitrary user wallets (e.g. /variable-stake/exit-tickets/
+// :address) where there is no known list, so a malformed input is functionally
+// indistinguishable from "address has no record" and 404 captures both. The
+// whitelisted variants distinguish 400 (malformed) from 404 (well-formed but
+// unknown) because that asymmetry carries useful information for known-list
+// endpoints.
 /**
  * Middleware to validate that the "address" route parameter is a valid
  * Ethereum address. If invalid, returns a 404 response.
@@ -22,23 +31,54 @@ export async function validateAddress(c: Context, next: Next) {
   return next();
 }
 
+const validateWhitelistedAddress = ({
+  errorMalformed,
+  errorNotFound,
+  paramName,
+  whitelist,
+}: {
+  errorMalformed: string;
+  errorNotFound: string;
+  paramName: "gatewayAddress" | "stakingVaultAddress";
+  whitelist: readonly Address[];
+}) =>
+  async function (c: Context, next: Next) {
+    const raw = c.req.param(paramName);
+    if (!raw || !isAddress(raw, { strict: false })) {
+      return c.json({ error: errorMalformed }, 400);
+    }
+    const address = checksumAddress(raw);
+    if (!whitelist.includes(address)) {
+      return c.json({ error: errorNotFound }, 404);
+    }
+    c.set(paramName, address);
+    return next();
+  };
+
 /**
  * Middleware to validate the "gatewayAddress" route parameter. Returns 400 if
  * the address is malformed and 404 if it is not a known gateway. On success,
  * stores the checksummed address on the context as `gatewayAddress`.
  */
-export async function validateGatewayAddress(c: Context, next: Next) {
-  const raw = c.req.param("gatewayAddress");
-  if (!raw || !isAddress(raw, { strict: false })) {
-    return c.json({ error: "Malformed Gateway Address" }, 400);
-  }
-  const gatewayAddress = checksumAddress(raw);
-  if (!gatewayAddresses.includes(gatewayAddress)) {
-    return c.json({ error: "Gateway not found" }, 404);
-  }
-  c.set("gatewayAddress", gatewayAddress);
-  return next();
-}
+export const validateGatewayAddress = validateWhitelistedAddress({
+  errorMalformed: "Malformed Gateway Address",
+  errorNotFound: "Gateway not found",
+  paramName: "gatewayAddress",
+  whitelist: gatewayAddresses,
+});
+
+/**
+ * Middleware to validate the "stakingVaultAddress" route parameter. Returns 400
+ * if the address is malformed and 404 if it is not a known staking vault. On
+ * success, stores the checksummed address on the context as
+ * `stakingVaultAddress`.
+ */
+export const validateStakingVaultAddress = validateWhitelistedAddress({
+  errorMalformed: "Malformed Staking Vault Address",
+  errorNotFound: "Staking vault not found",
+  paramName: "stakingVaultAddress",
+  whitelist: stakingVaultAddresses,
+});
 
 /**
  * Validates a given parameter against a list of valid options. If the parameter

--- a/api/src/share-value-history.ts
+++ b/api/src/share-value-history.ts
@@ -1,0 +1,81 @@
+import { type Address, formatUnits } from "viem";
+
+import * as graphql from "./graphql.ts";
+
+const secsPerDay = 86400;
+
+/* eslint-disable sort-keys */
+const periodToStartOffset: Record<string, number> = {
+  "1w": 7 * secsPerDay,
+  "1m": 30 * secsPerDay,
+  "3m": 90 * secsPerDay,
+  "1y": 366 * secsPerDay,
+};
+/* eslint-enable sort-keys */
+
+export const validPeriods = Object.keys(periodToStartOffset);
+
+const pageSize = 100;
+// To prevent infinite loops in the case of a misbehaving subgraph, we set a hard cap
+// but we shouldn't load more than 4 pages per year
+const hardCap = 4 * pageSize;
+
+type Row = { shareValue: string; timestamp: string };
+
+/**
+ * Query the subgraph for the share value history of a staking vault over the
+ * given period. Paginates over the subgraph's 100-result page cap so that long
+ * windows (e.g. "1y", up to ~366 daily entries) are returned in full. Stops
+ * defensively at hardCap rows to bound the loop.
+ */
+export async function getShareValueHistory({
+  period,
+  stakingVaultAddress,
+  url,
+}: {
+  period: string;
+  stakingVaultAddress: Address;
+  url: string;
+}): Promise<{ shareValue: number; timestamp: number }[]> {
+  const stakingVault = stakingVaultAddress.toLowerCase();
+  const start = (
+    Math.floor(Date.now() / 1000) - periodToStartOffset[period]
+  ).toString();
+  const query = `
+    query ($first: Int!, $skip: Int!, $stakingVault: Bytes!, $start: BigInt!) {
+      vaultHistories(
+        first: $first
+        orderBy: timestamp
+        orderDirection: asc
+        skip: $skip
+        where: {
+          stakingVaultAddress: $stakingVault
+          timestamp_gte: $start
+        }
+      ) {
+        shareValue
+        timestamp
+      }
+    }`;
+
+  const all: Row[] = [];
+  let skip = 0;
+  while (skip < hardCap) {
+    const { vaultHistories } = await graphql.runQuery<{
+      vaultHistories: Row[];
+    }>(url, query, { first: pageSize, skip, stakingVault, start });
+    if (!Array.isArray(vaultHistories)) {
+      throw new Error(
+        `Invalid subgraph response for vault history of ${stakingVaultAddress}`,
+      );
+    }
+    all.push(...vaultHistories);
+    if (vaultHistories.length < pageSize) break;
+    skip += pageSize;
+  }
+
+  return all.map((h) => ({
+    shareValue: Number(formatUnits(BigInt(h.shareValue), 18)),
+    timestamp: Number.parseInt(h.timestamp, 10) * 1000,
+  }));
+}

--- a/api/src/share-value-history.ts
+++ b/api/src/share-value-history.ts
@@ -38,9 +38,11 @@ export async function getShareValueHistory({
   url: string;
 }): Promise<{ shareValue: number; timestamp: number }[]> {
   const stakingVault = stakingVaultAddress.toLowerCase();
-  const start = (
-    Math.floor(Date.now() / 1000) - periodToStartOffset[period]
-  ).toString();
+  // Floor to the UTC day boundary so the filter always includes the snapshot
+  // exactly N days ago at 00:00 UTC, regardless of the time of day the request
+  // is made. VaultHistory entries are snapped to UTC day start by the indexer.
+  const todayStart = Math.floor(Date.now() / 1000 / secsPerDay) * secsPerDay;
+  const start = (todayStart - periodToStartOffset[period]).toString();
   const query = `
     query ($first: Int!, $skip: Int!, $stakingVault: Bytes!, $start: BigInt!) {
       vaultHistories(

--- a/api/test/param-validators.test.ts
+++ b/api/test/param-validators.test.ts
@@ -1,10 +1,14 @@
 import { sVusdAddress } from "@vetro-protocol/earn";
+import { gatewayAddresses } from "@vetro-protocol/gateway";
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 
-import { validateStakingVaultAddress } from "../src/param-validators.ts";
+import {
+  validateGatewayAddress,
+  validateStakingVaultAddress,
+} from "../src/param-validators.ts";
 
-const buildApp = function () {
+const buildStakingVaultApp = function () {
   const app = new Hono();
   app.get("/test/:stakingVaultAddress", validateStakingVaultAddress, (c) =>
     c.json({ stakingVaultAddress: c.get("stakingVaultAddress") }),
@@ -12,9 +16,17 @@ const buildApp = function () {
   return app;
 };
 
+const buildGatewayApp = function () {
+  const app = new Hono();
+  app.get("/test/:gatewayAddress", validateGatewayAddress, (c) =>
+    c.json({ gatewayAddress: c.get("gatewayAddress") }),
+  );
+  return app;
+};
+
 describe("validateStakingVaultAddress", function () {
   it("returns 400 with a Malformed error for a non-address parameter", async function () {
-    const app = buildApp();
+    const app = buildStakingVaultApp();
 
     const response = await app.request("/test/0xdeadbeef");
 
@@ -25,7 +37,7 @@ describe("validateStakingVaultAddress", function () {
   });
 
   it("returns 404 for a well-formed address that is not a known staking vault", async function () {
-    const app = buildApp();
+    const app = buildStakingVaultApp();
 
     const response = await app.request(
       "/test/0x0000000000000000000000000000000000000001",
@@ -36,7 +48,7 @@ describe("validateStakingVaultAddress", function () {
   });
 
   it("passes through and stores the checksummed address for a known staking vault", async function () {
-    const app = buildApp();
+    const app = buildStakingVaultApp();
 
     const response = await app.request(`/test/${sVusdAddress.toLowerCase()}`);
 
@@ -44,5 +56,39 @@ describe("validateStakingVaultAddress", function () {
     expect(await response.json()).toEqual({
       stakingVaultAddress: sVusdAddress,
     });
+  });
+});
+
+describe("validateGatewayAddress", function () {
+  it("returns 400 with a Malformed error for a non-address parameter", async function () {
+    const app = buildGatewayApp();
+
+    const response = await app.request("/test/0xdeadbeef");
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Malformed Gateway Address",
+    });
+  });
+
+  it("returns 404 for a well-formed address that is not a known gateway", async function () {
+    const app = buildGatewayApp();
+
+    const response = await app.request(
+      "/test/0x0000000000000000000000000000000000000001",
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Gateway not found" });
+  });
+
+  it("passes through and stores the checksummed address for a known gateway", async function () {
+    const app = buildGatewayApp();
+    const known = gatewayAddresses[0];
+
+    const response = await app.request(`/test/${known.toLowerCase()}`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ gatewayAddress: known });
   });
 });

--- a/api/test/param-validators.test.ts
+++ b/api/test/param-validators.test.ts
@@ -1,0 +1,48 @@
+import { sVusdAddress } from "@vetro-protocol/earn";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+
+import { validateStakingVaultAddress } from "../src/param-validators.ts";
+
+const buildApp = function () {
+  const app = new Hono();
+  app.get("/test/:stakingVaultAddress", validateStakingVaultAddress, (c) =>
+    c.json({ stakingVaultAddress: c.get("stakingVaultAddress") }),
+  );
+  return app;
+};
+
+describe("validateStakingVaultAddress", function () {
+  it("returns 400 with a Malformed error for a non-address parameter", async function () {
+    const app = buildApp();
+
+    const response = await app.request("/test/0xdeadbeef");
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Malformed Staking Vault Address",
+    });
+  });
+
+  it("returns 404 for a well-formed address that is not a known staking vault", async function () {
+    const app = buildApp();
+
+    const response = await app.request(
+      "/test/0x0000000000000000000000000000000000000001",
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Staking vault not found" });
+  });
+
+  it("passes through and stores the checksummed address for a known staking vault", async function () {
+    const app = buildApp();
+
+    const response = await app.request(`/test/${sVusdAddress.toLowerCase()}`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      stakingVaultAddress: sVusdAddress,
+    });
+  });
+});

--- a/api/test/share-value-history.test.ts
+++ b/api/test/share-value-history.test.ts
@@ -134,5 +134,15 @@ describe("share-value-history/getShareValueHistory", function () {
         );
       },
     );
+
+    it("floors start to the UTC day boundary even when called mid-day, so the snapshot from N days ago at 00:00 UTC is included", async function () {
+      vi.setSystemTime(new Date("2026-05-04T14:30:00Z"));
+
+      await fetchHistory("1w");
+
+      expect(lastCallVariables<{ start: string }>()?.start).toBe(
+        (nowSecs - 7 * secsPerDay).toString(),
+      );
+    });
   });
 });

--- a/api/test/share-value-history.test.ts
+++ b/api/test/share-value-history.test.ts
@@ -1,0 +1,138 @@
+import { sVusdAddress } from "@vetro-protocol/earn";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as graphql from "../src/graphql.ts";
+import { getShareValueHistory } from "../src/share-value-history.ts";
+
+vi.mock("../src/graphql.ts", () => ({
+  runQuery: vi.fn(),
+}));
+
+const url = "https://subgraph.example/v1";
+
+const fetchHistory = (period = "1w") =>
+  getShareValueHistory({ period, stakingVaultAddress: sVusdAddress, url });
+
+const buildPage = (count: number, startTimestamp = 1_700_000_000) =>
+  Array.from({ length: count }, (_, i) => ({
+    shareValue: (10n ** 18n + BigInt(i)).toString(),
+    timestamp: (startTimestamp + i * 86400).toString(),
+  }));
+
+const lastCallVariables = <T>() =>
+  vi.mocked(graphql.runQuery).mock.calls.at(-1)?.[2] as T | undefined;
+
+describe("share-value-history/getShareValueHistory", function () {
+  it("returns [] when the subgraph returns no entries", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({ vaultHistories: [] });
+
+    expect(await fetchHistory()).toEqual([]);
+  });
+
+  it("scales shareValue from 18-decimal wad to number and converts timestamp to ms", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultHistories: [
+        { shareValue: "1000412938421000000", timestamp: "1707782400" },
+        { shareValue: "1000506129482000000", timestamp: "1707868800" },
+      ],
+    });
+
+    expect(await fetchHistory()).toEqual([
+      { shareValue: 1.000412938421, timestamp: 1_707_782_400_000 },
+      { shareValue: 1.000506129482, timestamp: 1_707_868_800_000 },
+    ]);
+  });
+
+  it("makes a second request when the first page returns exactly 100 entries", async function () {
+    vi.mocked(graphql.runQuery)
+      .mockResolvedValueOnce({ vaultHistories: buildPage(100) })
+      .mockResolvedValueOnce({ vaultHistories: [] });
+
+    const result = await fetchHistory("1y");
+
+    expect(result).toHaveLength(100);
+    expect(graphql.runQuery).toHaveBeenCalledTimes(2);
+    expect(
+      (vi.mocked(graphql.runQuery).mock.calls[0][2] as { skip: number }).skip,
+    ).toBe(0);
+    expect(
+      (vi.mocked(graphql.runQuery).mock.calls[1][2] as { skip: number }).skip,
+    ).toBe(100);
+  });
+
+  it("concatenates results across multiple full pages and a partial last page", async function () {
+    vi.mocked(graphql.runQuery)
+      .mockResolvedValueOnce({ vaultHistories: buildPage(100, 1_700_000_000) })
+      .mockResolvedValueOnce({ vaultHistories: buildPage(100, 1_708_640_000) })
+      .mockResolvedValueOnce({ vaultHistories: buildPage(37, 1_717_280_000) });
+
+    const result = await fetchHistory("1y");
+
+    expect(result).toHaveLength(237);
+    expect(graphql.runQuery).toHaveBeenCalledTimes(3);
+    expect(result[0].timestamp).toBe(1_700_000_000_000);
+    expect(result[100].timestamp).toBe(1_708_640_000_000);
+    expect(result[200].timestamp).toBe(1_717_280_000_000);
+  });
+
+  it("breaks at the hard cap to bound runaway pagination", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultHistories: buildPage(100),
+    });
+
+    const result = await fetchHistory("1y");
+
+    expect(result).toHaveLength(400);
+    expect(graphql.runQuery).toHaveBeenCalledTimes(4);
+  });
+
+  it("throws when the subgraph response is malformed", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultHistories: undefined,
+    } as never);
+
+    await expect(fetchHistory()).rejects.toThrow(/Invalid subgraph response/);
+  });
+
+  it("queries the subgraph with the staking vault address lowercased", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({ vaultHistories: [] });
+
+    await fetchHistory();
+
+    expect(lastCallVariables<{ stakingVault: string }>()?.stakingVault).toBe(
+      sVusdAddress.toLowerCase(),
+    );
+  });
+
+  describe("start timestamp computation", function () {
+    const now = new Date("2026-05-04T00:00:00Z");
+    const nowSecs = Math.floor(now.getTime() / 1000);
+    const secsPerDay = 86400;
+
+    beforeEach(function () {
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+      vi.mocked(graphql.runQuery).mockResolvedValue({ vaultHistories: [] });
+    });
+
+    afterEach(function () {
+      vi.useRealTimers();
+    });
+
+    it.each([
+      ["1w", 7 * secsPerDay],
+      ["1m", 30 * secsPerDay],
+      ["3m", 90 * secsPerDay],
+      ["1y", 366 * secsPerDay],
+    ])(
+      "subtracts the right offset from now for period %s",
+      async function (period, offset) {
+        await fetchHistory(period);
+
+        expect(lastCallVariables<{ start: string }>()?.start).toBe(
+          (nowSecs - offset).toString(),
+        );
+      },
+    );
+  });
+});

--- a/web/src/components/borrow/historicApr.tsx
+++ b/web/src/components/borrow/historicApr.tsx
@@ -96,10 +96,10 @@ const EmptyChart = ({
 );
 
 const periodLabelKeys = {
-  "1m": "pages.borrow.period-1-month",
-  "1w": "pages.borrow.period-1-week",
-  "1y": "pages.borrow.period-1-year",
-  "3m": "pages.borrow.period-3-month",
+  "1m": "common.charts.period-1-month",
+  "1w": "common.charts.period-1-week",
+  "1y": "common.charts.period-1-year",
+  "3m": "common.charts.period-3-month",
 } as const;
 
 const ArrowPathIcon = () => (
@@ -227,7 +227,7 @@ export function HistoricApr({ marketId }: Props) {
                 <span className="opacity-72">
                   <ArrowPathIcon />
                 </span>
-                {t("pages.borrow.reload-chart")}
+                {t("common.charts.reload-chart")}
               </Button>
             </div>
           </>

--- a/web/src/hooks/useShareValueHistory.ts
+++ b/web/src/hooks/useShareValueHistory.ts
@@ -35,9 +35,13 @@ export const useShareValueHistory = function (
       );
       return data.map((entry) => ({ x: entry.timestamp, y: entry.shareValue }));
     },
+    // peggedToken.address is technically redundant — the gateway uniquely
+    // determines it via a 1:1 mapping. Included anyway to mirror every
+    // queryFn dependency in the cache key, per React Query's contract.
     queryKey: [
       "share-value-history",
       client?.chain?.id,
+      peggedToken?.address,
       peggedToken?.gatewayAddress,
       period,
     ],

--- a/web/src/hooks/useShareValueHistory.ts
+++ b/web/src/hooks/useShareValueHistory.ts
@@ -1,0 +1,46 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import fetch from "fetch-plus-plus";
+import { useEthereumClient } from "hooks/useEthereumClient";
+import { stakingVaultForPeggedTokenOptions } from "hooks/useStakingVaultForPeggedToken";
+import type { TokenWithGateway } from "types";
+import { isValidUrl } from "utils/url";
+
+export const shareValueHistoryPeriods = ["1w", "1m", "3m", "1y"] as const;
+export type ShareValueHistoryPeriod = (typeof shareValueHistoryPeriods)[number];
+
+type ApiEntry = { shareValue: number; timestamp: number };
+
+const apiUrl = import.meta.env.VITE_VETRO_API_URL;
+
+export const useShareValueHistory = function (
+  peggedToken: TokenWithGateway | undefined,
+  period: ShareValueHistoryPeriod,
+) {
+  const client = useEthereumClient();
+  const queryClient = useQueryClient();
+  return useQuery({
+    enabled:
+      !!client && !!peggedToken && apiUrl !== undefined && isValidUrl(apiUrl),
+    async queryFn() {
+      const stakingVaultAddress = await queryClient.ensureQueryData(
+        stakingVaultForPeggedTokenOptions({
+          chainId: client!.chain!.id,
+          client: client!,
+          peggedTokenAddress: peggedToken!.address,
+          queryClient,
+        }),
+      );
+      const data: ApiEntry[] = await fetch(
+        `${apiUrl}/variable-stake/share-value-history/${stakingVaultAddress}/${period}`,
+      );
+      return data.map((entry) => ({ x: entry.timestamp, y: entry.shareValue }));
+    },
+    queryKey: [
+      "share-value-history",
+      client?.chain?.id,
+      peggedToken?.gatewayAddress,
+      period,
+    ],
+    staleTime: 5 * 60 * 1000,
+  });
+};

--- a/web/src/hooks/useShareValueHistory.ts
+++ b/web/src/hooks/useShareValueHistory.ts
@@ -12,10 +12,13 @@ type ApiEntry = { shareValue: number; timestamp: number };
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
 
-export const useShareValueHistory = function (
-  peggedToken: TokenWithGateway | undefined,
-  period: ShareValueHistoryPeriod,
-) {
+export const useShareValueHistory = function ({
+  peggedToken,
+  period,
+}: {
+  peggedToken: TokenWithGateway | undefined;
+  period: ShareValueHistoryPeriod;
+}) {
   const client = useEthereumClient();
   const queryClient = useQueryClient();
   return useQuery({

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -2,6 +2,13 @@
   "common": {
     "approve-10x": "Approve 10x",
     "approve-10x-tooltip": "Approves up to 10× your transaction amount, reducing future approval steps. You can revoke it anytime.",
+    "charts": {
+      "period-1-month": "1 month",
+      "period-1-week": "1 week",
+      "period-1-year": "1 year",
+      "period-3-month": "3 months",
+      "reload-chart": "Reload chart"
+    },
     "clear-search": "Clear search",
     "connect-wallet": "Connect wallet",
     "enter-amount": "Enter an amount",
@@ -99,10 +106,6 @@
       "no-positions-description": "Deposit collateral to borrow {{symbol}} and put your assets to work.",
       "no-positions-title": "No active borrow position yet",
       "per-day": "/ day",
-      "period-1-month": "1 month",
-      "period-1-week": "1 week",
-      "period-1-year": "1 year",
-      "period-3-month": "3 months",
       "pool-size": "Pool size",
       "position-at-risk": "Position at risk",
       "position-review": "Position review",
@@ -118,7 +121,6 @@
         "supply-collateral-title": "Supply collateral",
         "title": "Borrow in progress"
       },
-      "reload-chart": "Reload chart",
       "repay-loan": "Repay loan",
       "repay-loan-progress": {
         "approve-description": "Approve the loan token spending",

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -38,6 +38,7 @@
       "collateralization-ratio-label": "Collateralization ratio",
       "exit-queue-label": "Total {{symbol}} on withdrawn cooldown",
       "liquid-reserves-label": "Liquid Reserves",
+      "peg-stability-label": "Peg stability",
       "reserve-buffer-label": "Reserve buffer",
       "staked-label": "Total {{symbol}} staked",
       "strategic-reserves-label": "Strategic Reserves",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -2,6 +2,13 @@
   "common": {
     "approve-10x": "Aprobar 10x",
     "approve-10x-tooltip": "Apruebe hasta 10× el monto de su transacción, reduciendo futuros pasos de aprobación. Puede revocarlo en cualquier momento.",
+    "charts": {
+      "period-1-month": "1 mes",
+      "period-1-week": "1 semana",
+      "period-1-year": "1 año",
+      "period-3-month": "3 meses",
+      "reload-chart": "Recargar gráfico"
+    },
     "clear-search": "Limpiar búsqueda",
     "connect-wallet": "Conectar billetera",
     "enter-amount": "Ingrese un monto",
@@ -99,10 +106,6 @@
       "no-positions-description": "Deposite garantía para pedir prestado {{symbol}} y poner sus activos a trabajar.",
       "no-positions-title": "Aún no hay posiciones de préstamos activos",
       "per-day": "/ día",
-      "period-1-month": "1 mes",
-      "period-1-week": "1 semana",
-      "period-1-year": "1 año",
-      "period-3-month": "3 meses",
       "pool-size": "Tamaño del fondo",
       "position-at-risk": "Posición en riesgo",
       "position-review": "Revisión de posición",
@@ -118,7 +121,6 @@
         "supply-collateral-title": "Depositar garantía",
         "title": "Préstamo en progreso"
       },
-      "reload-chart": "Recargar gráfico",
       "repay-loan": "Pagar préstamo",
       "repay-loan-progress": {
         "approve-description": "Apruebe el gasto del token de préstamo",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -38,6 +38,7 @@
       "collateralization-ratio-label": "Ratio de colateralización",
       "exit-queue-label": "Total {{symbol}} en período de espera de retiro",
       "liquid-reserves-label": "Reservas líquidas",
+      "peg-stability-label": "Estabilidad del peg",
       "reserve-buffer-label": "Reserva de liquidez",
       "staked-label": "Total {{symbol}} depositado",
       "strategic-reserves-label": "Reservas estratégicas",

--- a/web/src/pages/analytics/components/pegStabilityCard.tsx
+++ b/web/src/pages/analytics/components/pegStabilityCard.tsx
@@ -95,9 +95,13 @@ export function PegStabilityCard({ peggedToken, peggedTokenError }: Props) {
       >
         {isError ? (
           <div className="flex h-full items-center justify-center">
-            <Button onClick={() => refetch()} size="xSmall" variant="primary">
-              {t("common.charts.reload-chart")}
-            </Button>
+            {isHistoryError ? (
+              <Button onClick={() => refetch()} size="xSmall" variant="primary">
+                {t("common.charts.reload-chart")}
+              </Button>
+            ) : (
+              <span className="text-gray-500">-</span>
+            )}
           </div>
         ) : chartData === undefined ? (
           <Skeleton height={chartHeight} />

--- a/web/src/pages/analytics/components/pegStabilityCard.tsx
+++ b/web/src/pages/analytics/components/pegStabilityCard.tsx
@@ -1,0 +1,149 @@
+import { Button } from "components/base/button";
+import { SegmentedControl } from "components/base/segmentedControl";
+import {
+  type ShareValueHistoryPeriod,
+  shareValueHistoryPeriods,
+  useShareValueHistory,
+} from "hooks/useShareValueHistory";
+import { useLayoutEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import Skeleton from "react-loading-skeleton";
+import type { TokenWithGateway } from "types";
+import { formatDate, formatShortDate } from "utils/date";
+import {
+  VictoryAxis,
+  VictoryChart,
+  VictoryLine,
+  VictoryTooltip,
+  VictoryVoronoiContainer,
+} from "victory";
+
+type Props = {
+  peggedToken: TokenWithGateway | undefined;
+  peggedTokenError: boolean;
+};
+
+const chartHeight = 200;
+const chartPadding = { bottom: 30, left: 60, right: 16, top: 10 };
+
+const xAxisStyle = {
+  axis: { stroke: "transparent" },
+  tickLabels: { fill: "#6B7280", fontSize: 11 },
+};
+
+const yAxisStyle = {
+  ...xAxisStyle,
+  grid: { stroke: "#E5E7EB", strokeDasharray: "4,4" },
+};
+
+const periodLabelKeys = {
+  "1m": "common.charts.period-1-month",
+  "1w": "common.charts.period-1-week",
+  "1y": "common.charts.period-1-year",
+  "3m": "common.charts.period-3-month",
+} as const;
+
+const formatShareValue = (value: number) => value.toFixed(4);
+
+const useElementWidth = function () {
+  const ref = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+  useLayoutEffect(function observeWidth() {
+    if (!ref.current) return undefined;
+    const observer = new ResizeObserver(function ([entry]) {
+      setWidth(entry.contentRect.width);
+    });
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+  return [ref, width] as const;
+};
+
+export function PegStabilityCard({ peggedToken, peggedTokenError }: Props) {
+  const { i18n, t } = useTranslation();
+  const [period, setPeriod] = useState<ShareValueHistoryPeriod>("1w");
+  const [chartContainerRef, chartWidth] = useElementWidth();
+  const {
+    data: chartData,
+    isError: isHistoryError,
+    refetch,
+  } = useShareValueHistory(peggedToken, period);
+
+  const isError = peggedTokenError || isHistoryError;
+
+  return (
+    <div className="flex-1 px-3 py-6 md:px-14">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <span className="text-b-medium text-gray-900">
+          {t("pages.analytics.peg-stability-label")}
+        </span>
+        <SegmentedControl
+          onChange={setPeriod}
+          options={shareValueHistoryPeriods.map((p) => ({
+            label: t(periodLabelKeys[p]),
+            value: p,
+          }))}
+          size="xs"
+          value={period}
+          variant="pill"
+        />
+      </div>
+      <div
+        className="relative mt-6 md:mt-8"
+        ref={chartContainerRef}
+        style={{ height: chartHeight }}
+      >
+        {isError ? (
+          <div className="flex h-full items-center justify-center">
+            <Button onClick={() => refetch()} size="xSmall" variant="primary">
+              {t("common.charts.reload-chart")}
+            </Button>
+          </div>
+        ) : chartData === undefined ? (
+          <Skeleton height={chartHeight} />
+        ) : (
+          <VictoryChart
+            containerComponent={
+              <VictoryVoronoiContainer
+                labelComponent={
+                  <VictoryTooltip
+                    constrainToVisibleArea
+                    cornerRadius={8}
+                    flyoutPadding={{ bottom: 8, left: 12, right: 12, top: 8 }}
+                    flyoutStyle={{ fill: "white", stroke: "#E5E7EB" }}
+                    pointerLength={0}
+                    style={{ fontSize: 11 }}
+                  />
+                }
+                labels={({ datum }: { datum: { x: number; y: number } }) =>
+                  `${formatDate(datum.x / 1000, i18n.language)}  ${formatShareValue(datum.y)}`
+                }
+              />
+            }
+            height={chartHeight}
+            padding={chartPadding}
+            width={chartWidth || undefined}
+          >
+            <VictoryAxis
+              style={xAxisStyle}
+              tickCount={4}
+              tickFormat={(tick: number) =>
+                formatShortDate(tick / 1000, i18n.language)
+              }
+            />
+            <VictoryAxis
+              dependentAxis
+              style={yAxisStyle}
+              tickFormat={formatShareValue}
+            />
+            <VictoryLine
+              data={chartData}
+              interpolation="linear"
+              style={{ data: { stroke: "#416BFF", strokeWidth: 2 } }}
+            />
+          </VictoryChart>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/analytics/components/pegStabilityCard.tsx
+++ b/web/src/pages/analytics/components/pegStabilityCard.tsx
@@ -67,7 +67,7 @@ export function PegStabilityCard({ peggedToken, peggedTokenError }: Props) {
     data: chartData,
     isError: isHistoryError,
     refetch,
-  } = useShareValueHistory(peggedToken, period);
+  } = useShareValueHistory({ peggedToken, period });
 
   const isError = peggedTokenError || isHistoryError;
 

--- a/web/src/pages/analytics/index.tsx
+++ b/web/src/pages/analytics/index.tsx
@@ -9,6 +9,7 @@ import Skeleton from "react-loading-skeleton";
 
 import { CollateralizationCard } from "./components/collateralizationCard";
 import { ExitQueueCard } from "./components/exitQueueCard";
+import { PegStabilityCard } from "./components/pegStabilityCard";
 import { StakedCard } from "./components/stakedCard";
 import { TokenFilter } from "./components/tokenFilter";
 import { TvlCard } from "./components/tvlCard";
@@ -106,6 +107,12 @@ export const Analytics = function () {
           peggedTokenError={isPeggedTokensError}
         />
         <ExitQueueCard
+          peggedToken={selectedToken}
+          peggedTokenError={isPeggedTokensError}
+        />
+      </AllocationRow>
+      <AllocationRow>
+        <PegStabilityCard
           peggedToken={selectedToken}
           peggedTokenError={isPeggedTokensError}
         />


### PR DESCRIPTION
### Description

Adds a peg-stability line chart to the analytics page that plots the share value of the staking-vault Earn token (e.g. sVUSD) against the underlying pegged token (e.g. VUSD) over a 1w/1m/3m/1y window. Drift away from 1.0 is the visual signal of yield accruing or peg instability.

The change ships as three reviewable commits — an i18n refactor, then the API endpoint, then the frontend chart that consumes it.

**Commits:**

- 60069df Move chart i18n keys to common.charts
- b64a407 Add share-value-history endpoint to API
- 7ac95fc Add peg-stability chart to analytics page

### Screenshots

Current real data (Share equals pegged token)

<img width="2666" height="1158" alt="image" src="https://github.com/user-attachments/assets/c87b4507-826e-4df7-845d-cdf5caf781e0" />

Mocked data

<img width="2386" height="866" alt="image" src="https://github.com/user-attachments/assets/3c822d54-b446-46ea-b6f7-dea0bde878da" />

Hovering

<img width="2242" height="856" alt="image" src="https://github.com/user-attachments/assets/ab065bce-5353-4d04-9512-b59a085d3fd6" />


### Related issue(s)

Closes #364
Related to #365

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.