### PR TITLE
Set the environment in Sentry releases

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -8,20 +8,20 @@ Built with React, Viem, Wagmi, and Tailwind CSS.
 
 Vite only exposes variables prefixed with `VITE_` to the client bundle. Set these in `web/.env` (or a `.env.local` override) before running `dev` or `build`.
 
-| Variable                      | Required | Description                                                                           |
-| ----------------------------- | -------- | ------------------------------------------------------------------------------------- |
-| `VITE_FEATURE_BRIDGE_ENABLED` | No       | When `"true"`, the `/bridge` route and its nav entry are rendered. Defaults to false. |
-| `VITE_PORTAL_API_URL`         | Yes      | Hemi Portal API base URL (used for token prices).                                     |
-| `VITE_RPC_URL_MAINNET`        | No       | RPC URL for Ethereum mainnet. Falls back to viem's default when unset.                |
-| `VITE_SENTRY_DSN`             | No       | Sentry DSN. When unset, Sentry is disabled.                                           |
-| `VITE_VETRO_API_URL`          | Yes      | Vetro backend API base URL (analytics, APR history, exit tickets, rewards, etc.).     |
+| Variable                      | Required | Description                                                                                    |
+| ----------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `VITE_DEPLOY_ENV`             | No       | Set to `"production"` to hide source maps from browsers. Any other value serves them publicly. |
+| `VITE_FEATURE_BRIDGE_ENABLED` | No       | When `"true"`, the `/bridge` route and its nav entry are rendered. Defaults to false.          |
+| `VITE_PORTAL_API_URL`         | Yes      | Hemi Portal API base URL (used for token prices).                                              |
+| `VITE_RPC_URL_MAINNET`        | No       | RPC URL for Ethereum mainnet. Falls back to viem's default when unset.                         |
+| `VITE_SENTRY_DSN`             | No       | Sentry DSN. When unset, Sentry is disabled.                                                    |
+| `VITE_VETRO_API_URL`          | Yes      | Vetro backend API base URL (analytics, APR history, exit tickets, rewards, etc.).              |
 
 The following variables are read at build time (not baked into the bundle) and only matter in CI/CD:
 
-| Variable            | Required | Description                                                                                    |
-| ------------------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `DEPLOY_ENV`        | No       | Set to `"production"` to hide source maps from browsers. Any other value serves them publicly. |
-| `SENTRY_AUTH_TOKEN` | No       | Sentry auth token. Required for source map uploads to Sentry during `build`.                   |
+| Variable            | Required | Description                                                                  |
+| ------------------- | -------- | ---------------------------------------------------------------------------- |
+| `SENTRY_AUTH_TOKEN` | No       | Sentry auth token. Required for source map uploads to Sentry during `build`. |
 
 ## Scripts
 

--- a/web/src/instrument.ts
+++ b/web/src/instrument.ts
@@ -10,7 +10,7 @@ import {
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
   enabled: !!import.meta.env.VITE_SENTRY_DSN,
-  environment: import.meta.env.MODE,
+  environment: import.meta.env.VITE_DEPLOY_ENV,
   integrations: [
     Sentry.reactRouterV7BrowserTracingIntegration({
       createRoutesFromChildren,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
       project: "vetro-app",
       release: {
         deploy: {
-          env: process.env.VITE_DEPLOY_ENV!,
+          env: process.env.VITE_DEPLOY_ENV || "development",
         },
       },
       telemetry: false,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,12 +6,13 @@ import { defineConfig } from "vite";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig({
+const config = {
   build: {
     // "hidden" generates source maps for Sentry but strips sourceMappingURL
     // from the output so browsers can't discover them. "true" also serves them
     // publicly.
-    sourcemap: process.env.VITE_DEPLOY_ENV === "production" ? "hidden" : true,
+    sourcemap:
+      process.env.VITE_DEPLOY_ENV === "production" ? ("hidden" as const) : true,
   },
   plugins: [
     react(),
@@ -21,18 +22,25 @@ export default defineConfig({
     }),
     tailwindcss(),
     tsconfigPaths(),
-    // Sentry plugin should be last to ensures source maps are generated
-    // correctly and tree-shaking doesn't remove Sentry's instrumentation.
+  ],
+};
+
+if (process.env.VITE_DEPLOY_ENV) {
+  // Sentry plugin shall be last to ensure source maps are generated correctly
+  // and tree-shaking doesn't remove Sentry's instrumentation.
+  config.plugins.push(
     sentryVitePlugin({
       authToken: process.env.SENTRY_AUTH_TOKEN,
       org: "hemi-labs",
       project: "vetro-app",
       release: {
         deploy: {
-          env: process.env.VITE_DEPLOY_ENV || "development",
+          env: process.env.VITE_DEPLOY_ENV,
         },
       },
       telemetry: false,
     }),
-  ],
-});
+  );
+}
+
+export default defineConfig(config);

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     // "hidden" generates source maps for Sentry but strips sourceMappingURL
     // from the output so browsers can't discover them. "true" also serves them
     // publicly.
-    sourcemap: process.env.DEPLOY_ENV === "production" ? "hidden" : true,
+    sourcemap: process.env.VITE_DEPLOY_ENV === "production" ? "hidden" : true,
   },
   plugins: [
     react(),
@@ -19,12 +19,20 @@ export default defineConfig({
     nodePolyfills({
       include: ["http", "https"],
     }),
+    tailwindcss(),
+    tsconfigPaths(),
+    // Sentry plugin should be last to ensures source maps are generated
+    // correctly and tree-shaking doesn't remove Sentry's instrumentation.
     sentryVitePlugin({
       authToken: process.env.SENTRY_AUTH_TOKEN,
       org: "hemi-labs",
       project: "vetro-app",
+      release: {
+        deploy: {
+          env: process.env.VITE_DEPLOY_ENV!,
+        },
+      },
+      telemetry: false,
     }),
-    tailwindcss(),
-    tsconfigPaths(),
   ],
 });


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This pull request updates the way environment variables are handled in the web client, standardizing on the `VITE_DEPLOY_ENV` variable for both build and runtime configuration. It also ensures that Sentry instrumentation and source map handling are consistent and correctly reflect the deployment environment. The most important changes are grouped below:

**Environment variable standardization and documentation:**

* Updated documentation in `web/README.md` to use `VITE_DEPLOY_ENV` instead of `DEPLOY_ENV` for controlling source map visibility and Sentry environment, clarifying its usage and removing the old variable from the build-time variables table. [[1]](diffhunk://#diff-4a534cf0dab53faad7a19d1926cb05f63ebf793e827bdf11a4a19e0e654ef639L12-R13) [[2]](diffhunk://#diff-4a534cf0dab53faad7a19d1926cb05f63ebf793e827bdf11a4a19e0e654ef639L22-R23)

**Sentry and build configuration:**

* Changed Sentry initialization in `web/src/instrument.ts` to use `import.meta.env.VITE_DEPLOY_ENV` for the environment, ensuring consistency with deployment settings.
* Updated `web/vite.config.ts` to use `process.env.VITE_DEPLOY_ENV` for source map configuration and Sentry release environment, and ensured the Sentry plugin is added last when the variable is set. This guarantees correct source map generation and environment reporting.

### Note

`DEPLOY_ENV` needs to be moved to `VITE_DEPLOY_ENV` in the build environments before merging this PR. I will coordinate that change with @joshuasing.