### PR TITLE
Add LayerZero OFT bridge package

### DIFF
--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -1,0 +1,104 @@
+# @vetro-protocol/bridge
+
+LayerZero V2 OFT/OFTAdapter bridge actions for viem clients. Generic — works with any pair of tokens that have OFT contracts deployed on the supported chains.
+
+## Installation
+
+```sh
+pnpm add @vetro-protocol/bridge viem viem-erc20
+```
+
+## Overview
+
+- Works with both pure OFT contracts and OFTAdapter contracts.
+- Approval is auto-detected via on-chain `approvalRequired()`. When required, the underlying ERC20 is read from `token()` and the standard allowance/approve flow runs before the send.
+- Caller owns chain/contract addressing; the package only knows the `chainId → LayerZero EID` mapping (see `layerZeroEids`).
+- Slippage defaults to zero (`minAmountLD === amount`); pass `minAmount` to opt in to a tolerance.
+
+Supported chains (chainId → LayerZero EID):
+
+| Chain            | chainId | EID   |
+| ---------------- | ------- | ----- |
+| Ethereum mainnet | 1       | 30101 |
+| Optimism         | 10      | 30111 |
+| BSC              | 56      | 30102 |
+| Base             | 8453    | 30184 |
+| Arbitrum         | 42161   | 30110 |
+| Hemi             | 43111   | 30329 |
+
+## Usage
+
+```ts
+import { quoteSend, send } from "@vetro-protocol/bridge/actions";
+import { createPublicClient, createWalletClient, custom, http } from "viem";
+import { hemi, mainnet } from "viem/chains";
+
+const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: http(),
+});
+
+const walletClient = createWalletClient({
+  chain: mainnet,
+  transport: custom(window.ethereum),
+});
+
+// 1. Quote the LayerZero messaging fee
+const fee = await quoteSend(publicClient, {
+  amount: 1_000_000_000_000_000_000n,
+  destinationChainId: hemi.id,
+  oftAddress: "0x5fFD0EAdc186AF9512542d0d5e5eAFC65d5aFc5B",
+  recipient: "0x...",
+});
+
+// 2. Send (approval handled automatically when the OFT requires it)
+const { emitter, promise } = send(walletClient, {
+  amount: 1_000_000_000_000_000_000n,
+  destinationChainId: hemi.id,
+  oftAddress: "0x5fFD0EAdc186AF9512542d0d5e5eAFC65d5aFc5B",
+  recipient: "0x...",
+});
+
+emitter.on("user-signed-send", (hash) => console.log("tx hash:", hash));
+emitter.on("send-transaction-succeeded", (receipt) =>
+  console.log("delivered:", receipt),
+);
+
+await promise;
+```
+
+The same actions are also available via `.extend()` factories (`bridgePublicActions()`, `bridgeWalletActions()`) for callers who prefer viem's extension pattern.
+
+## Events
+
+The `send` wallet action emits the following events through the `EventEmitter`:
+
+| Event                           | Payload                | When                                                                                                                  |
+| ------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `pre-approve`                   | `[]`                   | Before the ERC20 approval transaction (only when `approvalRequired() === true` and current allowance is insufficient) |
+| `user-signed-approval`          | `[Hash]`               | The user signed the approval transaction                                                                              |
+| `user-signing-approval-error`   | `[Error]`              | The user rejected or otherwise failed to sign the approval                                                            |
+| `approve-transaction-succeeded` | `[TransactionReceipt]` | Approval transaction confirmed successfully                                                                           |
+| `approve-transaction-reverted`  | `[TransactionReceipt]` | Approval transaction reverted on-chain                                                                                |
+| `pre-send`                      | `[]`                   | Before the OFT `send` transaction                                                                                     |
+| `user-signed-send`              | `[Hash]`               | The user signed the send transaction                                                                                  |
+| `user-signing-send-error`       | `[Error]`              | The user rejected or otherwise failed to sign the send                                                                |
+| `send-transaction-succeeded`    | `[TransactionReceipt]` | Send transaction confirmed successfully                                                                               |
+| `send-transaction-reverted`     | `[TransactionReceipt]` | Send transaction reverted on-chain                                                                                    |
+| `send-failed`                   | `[Error]`              | A transaction-receipt fetch failed                                                                                    |
+| `send-failed-validation`        | `[string]`             | Input validation failed; payload is a human-readable reason                                                           |
+| `unexpected-error`              | `[Error]`              | An unhandled error escaped the action                                                                                 |
+| `send-settled`                  | `[]`                   | Always emitted in the `finally` block                                                                                 |
+
+## API
+
+- `quoteSend(client, params)` — public action; reads the LayerZero messaging fee for a send.
+- `approvalRequired(client, params)` — public action; reads `approvalRequired()` on the OFT/OFTAdapter.
+- `token(client, params)` — public action; reads the underlying ERC20 wrapped by an OFTAdapter.
+- `send(walletClient, params)` — wallet action; runs the full bridge flow (auto-approval + send) and returns `{ emitter, promise }`.
+- `encodeSend(params)` — synchronous helper that returns the encoded `send` calldata. The caller must pre-quote the LayerZero fee (e.g. with `quoteSend`) and pass it in.
+- `bridgePublicActions()` / `bridgeWalletActions()` — viem extension factories that wire the same actions onto a client via `.extend()`.
+- `getLayerZeroEid(chainId)`, `layerZeroEids` — chainId → EID lookup helpers.
+- `addressToBytes32(addr)` — pads an address to bytes32 for LayerZero `to` fields.
+- `oftAbi` — the minimal ABI subset used by the package (`send`, `quoteSend`, `approvalRequired`, `token`).
+- Types: `SendEvents`, `ApprovalEvents`, `CommonEvents`, `MessagingFee`, `SendParams`, `QuoteSendParams`.

--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -12,7 +12,7 @@ pnpm add @vetro-protocol/bridge viem viem-erc20
 
 - Works with both pure OFT contracts and OFTAdapter contracts.
 - Approval is auto-detected via on-chain `approvalRequired()`. When required, the underlying ERC20 is read from `token()` and the standard allowance/approve flow runs before the send.
-- Caller owns chain/contract addressing; the package only knows the `chainId → LayerZero EID` mapping (see `layerZeroEids`).
+- Caller owns chain/contract addressing; the package only knows the `chainId → LayerZero EID` mapping (see the table below).
 - Slippage defaults to zero (`minAmountLD === amount`); pass `minAmount` to opt in to a tolerance.
 
 Supported chains (chainId → LayerZero EID):
@@ -98,7 +98,5 @@ The `send` wallet action emits the following events through the `EventEmitter`:
 - `send(walletClient, params)` — wallet action; runs the full bridge flow (auto-approval + send) and returns `{ emitter, promise }`.
 - `encodeSend(params)` — synchronous helper that returns the encoded `send` calldata. The caller must pre-quote the LayerZero fee (e.g. with `quoteSend`) and pass it in.
 - `bridgePublicActions()` / `bridgeWalletActions()` — viem extension factories that wire the same actions onto a client via `.extend()`.
-- `getLayerZeroEid(chainId)`, `layerZeroEids` — chainId → EID lookup helpers.
-- `addressToBytes32(addr)` — pads an address to bytes32 for LayerZero `to` fields.
 - `oftAbi` — the minimal ABI subset used by the package (`send`, `quoteSend`, `approvalRequired`, `token`).
-- Types: `SendEvents`, `ApprovalEvents`, `CommonEvents`, `MessagingFee`, `SendParams`, `QuoteSendParams`.
+- Types: `SendEvents`.

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@vetro-protocol/bridge",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "to-promise-event": "1.0.0",
+    "viem-erc20": "2.1.0"
+  },
+  "devDependencies": {
+    "@tsconfig/node24": "24.0.4",
+    "@vitest/coverage-v8": "4.0.18",
+    "typescript": "5.9.3",
+    "viem": "2.44.4",
+    "vitest": "4.0.18"
+  },
+  "peerDependencies": {
+    "viem": "^2.x"
+  },
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./actions": {
+      "types": "./src/actions/index.ts",
+      "default": "./src/actions/index.ts"
+    }
+  }
+}

--- a/packages/bridge/src/abi/oftAbi.ts
+++ b/packages/bridge/src/abi/oftAbi.ts
@@ -1,0 +1,102 @@
+export const oftAbi = [
+  {
+    inputs: [],
+    name: "approvalRequired",
+    outputs: [{ type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { name: "dstEid", type: "uint32" },
+          { name: "to", type: "bytes32" },
+          { name: "amountLD", type: "uint256" },
+          { name: "minAmountLD", type: "uint256" },
+          { name: "extraOptions", type: "bytes" },
+          { name: "composeMsg", type: "bytes" },
+          { name: "oftCmd", type: "bytes" },
+        ],
+        name: "sendParam",
+        type: "tuple",
+      },
+      { name: "payInLzToken", type: "bool" },
+    ],
+    name: "quoteSend",
+    outputs: [
+      {
+        components: [
+          { name: "nativeFee", type: "uint256" },
+          { name: "lzTokenFee", type: "uint256" },
+        ],
+        name: "msgFee",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { name: "dstEid", type: "uint32" },
+          { name: "to", type: "bytes32" },
+          { name: "amountLD", type: "uint256" },
+          { name: "minAmountLD", type: "uint256" },
+          { name: "extraOptions", type: "bytes" },
+          { name: "composeMsg", type: "bytes" },
+          { name: "oftCmd", type: "bytes" },
+        ],
+        name: "sendParam",
+        type: "tuple",
+      },
+      {
+        components: [
+          { name: "nativeFee", type: "uint256" },
+          { name: "lzTokenFee", type: "uint256" },
+        ],
+        name: "fee",
+        type: "tuple",
+      },
+      { name: "refundAddress", type: "address" },
+    ],
+    name: "send",
+    outputs: [
+      {
+        components: [
+          { name: "guid", type: "bytes32" },
+          { name: "nonce", type: "uint64" },
+          {
+            components: [
+              { name: "nativeFee", type: "uint256" },
+              { name: "lzTokenFee", type: "uint256" },
+            ],
+            name: "fee",
+            type: "tuple",
+          },
+        ],
+        name: "msgReceipt",
+        type: "tuple",
+      },
+      {
+        components: [
+          { name: "amountSentLD", type: "uint256" },
+          { name: "amountReceivedLD", type: "uint256" },
+        ],
+        name: "oftReceipt",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "token",
+    outputs: [{ type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;

--- a/packages/bridge/src/actions/index.ts
+++ b/packages/bridge/src/actions/index.ts
@@ -1,0 +1,7 @@
+// Public actions
+export * from "./public/approvalRequired.js";
+export * from "./public/quoteSend.js";
+export * from "./public/token.js";
+
+// Wallet actions
+export * from "./wallet/send.js";

--- a/packages/bridge/src/actions/public/approvalRequired.ts
+++ b/packages/bridge/src/actions/public/approvalRequired.ts
@@ -1,0 +1,37 @@
+import { type Address, type Client } from "viem";
+import { readContract } from "viem/actions";
+
+import { oftAbi } from "../../abi/oftAbi.js";
+import { isAddressValid } from "../../utils/isAddressValid.js";
+
+export type ApprovalRequiredParams = {
+  oftAddress: Address;
+};
+
+// Pure OFT contracts own their token ledger and debit the sender directly,
+// so no ERC20 allowance is needed. OFTAdapter contracts wrap a pre-existing
+// ERC20 and must `transferFrom` it into custody, which requires approval.
+export async function approvalRequired(
+  client: Client,
+  parameters: ApprovalRequiredParams,
+): Promise<boolean> {
+  if (!client) {
+    throw new Error("Client is not defined");
+  }
+
+  if (!parameters) {
+    throw new Error("Parameters are required");
+  }
+
+  const { oftAddress } = parameters;
+
+  if (!isAddressValid(oftAddress)) {
+    throw new Error("OFT address is invalid");
+  }
+
+  return readContract(client, {
+    abi: oftAbi,
+    address: oftAddress,
+    functionName: "approvalRequired",
+  });
+}

--- a/packages/bridge/src/actions/public/quoteSend.ts
+++ b/packages/bridge/src/actions/public/quoteSend.ts
@@ -1,0 +1,57 @@
+import { type Client } from "viem";
+import { readContract } from "viem/actions";
+
+import { oftAbi } from "../../abi/oftAbi.js";
+import { getLayerZeroEid } from "../../layerZeroEids.js";
+import type { MessagingFee, QuoteSendParams } from "../../types.js";
+import { addressToBytes32 } from "../../utils/addressToBytes32.js";
+import { isAddressValid } from "../../utils/isAddressValid.js";
+
+export async function quoteSend(
+  client: Client,
+  parameters: QuoteSendParams,
+): Promise<MessagingFee> {
+  if (!client) {
+    throw new Error("Client is not defined");
+  }
+
+  if (!parameters) {
+    throw new Error("Parameters are required");
+  }
+
+  const { amount, destinationChainId, minAmount, oftAddress, recipient } =
+    parameters;
+
+  if (!isAddressValid(oftAddress)) {
+    throw new Error("OFT address is invalid");
+  }
+
+  if (!isAddressValid(recipient)) {
+    throw new Error("Recipient address is invalid");
+  }
+
+  if (typeof amount !== "bigint") {
+    throw new Error("Amount must be a bigint");
+  }
+
+  if (amount <= 0n) {
+    throw new Error("Amount must be greater than 0");
+  }
+
+  const sendParam = {
+    amountLD: amount,
+    composeMsg: "0x" as const,
+    dstEid: getLayerZeroEid(destinationChainId),
+    extraOptions: "0x" as const,
+    minAmountLD: minAmount ?? amount,
+    oftCmd: "0x" as const,
+    to: addressToBytes32(recipient),
+  };
+
+  return readContract(client, {
+    abi: oftAbi,
+    address: oftAddress,
+    args: [sendParam, false],
+    functionName: "quoteSend",
+  });
+}

--- a/packages/bridge/src/actions/public/quoteSend.ts
+++ b/packages/bridge/src/actions/public/quoteSend.ts
@@ -38,6 +38,18 @@ export async function quoteSend(
     throw new Error("Amount must be greater than 0");
   }
 
+  if (minAmount !== undefined) {
+    if (typeof minAmount !== "bigint") {
+      throw new Error("Min amount must be a bigint");
+    }
+    if (minAmount <= 0n) {
+      throw new Error("Min amount must be greater than 0");
+    }
+    if (minAmount > amount) {
+      throw new Error("Min amount must be less than or equal to amount");
+    }
+  }
+
   const sendParam = {
     amountLD: amount,
     composeMsg: "0x" as const,

--- a/packages/bridge/src/actions/public/token.ts
+++ b/packages/bridge/src/actions/public/token.ts
@@ -1,0 +1,37 @@
+import { type Address, type Client } from "viem";
+import { readContract } from "viem/actions";
+
+import { oftAbi } from "../../abi/oftAbi.js";
+import { isAddressValid } from "../../utils/isAddressValid.js";
+
+export type TokenParams = {
+  oftAddress: Address;
+};
+
+// Returns the underlying ERC20 address an OFT/OFTAdapter wraps. For pure OFT
+// contracts this typically returns the OFT address itself; for OFTAdapter
+// contracts it returns the wrapped ERC20 (the contract callers must approve).
+export async function token(
+  client: Client,
+  parameters: TokenParams,
+): Promise<Address> {
+  if (!client) {
+    throw new Error("Client is not defined");
+  }
+
+  if (!parameters) {
+    throw new Error("Parameters are required");
+  }
+
+  const { oftAddress } = parameters;
+
+  if (!isAddressValid(oftAddress)) {
+    throw new Error("OFT address is invalid");
+  }
+
+  return readContract(client, {
+    abi: oftAbi,
+    address: oftAddress,
+    functionName: "token",
+  });
+}

--- a/packages/bridge/src/actions/wallet/send.ts
+++ b/packages/bridge/src/actions/wallet/send.ts
@@ -101,9 +101,10 @@ const canSend = function ({
 
 const runSend = (walletClient: WalletClient, params: SendParams) =>
   async function (emitter: EventEmitter<SendEvents>) {
-    const { amount, destinationChainId, oftAddress, recipient } = params;
-    const approveAmount = params.approveAmount ?? amount;
-    const minAmount = params.minAmount ?? amount;
+    const { amount, destinationChainId, oftAddress, recipient } =
+      params ?? ({} as SendParams);
+    const approveAmount = params?.approveAmount ?? amount;
+    const minAmount = params?.minAmount ?? amount;
 
     try {
       const { canSend: canSendFlag, reason } = canSend({
@@ -111,7 +112,7 @@ const runSend = (walletClient: WalletClient, params: SendParams) =>
         approveAmount,
         client: walletClient,
         destinationChainId,
-        minAmount: params.minAmount,
+        minAmount: params?.minAmount,
         oftAddress,
         recipient,
       });

--- a/packages/bridge/src/actions/wallet/send.ts
+++ b/packages/bridge/src/actions/wallet/send.ts
@@ -77,6 +77,9 @@ const canSend = function ({
       };
     }
   }
+  if (typeof approveAmount !== "bigint") {
+    return { canSend: false, reason: "Approve amount must be a bigint" };
+  }
   if (approveAmount < amount) {
     return {
       canSend: false,

--- a/packages/bridge/src/actions/wallet/send.ts
+++ b/packages/bridge/src/actions/wallet/send.ts
@@ -1,0 +1,278 @@
+import { EventEmitter } from "events";
+import { toPromiseEvent } from "to-promise-event";
+import {
+  type Address,
+  type TransactionReceipt,
+  type WalletClient,
+  encodeFunctionData,
+} from "viem";
+import {
+  readContract,
+  simulateContract,
+  waitForTransactionReceipt,
+  writeContract,
+} from "viem/actions";
+import { allowance, approve } from "viem-erc20/actions";
+
+import { oftAbi } from "../../abi/oftAbi.js";
+import { getLayerZeroEid, layerZeroEids } from "../../layerZeroEids.js";
+import type { MessagingFee, SendEvents, SendParams } from "../../types.js";
+import { addressToBytes32 } from "../../utils/addressToBytes32.js";
+import { isAddressValid } from "../../utils/isAddressValid.js";
+import { approvalRequired } from "../public/approvalRequired.js";
+import { token } from "../public/token.js";
+
+const canSend = function ({
+  amount,
+  approveAmount,
+  client,
+  destinationChainId,
+  minAmount,
+  oftAddress,
+  recipient,
+}: {
+  amount: bigint;
+  approveAmount: bigint;
+  client: WalletClient;
+  destinationChainId: number;
+  minAmount?: bigint;
+  oftAddress: Address;
+  recipient: Address;
+}): {
+  canSend: boolean;
+  reason?: string;
+} {
+  if (!client) {
+    return { canSend: false, reason: "Client is not defined" };
+  }
+  if (!client.chain) {
+    return { canSend: false, reason: "Chain is not defined on wallet client" };
+  }
+  if (!client.account) {
+    return { canSend: false, reason: "Client must have an account" };
+  }
+  if (!isAddressValid(oftAddress)) {
+    return { canSend: false, reason: "OFT address is invalid" };
+  }
+  if (!isAddressValid(recipient)) {
+    return { canSend: false, reason: "Recipient address is invalid" };
+  }
+  if (typeof amount !== "bigint") {
+    return { canSend: false, reason: "Amount must be a bigint" };
+  }
+  if (amount <= 0n) {
+    return { canSend: false, reason: "Amount must be greater than 0" };
+  }
+  if (minAmount !== undefined) {
+    if (typeof minAmount !== "bigint") {
+      return { canSend: false, reason: "Min amount must be a bigint" };
+    }
+    if (minAmount <= 0n) {
+      return { canSend: false, reason: "Min amount must be greater than 0" };
+    }
+    if (minAmount > amount) {
+      return {
+        canSend: false,
+        reason: "Min amount must be less than or equal to amount",
+      };
+    }
+  }
+  if (approveAmount < amount) {
+    return {
+      canSend: false,
+      reason: "Approve amount must be greater than or equal to amount",
+    };
+  }
+  if (destinationChainId === client.chain.id) {
+    return {
+      canSend: false,
+      reason: "Destination chain must be different from source chain",
+    };
+  }
+  if (layerZeroEids[destinationChainId] === undefined) {
+    return { canSend: false, reason: "Unsupported destination chain" };
+  }
+
+  return { canSend: true };
+};
+
+const runSend = (walletClient: WalletClient, params: SendParams) =>
+  async function (emitter: EventEmitter<SendEvents>) {
+    const { amount, destinationChainId, oftAddress, recipient } = params;
+    const approveAmount = params.approveAmount ?? amount;
+    const minAmount = params.minAmount ?? amount;
+
+    try {
+      const { canSend: canSendFlag, reason } = canSend({
+        amount,
+        approveAmount,
+        client: walletClient,
+        destinationChainId,
+        minAmount: params.minAmount,
+        oftAddress,
+        recipient,
+      });
+
+      if (!canSendFlag) {
+        emitter.emit("send-failed-validation", reason!);
+        return;
+      }
+
+      const refundAddress = walletClient.account!.address;
+
+      const sendParam = {
+        amountLD: amount,
+        composeMsg: "0x" as const,
+        dstEid: getLayerZeroEid(destinationChainId),
+        extraOptions: "0x" as const,
+        minAmountLD: minAmount,
+        oftCmd: "0x" as const,
+        to: addressToBytes32(recipient),
+      };
+
+      const needsApproval = await approvalRequired(walletClient, {
+        oftAddress,
+      });
+
+      if (needsApproval) {
+        const tokenAddress = await token(walletClient, { oftAddress });
+
+        const currentAllowance = await allowance(walletClient, {
+          address: tokenAddress,
+          owner: walletClient.account!.address,
+          spender: oftAddress,
+        });
+
+        if (currentAllowance < amount) {
+          emitter.emit("pre-approve");
+
+          const approvalHash = await approve(walletClient, {
+            address: tokenAddress,
+            amount: approveAmount,
+            spender: oftAddress,
+          }).catch(function (error: Error) {
+            emitter.emit("user-signing-approval-error", error);
+          });
+
+          if (!approvalHash) {
+            return;
+          }
+
+          emitter.emit("user-signed-approval", approvalHash);
+
+          const approvalReceipt = await waitForTransactionReceipt(
+            walletClient,
+            {
+              hash: approvalHash,
+            },
+          ).catch(function (error: Error) {
+            emitter.emit("send-failed", error);
+          });
+
+          if (!approvalReceipt) {
+            return;
+          }
+
+          if (approvalReceipt.status === "reverted") {
+            emitter.emit("approve-transaction-reverted", approvalReceipt);
+            return;
+          }
+
+          emitter.emit("approve-transaction-succeeded", approvalReceipt);
+        }
+      }
+
+      const fee = await readContract(walletClient, {
+        abi: oftAbi,
+        address: oftAddress,
+        args: [sendParam, false],
+        functionName: "quoteSend",
+      });
+
+      emitter.emit("pre-send");
+
+      const { request } = await simulateContract(walletClient, {
+        abi: oftAbi,
+        account: walletClient.account!,
+        address: oftAddress,
+        args: [sendParam, fee, refundAddress],
+        chain: walletClient.chain,
+        functionName: "send",
+        value: fee.nativeFee,
+      });
+
+      const sendHash = await writeContract(walletClient, request).catch(
+        function (error: Error) {
+          emitter.emit("user-signing-send-error", error);
+        },
+      );
+
+      if (!sendHash) {
+        return;
+      }
+
+      emitter.emit("user-signed-send", sendHash);
+
+      const sendReceipt = await waitForTransactionReceipt(walletClient, {
+        hash: sendHash,
+      }).catch(function (error: Error) {
+        emitter.emit("send-failed", error);
+      });
+
+      if (!sendReceipt) {
+        return;
+      }
+
+      const sendEventMap: Record<
+        TransactionReceipt["status"],
+        keyof SendEvents
+      > = {
+        reverted: "send-transaction-reverted",
+        success: "send-transaction-succeeded",
+      };
+
+      emitter.emit(sendEventMap[sendReceipt.status], sendReceipt);
+    } catch (error) {
+      emitter.emit("unexpected-error", error as Error);
+    } finally {
+      emitter.emit("send-settled");
+    }
+  };
+
+export const send = (...args: Parameters<typeof runSend>) =>
+  toPromiseEvent<SendEvents>(runSend(...args));
+
+export type EncodeSendParams = {
+  amount: bigint;
+  destinationChainId: number;
+  fee: MessagingFee;
+  minAmount?: bigint;
+  recipient: Address;
+  refundAddress: Address;
+};
+
+export const encodeSend = ({
+  amount,
+  destinationChainId,
+  fee,
+  minAmount,
+  recipient,
+  refundAddress,
+}: EncodeSendParams) =>
+  encodeFunctionData({
+    abi: oftAbi,
+    args: [
+      {
+        amountLD: amount,
+        composeMsg: "0x" as const,
+        dstEid: getLayerZeroEid(destinationChainId),
+        extraOptions: "0x" as const,
+        minAmountLD: minAmount ?? amount,
+        oftCmd: "0x" as const,
+        to: addressToBytes32(recipient),
+      },
+      fee,
+      refundAddress,
+    ],
+    functionName: "send",
+  });

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -1,0 +1,29 @@
+import type { Client, WalletClient } from "viem";
+
+import { approvalRequired } from "./actions/public/approvalRequired.js";
+import { quoteSend } from "./actions/public/quoteSend.js";
+import { token } from "./actions/public/token.js";
+import { send } from "./actions/wallet/send.js";
+import type { SendParams } from "./types.js";
+
+// Export ABI
+export { oftAbi } from "./abi/oftAbi.js";
+
+// Export types
+export type { SendEvents } from "./types.js";
+
+// Export encoders
+export { encodeSend } from "./actions/wallet/send.js";
+
+// Export factory functions for .extend() pattern
+export const bridgePublicActions = () => (client: Client) => ({
+  approvalRequired: (params: Parameters<typeof approvalRequired>[1]) =>
+    approvalRequired(client, params),
+  quoteSend: (params: Parameters<typeof quoteSend>[1]) =>
+    quoteSend(client, params),
+  token: (params: Parameters<typeof token>[1]) => token(client, params),
+});
+
+export const bridgeWalletActions = () => (client: WalletClient) => ({
+  send: (params: SendParams) => send(client, params),
+});

--- a/packages/bridge/src/layerZeroEids.ts
+++ b/packages/bridge/src/layerZeroEids.ts
@@ -1,0 +1,18 @@
+import { arbitrum, base, bsc, hemi, mainnet, optimism } from "viem/chains";
+
+export const layerZeroEids: Record<number, number> = {
+  [arbitrum.id]: 30110,
+  [base.id]: 30184,
+  [bsc.id]: 30102,
+  [hemi.id]: 30329,
+  [mainnet.id]: 30101,
+  [optimism.id]: 30111,
+};
+
+export const getLayerZeroEid = function (chainId: number): number {
+  const eid = layerZeroEids[chainId];
+  if (eid === undefined) {
+    throw new Error(`No LayerZero EID registered for chainId ${chainId}`);
+  }
+  return eid;
+};

--- a/packages/bridge/src/types.ts
+++ b/packages/bridge/src/types.ts
@@ -1,0 +1,47 @@
+import type { Address, Chain, Hash, TransactionReceipt } from "viem";
+
+export type CommonEvents = {
+  "unexpected-error": [Error];
+};
+
+export type ApprovalEvents = {
+  "approve-transaction-reverted": [TransactionReceipt];
+  "approve-transaction-succeeded": [TransactionReceipt];
+  "pre-approve": [];
+  "user-signed-approval": [Hash];
+  "user-signing-approval-error": [Error];
+};
+
+export type SendEvents = ApprovalEvents &
+  CommonEvents & {
+    "pre-send": [];
+    "send-failed": [Error];
+    "send-failed-validation": [string];
+    "send-settled": [];
+    "send-transaction-reverted": [TransactionReceipt];
+    "send-transaction-succeeded": [TransactionReceipt];
+    "user-signed-send": [Hash];
+    "user-signing-send-error": [Error];
+  };
+
+export type MessagingFee = {
+  lzTokenFee: bigint;
+  nativeFee: bigint;
+};
+
+export type SendParams = {
+  amount: bigint;
+  approveAmount?: bigint;
+  destinationChainId: Chain["id"];
+  minAmount?: bigint;
+  oftAddress: Address;
+  recipient: Address;
+};
+
+export type QuoteSendParams = {
+  amount: bigint;
+  destinationChainId: Chain["id"];
+  minAmount?: bigint;
+  oftAddress: Address;
+  recipient: Address;
+};

--- a/packages/bridge/src/utils/addressToBytes32.ts
+++ b/packages/bridge/src/utils/addressToBytes32.ts
@@ -1,0 +1,4 @@
+import { type Address, type Hex, padHex } from "viem";
+
+export const addressToBytes32 = (address: Address): Hex =>
+  padHex(address, { size: 32 });

--- a/packages/bridge/src/utils/isAddressValid.ts
+++ b/packages/bridge/src/utils/isAddressValid.ts
@@ -1,0 +1,6 @@
+import { type Address, isAddress, isAddressEqual, zeroAddress } from "viem";
+
+export const isAddressValid = (
+  address: Address | undefined,
+): address is Address =>
+  !!address && isAddress(address) && !isAddressEqual(address, zeroAddress);

--- a/packages/bridge/test/public/approvalRequired.test.ts
+++ b/packages/bridge/test/public/approvalRequired.test.ts
@@ -1,0 +1,59 @@
+import { type Address, type Client, zeroAddress } from "viem";
+import { readContract } from "viem/actions";
+import { describe, expect, it, vi } from "vitest";
+
+import { approvalRequired } from "../../src/actions/public/approvalRequired";
+
+vi.mock("viem/actions", () => ({
+  readContract: vi.fn(),
+}));
+
+const validParameters = {
+  oftAddress: "0x1234567890123456789012345678901234567890" as Address,
+};
+
+// @ts-expect-error - We only create an empty client for testing purposes
+const client: Client = {};
+
+describe("approvalRequired", function () {
+  it("should throw an error if client is not defined", async function () {
+    await expect(
+      // @ts-expect-error - Testing invalid input
+      approvalRequired(undefined, validParameters),
+    ).rejects.toThrow("Client is not defined");
+  });
+
+  it("should throw an error if parameters are not provided", async function () {
+    // @ts-expect-error - Testing invalid input
+    await expect(approvalRequired(client, undefined)).rejects.toThrow(
+      "Parameters are required",
+    );
+  });
+
+  it("should throw an error if oftAddress is invalid", async function () {
+    const parameters = { oftAddress: "not_an_address" };
+    // @ts-expect-error - Testing invalid input
+    await expect(approvalRequired(client, parameters)).rejects.toThrow(
+      "OFT address is invalid",
+    );
+  });
+
+  it("should throw an error if oftAddress is zero address", async function () {
+    await expect(
+      approvalRequired(client, { oftAddress: zeroAddress }),
+    ).rejects.toThrow("OFT address is invalid");
+  });
+
+  it("should call readContract and return the boolean result", async function () {
+    vi.mocked(readContract).mockResolvedValueOnce(true);
+
+    const result = await approvalRequired(client, validParameters);
+
+    expect(readContract).toHaveBeenCalledWith(client, {
+      abi: expect.anything(),
+      address: validParameters.oftAddress,
+      functionName: "approvalRequired",
+    });
+    expect(result).toBe(true);
+  });
+});

--- a/packages/bridge/test/public/quoteSend.test.ts
+++ b/packages/bridge/test/public/quoteSend.test.ts
@@ -1,0 +1,129 @@
+import { type Address, type Client, padHex, zeroAddress } from "viem";
+import { readContract } from "viem/actions";
+import { hemi } from "viem/chains";
+import { describe, expect, it, vi } from "vitest";
+
+import { quoteSend } from "../../src/actions/public/quoteSend";
+
+vi.mock("viem/actions", () => ({
+  readContract: vi.fn(),
+}));
+
+const validParameters = {
+  amount: BigInt(1000),
+  destinationChainId: hemi.id,
+  oftAddress: "0x1234567890123456789012345678901234567890" as Address,
+  recipient: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" as Address,
+};
+
+// @ts-expect-error - We only create an empty client for testing purposes
+const client: Client = {};
+
+describe("quoteSend", function () {
+  it("should throw an error if client is not defined", async function () {
+    await expect(
+      // @ts-expect-error - Testing invalid input
+      quoteSend(undefined, validParameters),
+    ).rejects.toThrow("Client is not defined");
+  });
+
+  it("should throw an error if parameters are not provided", async function () {
+    // @ts-expect-error - Testing invalid input
+    await expect(quoteSend(client, undefined)).rejects.toThrow(
+      "Parameters are required",
+    );
+  });
+
+  it("should throw an error if oftAddress is invalid", async function () {
+    const parameters = { ...validParameters, oftAddress: "not_an_address" };
+    // @ts-expect-error - Testing invalid input
+    await expect(quoteSend(client, parameters)).rejects.toThrow(
+      "OFT address is invalid",
+    );
+  });
+
+  it("should throw an error if oftAddress is zero address", async function () {
+    const parameters = { ...validParameters, oftAddress: zeroAddress };
+    await expect(quoteSend(client, parameters)).rejects.toThrow(
+      "OFT address is invalid",
+    );
+  });
+
+  it("should throw an error if recipient is invalid", async function () {
+    const parameters = { ...validParameters, recipient: "not_an_address" };
+    // @ts-expect-error - Testing invalid input
+    await expect(quoteSend(client, parameters)).rejects.toThrow(
+      "Recipient address is invalid",
+    );
+  });
+
+  it("should throw an error if recipient is zero address", async function () {
+    const parameters = { ...validParameters, recipient: zeroAddress };
+    await expect(quoteSend(client, parameters)).rejects.toThrow(
+      "Recipient address is invalid",
+    );
+  });
+
+  it("should throw an error if amount is not a bigint", async function () {
+    const parameters = { ...validParameters, amount: 1000 };
+    // @ts-expect-error - Testing invalid input
+    await expect(quoteSend(client, parameters)).rejects.toThrow(
+      "Amount must be a bigint",
+    );
+  });
+
+  it("should throw an error if amount is zero", async function () {
+    const parameters = { ...validParameters, amount: 0n };
+    await expect(quoteSend(client, parameters)).rejects.toThrow(
+      "Amount must be greater than 0",
+    );
+  });
+
+  it("should throw an error if destinationChainId has no LayerZero EID", async function () {
+    const parameters = { ...validParameters, destinationChainId: 999_999 };
+    await expect(quoteSend(client, parameters)).rejects.toThrow(
+      "No LayerZero EID registered for chainId 999999",
+    );
+  });
+
+  it("should call readContract with the correct sendParam and return the fee", async function () {
+    const fee = { lzTokenFee: 0n, nativeFee: 1_000_000_000n };
+    vi.mocked(readContract).mockResolvedValueOnce(fee);
+
+    const result = await quoteSend(client, validParameters);
+
+    expect(readContract).toHaveBeenCalledWith(client, {
+      abi: expect.anything(),
+      address: validParameters.oftAddress,
+      args: [
+        {
+          amountLD: validParameters.amount,
+          composeMsg: "0x",
+          dstEid: 30329,
+          extraOptions: "0x",
+          minAmountLD: validParameters.amount,
+          oftCmd: "0x",
+          to: padHex(validParameters.recipient, { size: 32 }),
+        },
+        false,
+      ],
+      functionName: "quoteSend",
+    });
+    expect(result).toEqual(fee);
+  });
+
+  it("should propagate explicit minAmount into minAmountLD", async function () {
+    const fee = { lzTokenFee: 0n, nativeFee: 1_000_000_000n };
+    vi.mocked(readContract).mockResolvedValueOnce(fee);
+
+    const minAmount = validParameters.amount - 10n;
+    await quoteSend(client, { ...validParameters, minAmount });
+
+    expect(readContract).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        args: [expect.objectContaining({ minAmountLD: minAmount }), false],
+      }),
+    );
+  });
+});

--- a/packages/bridge/test/public/quoteSend.test.ts
+++ b/packages/bridge/test/public/quoteSend.test.ts
@@ -79,6 +79,31 @@ describe("quoteSend", function () {
     );
   });
 
+  it("should throw an error if minAmount is not a bigint", async function () {
+    const parameters = { ...validParameters, minAmount: 1000 };
+    // @ts-expect-error - Testing invalid input
+    await expect(quoteSend(client, parameters)).rejects.toThrow(
+      "Min amount must be a bigint",
+    );
+  });
+
+  it("should throw an error if minAmount is zero", async function () {
+    const parameters = { ...validParameters, minAmount: 0n };
+    await expect(quoteSend(client, parameters)).rejects.toThrow(
+      "Min amount must be greater than 0",
+    );
+  });
+
+  it("should throw an error if minAmount is greater than amount", async function () {
+    const parameters = {
+      ...validParameters,
+      minAmount: validParameters.amount + 1n,
+    };
+    await expect(quoteSend(client, parameters)).rejects.toThrow(
+      "Min amount must be less than or equal to amount",
+    );
+  });
+
   it("should throw an error if destinationChainId has no LayerZero EID", async function () {
     const parameters = { ...validParameters, destinationChainId: 999_999 };
     await expect(quoteSend(client, parameters)).rejects.toThrow(

--- a/packages/bridge/test/public/token.test.ts
+++ b/packages/bridge/test/public/token.test.ts
@@ -1,0 +1,61 @@
+import { type Address, type Client, zeroAddress } from "viem";
+import { readContract } from "viem/actions";
+import { describe, expect, it, vi } from "vitest";
+
+import { token } from "../../src/actions/public/token";
+
+vi.mock("viem/actions", () => ({
+  readContract: vi.fn(),
+}));
+
+const validParameters = {
+  oftAddress: "0x1234567890123456789012345678901234567890" as Address,
+};
+
+// @ts-expect-error - We only create an empty client for testing purposes
+const client: Client = {};
+
+describe("token", function () {
+  it("should throw an error if client is not defined", async function () {
+    await expect(
+      // @ts-expect-error - Testing invalid input
+      token(undefined, validParameters),
+    ).rejects.toThrow("Client is not defined");
+  });
+
+  it("should throw an error if parameters are not provided", async function () {
+    // @ts-expect-error - Testing invalid input
+    await expect(token(client, undefined)).rejects.toThrow(
+      "Parameters are required",
+    );
+  });
+
+  it("should throw an error if oftAddress is invalid", async function () {
+    const parameters = { oftAddress: "not_an_address" };
+    // @ts-expect-error - Testing invalid input
+    await expect(token(client, parameters)).rejects.toThrow(
+      "OFT address is invalid",
+    );
+  });
+
+  it("should throw an error if oftAddress is zero address", async function () {
+    await expect(token(client, { oftAddress: zeroAddress })).rejects.toThrow(
+      "OFT address is invalid",
+    );
+  });
+
+  it("should call readContract and return the underlying token address", async function () {
+    const tokenAddress =
+      "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" as Address;
+    vi.mocked(readContract).mockResolvedValueOnce(tokenAddress);
+
+    const result = await token(client, validParameters);
+
+    expect(readContract).toHaveBeenCalledWith(client, {
+      abi: expect.anything(),
+      address: validParameters.oftAddress,
+      functionName: "token",
+    });
+    expect(result).toBe(tokenAddress);
+  });
+});

--- a/packages/bridge/test/wallet/send.test.ts
+++ b/packages/bridge/test/wallet/send.test.ts
@@ -214,6 +214,23 @@ describe("send", function () {
     );
   });
 
+  it("should emit 'send-failed-validation' if approveAmount is not a bigint", async function () {
+    const { emitter, promise } = send(mockWalletClient, {
+      ...validParameters,
+      // @ts-expect-error - Testing invalid input
+      approveAmount: 1000,
+    });
+
+    const onSendFailedValidation = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Approve amount must be a bigint",
+    );
+  });
+
   it("should emit 'send-failed-validation' if approveAmount is less than amount", async function () {
     const { emitter, promise } = send(mockWalletClient, {
       ...validParameters,

--- a/packages/bridge/test/wallet/send.test.ts
+++ b/packages/bridge/test/wallet/send.test.ts
@@ -1,0 +1,611 @@
+import {
+  type Address,
+  type TransactionReceipt,
+  type WalletClient,
+  zeroAddress,
+  zeroHash,
+} from "viem";
+import {
+  readContract,
+  simulateContract,
+  waitForTransactionReceipt,
+  writeContract,
+} from "viem/actions";
+import { bsc, hemi } from "viem/chains";
+import { allowance, approve } from "viem-erc20/actions";
+import { describe, expect, it, vi } from "vitest";
+
+import { send } from "../../src/actions/wallet/send";
+
+vi.mock("viem/actions", () => ({
+  readContract: vi.fn(),
+  simulateContract: vi.fn(),
+  waitForTransactionReceipt: vi.fn(),
+  writeContract: vi.fn(),
+}));
+
+vi.mock("viem-erc20/actions", () => ({
+  allowance: vi.fn(),
+  approve: vi.fn(),
+}));
+
+const account = "0x1111111111111111111111111111111111111111" as Address;
+const tokenAddress = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" as Address;
+
+const mockWalletClient = {
+  account: { address: account },
+  chain: bsc,
+} as unknown as WalletClient;
+
+const validParameters = {
+  amount: BigInt(1000),
+  destinationChainId: hemi.id,
+  oftAddress: "0x1234567890123456789012345678901234567890" as Address,
+  recipient: "0x2222222222222222222222222222222222222222" as Address,
+};
+
+const fee = { lzTokenFee: 0n, nativeFee: 1_000_000_000n };
+
+const mockReadContractFor = function ({
+  approvalRequired = false,
+}: { approvalRequired?: boolean } = {}) {
+  vi.mocked(readContract).mockImplementation(async function (
+    _client: unknown,
+    params: { functionName: string },
+  ): Promise<unknown> {
+    switch (params.functionName) {
+      case "approvalRequired":
+        return approvalRequired;
+      case "token":
+        return tokenAddress;
+      case "quoteSend":
+        return fee;
+      default:
+        throw new Error(`unexpected functionName: ${params.functionName}`);
+    }
+  });
+};
+
+describe("send", function () {
+  it("should emit 'send-failed-validation' if client is not defined", async function () {
+    const { emitter, promise } = send(
+      // @ts-expect-error - Testing invalid input
+      undefined,
+      validParameters,
+    );
+
+    const onSendFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Client is not defined",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'send-failed-validation' if client.chain is not defined", async function () {
+    const clientWithoutChain = {
+      account: { address: account },
+    } as WalletClient;
+    const { emitter, promise } = send(clientWithoutChain, validParameters);
+
+    const onSendFailedValidation = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Chain is not defined on wallet client",
+    );
+  });
+
+  it("should emit 'send-failed-validation' if client.account is not defined", async function () {
+    const clientWithoutAccount = { chain: bsc } as unknown as WalletClient;
+    const { emitter, promise } = send(clientWithoutAccount, validParameters);
+
+    const onSendFailedValidation = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Client must have an account",
+    );
+  });
+
+  it("should emit 'send-failed-validation' if oftAddress is invalid", async function () {
+    const { emitter, promise } = send(mockWalletClient, {
+      ...validParameters,
+      oftAddress: zeroAddress,
+    });
+
+    const onSendFailedValidation = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "OFT address is invalid",
+    );
+  });
+
+  it("should emit 'send-failed-validation' if recipient is invalid", async function () {
+    const { emitter, promise } = send(mockWalletClient, {
+      ...validParameters,
+      recipient: zeroAddress,
+    });
+
+    const onSendFailedValidation = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Recipient address is invalid",
+    );
+  });
+
+  it("should emit 'send-failed-validation' if amount is not a bigint", async function () {
+    const { emitter, promise } = send(mockWalletClient, {
+      ...validParameters,
+      // @ts-expect-error - Testing invalid input
+      amount: 1000,
+    });
+
+    const onSendFailedValidation = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Amount must be a bigint",
+    );
+  });
+
+  it("should emit 'send-failed-validation' if amount is zero", async function () {
+    const { emitter, promise } = send(mockWalletClient, {
+      ...validParameters,
+      amount: 0n,
+    });
+
+    const onSendFailedValidation = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Amount must be greater than 0",
+    );
+  });
+
+  it("should emit 'send-failed-validation' if minAmount is greater than amount", async function () {
+    const { emitter, promise } = send(mockWalletClient, {
+      ...validParameters,
+      minAmount: validParameters.amount + 1n,
+    });
+
+    const onSendFailedValidation = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Min amount must be less than or equal to amount",
+    );
+  });
+
+  it("should emit 'send-failed-validation' if minAmount is zero", async function () {
+    const { emitter, promise } = send(mockWalletClient, {
+      ...validParameters,
+      minAmount: 0n,
+    });
+
+    const onSendFailedValidation = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Min amount must be greater than 0",
+    );
+  });
+
+  it("should emit 'send-failed-validation' if approveAmount is less than amount", async function () {
+    const { emitter, promise } = send(mockWalletClient, {
+      ...validParameters,
+      approveAmount: validParameters.amount - 1n,
+    });
+
+    const onSendFailedValidation = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Approve amount must be greater than or equal to amount",
+    );
+  });
+
+  it("should emit 'send-failed-validation' when source and destination chains match", async function () {
+    const { emitter, promise } = send(mockWalletClient, {
+      ...validParameters,
+      destinationChainId: bsc.id,
+    });
+
+    const onSendFailedValidation = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Destination chain must be different from source chain",
+    );
+  });
+
+  it("should emit 'send-failed-validation' when destinationChainId has no EID", async function () {
+    const { emitter, promise } = send(mockWalletClient, {
+      ...validParameters,
+      destinationChainId: 999_999,
+    });
+
+    const onSendFailedValidation = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledExactlyOnceWith(
+      "Unsupported destination chain",
+    );
+  });
+
+  it("should skip approval entirely when approvalRequired is false", async function () {
+    mockReadContractFor({ approvalRequired: false });
+    vi.mocked(simulateContract).mockResolvedValue({ request: {} } as never);
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue({
+      status: "success",
+    } as TransactionReceipt);
+
+    const { emitter, promise } = send(mockWalletClient, validParameters);
+
+    const onPreApprove = vi.fn();
+    const onPreSend = vi.fn();
+    const onUserSignedSend = vi.fn();
+    const onSendTransactionSucceeded = vi.fn();
+    const onSettled = vi.fn();
+    emitter.on("pre-approve", onPreApprove);
+    emitter.on("pre-send", onPreSend);
+    emitter.on("user-signed-send", onUserSignedSend);
+    emitter.on("send-transaction-succeeded", onSendTransactionSucceeded);
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(onPreApprove).not.toHaveBeenCalled();
+    expect(allowance).not.toHaveBeenCalled();
+    expect(approve).not.toHaveBeenCalled();
+    expect(onPreSend).toHaveBeenCalledOnce();
+    expect(onUserSignedSend).toHaveBeenCalledExactlyOnceWith(zeroHash);
+    expect(onSendTransactionSucceeded).toHaveBeenCalledOnce();
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should read token() and allowance but skip approve when allowance is sufficient", async function () {
+    mockReadContractFor({ approvalRequired: true });
+    vi.mocked(allowance).mockResolvedValue(validParameters.amount);
+    vi.mocked(simulateContract).mockResolvedValue({ request: {} } as never);
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue({
+      status: "success",
+    } as TransactionReceipt);
+
+    const { emitter, promise } = send(mockWalletClient, validParameters);
+
+    const onPreApprove = vi.fn();
+    const onPreSend = vi.fn();
+    const onSendTransactionSucceeded = vi.fn();
+    const onSettled = vi.fn();
+    emitter.on("pre-approve", onPreApprove);
+    emitter.on("pre-send", onPreSend);
+    emitter.on("send-transaction-succeeded", onSendTransactionSucceeded);
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(allowance).toHaveBeenCalledOnce();
+    expect(approve).not.toHaveBeenCalled();
+    expect(onPreApprove).not.toHaveBeenCalled();
+    expect(onPreSend).toHaveBeenCalledOnce();
+    expect(onSendTransactionSucceeded).toHaveBeenCalledOnce();
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should run full approval lifecycle when approvalRequired and allowance is insufficient", async function () {
+    mockReadContractFor({ approvalRequired: true });
+    vi.mocked(allowance).mockResolvedValue(validParameters.amount - 1n);
+    vi.mocked(approve).mockResolvedValue(zeroHash);
+    vi.mocked(simulateContract).mockResolvedValue({ request: {} } as never);
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt)
+      .mockResolvedValueOnce({ status: "success" } as TransactionReceipt)
+      .mockResolvedValueOnce({ status: "success" } as TransactionReceipt);
+
+    const { emitter, promise } = send(mockWalletClient, validParameters);
+
+    const onPreApprove = vi.fn();
+    const onUserSignedApproval = vi.fn();
+    const onApproveTransactionSucceeded = vi.fn();
+    const onPreSend = vi.fn();
+    const onUserSignedSend = vi.fn();
+    const onSendTransactionSucceeded = vi.fn();
+    const onSettled = vi.fn();
+    emitter.on("pre-approve", onPreApprove);
+    emitter.on("user-signed-approval", onUserSignedApproval);
+    emitter.on("approve-transaction-succeeded", onApproveTransactionSucceeded);
+    emitter.on("pre-send", onPreSend);
+    emitter.on("user-signed-send", onUserSignedSend);
+    emitter.on("send-transaction-succeeded", onSendTransactionSucceeded);
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(onPreApprove).toHaveBeenCalledOnce();
+    expect(approve).toHaveBeenCalledOnce();
+    expect(onUserSignedApproval).toHaveBeenCalledExactlyOnceWith(zeroHash);
+    expect(onApproveTransactionSucceeded).toHaveBeenCalledOnce();
+    expect(onPreSend).toHaveBeenCalledOnce();
+    expect(onUserSignedSend).toHaveBeenCalledExactlyOnceWith(zeroHash);
+    expect(onSendTransactionSucceeded).toHaveBeenCalledOnce();
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should approve with explicit approveAmount when allowance is insufficient", async function () {
+    mockReadContractFor({ approvalRequired: true });
+    const approveAmount = validParameters.amount * 10n;
+    vi.mocked(allowance).mockResolvedValue(0n);
+    vi.mocked(approve).mockResolvedValue(zeroHash);
+    vi.mocked(simulateContract).mockResolvedValue({ request: {} } as never);
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue({
+      status: "success",
+    } as TransactionReceipt);
+
+    const { emitter, promise } = send(mockWalletClient, {
+      ...validParameters,
+      approveAmount,
+    });
+
+    const onSettled = vi.fn();
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(approve).toHaveBeenCalledWith(
+      mockWalletClient,
+      expect.objectContaining({ amount: approveAmount }),
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should pass minAmount through to simulateContract args", async function () {
+    mockReadContractFor({ approvalRequired: false });
+    vi.mocked(simulateContract).mockResolvedValue({ request: {} } as never);
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue({
+      status: "success",
+    } as TransactionReceipt);
+
+    const minAmount = validParameters.amount - 10n;
+    const { emitter, promise } = send(mockWalletClient, {
+      ...validParameters,
+      minAmount,
+    });
+
+    const onSettled = vi.fn();
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(simulateContract).toHaveBeenCalledWith(
+      mockWalletClient,
+      expect.objectContaining({
+        args: [
+          expect.objectContaining({ minAmountLD: minAmount }),
+          fee,
+          account,
+        ],
+        value: fee.nativeFee,
+      }),
+    );
+  });
+
+  it("should use walletClient.account.address as refundAddress", async function () {
+    mockReadContractFor({ approvalRequired: false });
+    vi.mocked(simulateContract).mockResolvedValue({ request: {} } as never);
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue({
+      status: "success",
+    } as TransactionReceipt);
+
+    const { emitter, promise } = send(mockWalletClient, validParameters);
+    const onSettled = vi.fn();
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(simulateContract).toHaveBeenCalledWith(
+      mockWalletClient,
+      expect.objectContaining({
+        args: [expect.anything(), fee, account],
+      }),
+    );
+  });
+
+  it("should emit 'user-signing-approval-error' when approval signing fails", async function () {
+    mockReadContractFor({ approvalRequired: true });
+    vi.mocked(allowance).mockResolvedValue(0n);
+    vi.mocked(approve).mockRejectedValue(new Error("rejected"));
+
+    const { emitter, promise } = send(mockWalletClient, validParameters);
+    const onUserSigningApprovalError = vi.fn();
+    const onSettled = vi.fn();
+    emitter.on("user-signing-approval-error", onUserSigningApprovalError);
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(onUserSigningApprovalError).toHaveBeenCalledExactlyOnceWith(
+      expect.any(Error),
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+    expect(simulateContract).not.toHaveBeenCalled();
+  });
+
+  it("should emit 'approve-transaction-reverted' when approval reverts", async function () {
+    mockReadContractFor({ approvalRequired: true });
+    vi.mocked(allowance).mockResolvedValue(0n);
+    vi.mocked(approve).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue({
+      status: "reverted",
+    } as TransactionReceipt);
+
+    const { emitter, promise } = send(mockWalletClient, validParameters);
+    const onApproveTransactionReverted = vi.fn();
+    const onPreSend = vi.fn();
+    const onSettled = vi.fn();
+    emitter.on("approve-transaction-reverted", onApproveTransactionReverted);
+    emitter.on("pre-send", onPreSend);
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(onApproveTransactionReverted).toHaveBeenCalledOnce();
+    expect(onPreSend).not.toHaveBeenCalled();
+    expect(simulateContract).not.toHaveBeenCalled();
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'send-failed' when approval receipt fetch fails", async function () {
+    mockReadContractFor({ approvalRequired: true });
+    vi.mocked(allowance).mockResolvedValue(0n);
+    vi.mocked(approve).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockRejectedValue(
+      new Error("receipt error"),
+    );
+
+    const { emitter, promise } = send(mockWalletClient, validParameters);
+    const onSendFailed = vi.fn();
+    const onSettled = vi.fn();
+    emitter.on("send-failed", onSendFailed);
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(onSendFailed).toHaveBeenCalledExactlyOnceWith(expect.any(Error));
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'user-signing-send-error' when send signing fails", async function () {
+    mockReadContractFor({ approvalRequired: false });
+    vi.mocked(simulateContract).mockResolvedValue({ request: {} } as never);
+    vi.mocked(writeContract).mockRejectedValue(new Error("rejected"));
+
+    const { emitter, promise } = send(mockWalletClient, validParameters);
+    const onPreSend = vi.fn();
+    const onUserSigningSendError = vi.fn();
+    const onSettled = vi.fn();
+    emitter.on("pre-send", onPreSend);
+    emitter.on("user-signing-send-error", onUserSigningSendError);
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(onPreSend).toHaveBeenCalledOnce();
+    expect(onUserSigningSendError).toHaveBeenCalledExactlyOnceWith(
+      expect.any(Error),
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'send-transaction-reverted' when send transaction reverts", async function () {
+    mockReadContractFor({ approvalRequired: false });
+    vi.mocked(simulateContract).mockResolvedValue({ request: {} } as never);
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue({
+      status: "reverted",
+    } as TransactionReceipt);
+
+    const { emitter, promise } = send(mockWalletClient, validParameters);
+    const onSendTransactionReverted = vi.fn();
+    const onSendTransactionSucceeded = vi.fn();
+    const onSettled = vi.fn();
+    emitter.on("send-transaction-reverted", onSendTransactionReverted);
+    emitter.on("send-transaction-succeeded", onSendTransactionSucceeded);
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(onSendTransactionReverted).toHaveBeenCalledOnce();
+    expect(onSendTransactionSucceeded).not.toHaveBeenCalled();
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'send-failed' when send receipt fetch fails", async function () {
+    mockReadContractFor({ approvalRequired: false });
+    vi.mocked(simulateContract).mockResolvedValue({ request: {} } as never);
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt).mockRejectedValue(
+      new Error("receipt error"),
+    );
+
+    const { emitter, promise } = send(mockWalletClient, validParameters);
+    const onSendFailed = vi.fn();
+    const onSettled = vi.fn();
+    emitter.on("send-failed", onSendFailed);
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(onSendFailed).toHaveBeenCalledExactlyOnceWith(expect.any(Error));
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'unexpected-error' when simulateContract throws", async function () {
+    mockReadContractFor({ approvalRequired: false });
+    vi.mocked(simulateContract).mockRejectedValue(new Error("simulate boom"));
+
+    const { emitter, promise } = send(mockWalletClient, validParameters);
+    const onUnexpectedError = vi.fn();
+    const onSettled = vi.fn();
+    emitter.on("unexpected-error", onUnexpectedError);
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(onUnexpectedError).toHaveBeenCalledExactlyOnceWith(
+      expect.any(Error),
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("should emit 'unexpected-error' when approvalRequired read throws", async function () {
+    vi.mocked(readContract).mockRejectedValue(new Error("rpc boom"));
+
+    const { emitter, promise } = send(mockWalletClient, validParameters);
+    const onUnexpectedError = vi.fn();
+    const onSettled = vi.fn();
+    emitter.on("unexpected-error", onUnexpectedError);
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(onUnexpectedError).toHaveBeenCalledExactlyOnceWith(
+      expect.any(Error),
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/bridge/test/wallet/send.test.ts
+++ b/packages/bridge/test/wallet/send.test.ts
@@ -370,9 +370,9 @@ describe("send", function () {
     vi.mocked(approve).mockResolvedValue(zeroHash);
     vi.mocked(simulateContract).mockResolvedValue({ request: {} } as never);
     vi.mocked(writeContract).mockResolvedValue(zeroHash);
-    vi.mocked(waitForTransactionReceipt).mockResolvedValue({
-      status: "success",
-    } as TransactionReceipt);
+    vi.mocked(waitForTransactionReceipt)
+      .mockResolvedValueOnce({ status: "success" } as TransactionReceipt)
+      .mockResolvedValueOnce({ status: "success" } as TransactionReceipt);
 
     const { emitter, promise } = send(mockWalletClient, {
       ...validParameters,

--- a/packages/bridge/test/wallet/send.test.ts
+++ b/packages/bridge/test/wallet/send.test.ts
@@ -87,6 +87,24 @@ describe("send", function () {
     expect(onSettled).toHaveBeenCalledOnce();
   });
 
+  it("should emit 'send-failed-validation' and 'send-settled' if params is not defined", async function () {
+    const { emitter, promise } = send(
+      mockWalletClient,
+      // @ts-expect-error - Testing invalid input
+      undefined,
+    );
+
+    const onSendFailedValidation = vi.fn();
+    const onSettled = vi.fn();
+    emitter.on("send-failed-validation", onSendFailedValidation);
+    emitter.on("send-settled", onSettled);
+
+    await promise;
+
+    expect(onSendFailedValidation).toHaveBeenCalledOnce();
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
   it("should emit 'send-failed-validation' if client.chain is not defined", async function () {
     const clientWithoutChain = {
       account: { address: account },

--- a/packages/bridge/tsconfig.json
+++ b/packages/bridge/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "erasableSyntaxOnly": true,
+    "noEmit": true
+  },
+  "exclude": ["node_modules", "test/*"],
+  "extends": "@tsconfig/node24/tsconfig.json",
+  "include": ["**/*.ts"]
+}

--- a/packages/bridge/vitest.config.ts
+++ b/packages/bridge/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    clearMocks: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,9 +289,6 @@ importers:
       '@tanstack/react-table':
         specifier: 8.21.3
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@vetro-protocol/bridge':
-        specifier: workspace:*
-        version: link:../packages/bridge
       '@vetro-protocol/earn':
         specifier: workspace:*
         version: link:../packages/earn

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,31 @@ importers:
         specifier: 4.79.0
         version: 4.79.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
+  packages/bridge:
+    dependencies:
+      to-promise-event:
+        specifier: 1.0.0
+        version: 1.0.0
+      viem-erc20:
+        specifier: 2.1.0
+        version: 2.1.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
+    devDependencies:
+      '@tsconfig/node24':
+        specifier: 24.0.4
+        version: 24.0.4
+      '@vitest/coverage-v8':
+        specifier: 4.0.18
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      viem:
+        specifier: 2.44.4
+        version: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      vitest:
+        specifier: 4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+
   packages/earn:
     dependencies:
       to-promise-event:
@@ -264,6 +289,9 @@ importers:
       '@tanstack/react-table':
         specifier: 8.21.3
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@vetro-protocol/bridge':
+        specifier: workspace:*
+        version: link:../packages/bridge
       '@vetro-protocol/earn':
         specifier: workspace:*
         version: link:../packages/earn


### PR DESCRIPTION
### Description

New `@vetro-protocol/bridge` workspace package: viem-style actions for LayerZero V2 OFT/OFTAdapter bridging, generic over any pair of OFT-deployed tokens.

Public actions (`quoteSend`, `approvalRequired`, `token`) and the wallet `send` action are exposed both as direct functions (`import { ... } from "@vetro-protocol/bridge/actions"`) and via `.extend()` factories. `send` auto-detects approval shape via on-chain `approvalRequired()` — pure OFTs skip the ERC20 approval flow, OFTAdapters run `allowance` / `approve` against the underlying ERC20 read from `token()` before the send. Slippage defaults to zero; pass `minAmount` to opt in to a tolerance.

Refund address is fixed to `walletClient.account.address`. `encodeSend` stays separate as a synchronous calldata helper for gas estimation in the web app.

Includes the minimal OFT ABI subset, `chainId → LayerZero EID` mapping for the six supported chains (mainnet, optimism, bsc, base, arbitrum, hemi), input validation, and unit tests for every action.

This PR ships only the package; the web bridge UI consuming it lands in a follow-up PR.

### Screenshots

N/A — backend package, no UI changes.

### Related issue(s)

Related to #338

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.