### PR TITLE
Add bridge form UI and fee plumbing

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       '@tanstack/react-table':
         specifier: 8.21.3
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@vetro-protocol/bridge':
+        specifier: workspace:*
+        version: link:../packages/bridge
       '@vetro-protocol/earn':
         specifier: workspace:*
         version: link:../packages/earn
@@ -7894,6 +7897,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-name@6.0.2:

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "@sentry/react": "10.50.0",
     "@tanstack/react-query": "5.90.19",
     "@tanstack/react-table": "8.21.3",
+    "@vetro-protocol/bridge": "workspace:*",
     "@vetro-protocol/earn": "workspace:*",
     "@vetro-protocol/gateway": "workspace:*",
     "@vetro-protocol/morpho-blue-market": "workspace:*",

--- a/web/src/components/base/activityList/activityItem.tsx
+++ b/web/src/components/base/activityList/activityItem.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 
 import { formatShortDate } from "../../../utils/date";
 import { BorrowIcon } from "../../navbar/borrowIcon";
+import { BridgeIcon } from "../../navbar/bridgeIcon";
 import { EarnIcon } from "../../navbar/earnIcon";
 import { SwapIcon } from "../../navbar/swapIcon";
 import { ExternalLink } from "../externalLink";
@@ -13,6 +14,7 @@ import type { Activity } from "./types";
 
 const pageIcons = {
   borrow: BorrowIcon,
+  bridge: BridgeIcon,
   earn: EarnIcon,
   swap: SwapIcon,
 } as const;

--- a/web/src/components/base/activityList/types.ts
+++ b/web/src/components/base/activityList/types.ts
@@ -1,4 +1,4 @@
-export type ActivityPage = "borrow" | "earn" | "swap";
+export type ActivityPage = "borrow" | "bridge" | "earn" | "swap";
 
 export type ActivityStatus = "completed" | "failed" | "pending";
 

--- a/web/src/components/bridgeForm/bridgeFees.tsx
+++ b/web/src/components/bridgeForm/bridgeFees.tsx
@@ -1,0 +1,61 @@
+import { FeeDetails } from "components/feeDetails";
+import { FeesContainer } from "components/feesContainer";
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { formatFiatNumber } from "utils/format";
+
+const DollarSign = () => <span className="mr-1">$</span>;
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div className="flex items-center gap-x-1">{children}</div>
+);
+
+type FeeData = {
+  data: number | undefined;
+  isError: boolean;
+};
+
+type Props = {
+  layerZeroFee: FeeData;
+  networkFee: FeeData;
+  sectionClassName?: string;
+  total: FeeData;
+};
+
+export function BridgeFees({
+  layerZeroFee,
+  networkFee,
+  sectionClassName,
+  total,
+}: Props) {
+  const { t } = useTranslation();
+
+  const renderFiat = (value: number | undefined) =>
+    value !== undefined ? (
+      <Container>
+        <DollarSign />
+        {formatFiatNumber(value)}
+      </Container>
+    ) : undefined;
+
+  return (
+    <FeesContainer
+      isError={total.isError}
+      sectionClassName={sectionClassName}
+      totalFees={renderFiat(total.data)}
+    >
+      <FeeDetails
+        className={sectionClassName}
+        isError={networkFee.isError}
+        label={t("common.network-fee")}
+        value={renderFiat(networkFee.data)}
+      />
+      <FeeDetails
+        className={sectionClassName}
+        isError={layerZeroFee.isError}
+        label={t("pages.bridge.fees.layerzero-fee")}
+        value={renderFiat(layerZeroFee.data)}
+      />
+    </FeesContainer>
+  );
+}

--- a/web/src/components/bridgeForm/bridgeSubmitButton.tsx
+++ b/web/src/components/bridgeForm/bridgeSubmitButton.tsx
@@ -14,12 +14,14 @@ const Container = ({ children }: { children: ReactNode }) => (
 
 type Props = {
   inputError: InputError | undefined;
+  isLoadingData?: boolean;
   isPending?: boolean;
   isPreviewError?: boolean;
 };
 
 export function BridgeSubmitButton({
   inputError,
+  isLoadingData,
   isPending,
   isPreviewError,
 }: Props) {
@@ -56,6 +58,16 @@ export function BridgeSubmitButton({
       <Container>
         <Button disabled size="xLarge" type="button">
           {t("pages.bridge.form.preview-error")}
+        </Button>
+      </Container>
+    );
+  }
+
+  if (isLoadingData) {
+    return (
+      <Container>
+        <Button disabled size="xLarge" type="button">
+          <Spinner />
         </Button>
       </Container>
     );

--- a/web/src/components/bridgeForm/bridgeSubmitButton.tsx
+++ b/web/src/components/bridgeForm/bridgeSubmitButton.tsx
@@ -1,5 +1,6 @@
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { Button } from "components/base/button";
+import { Spinner } from "components/base/spinner";
 import type { InputError } from "components/tokenInput/utils";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
@@ -13,9 +14,15 @@ const Container = ({ children }: { children: ReactNode }) => (
 
 type Props = {
   inputError: InputError | undefined;
+  isPending?: boolean;
+  isPreviewError?: boolean;
 };
 
-export function BridgeSubmitButton({ inputError }: Props) {
+export function BridgeSubmitButton({
+  inputError,
+  isPending,
+  isPreviewError,
+}: Props) {
   const { address } = useAccount();
   const { openConnectModal } = useConnectModal();
   const { t } = useTranslation();
@@ -39,6 +46,26 @@ export function BridgeSubmitButton({ inputError }: Props) {
       <Container>
         <Button disabled size="xLarge" type="button">
           {t(`common.${inputError}`)}
+        </Button>
+      </Container>
+    );
+  }
+
+  if (isPreviewError) {
+    return (
+      <Container>
+        <Button disabled size="xLarge" type="button">
+          {t("pages.bridge.form.preview-error")}
+        </Button>
+      </Container>
+    );
+  }
+
+  if (isPending) {
+    return (
+      <Container>
+        <Button disabled size="xLarge" type="button">
+          <Spinner />
         </Button>
       </Container>
     );

--- a/web/src/components/bridgeForm/bridgeSubmitButton.tsx
+++ b/web/src/components/bridgeForm/bridgeSubmitButton.tsx
@@ -63,17 +63,7 @@ export function BridgeSubmitButton({
     );
   }
 
-  if (isLoadingData) {
-    return (
-      <Container>
-        <Button disabled size="xLarge" type="button">
-          <Spinner />
-        </Button>
-      </Container>
-    );
-  }
-
-  if (isPending) {
+  if (isLoadingData || isPending) {
     return (
       <Container>
         <Button disabled size="xLarge" type="button">

--- a/web/src/components/bridgeForm/bridgeSubmitDrawer.tsx
+++ b/web/src/components/bridgeForm/bridgeSubmitDrawer.tsx
@@ -1,0 +1,185 @@
+import { Button } from "components/base/button";
+import { Drawer } from "components/base/drawer";
+import { DrawerTitle } from "components/base/drawer/drawerTitle";
+import {
+  type Step,
+  VerticalStepper,
+  stepStatus,
+} from "components/base/verticalStepper";
+import { DrawerFeesContainer } from "components/feesContainer";
+import { allChains } from "networks";
+import { type ComponentProps } from "react";
+import { useTranslation } from "react-i18next";
+import type { BridgeableToken } from "types";
+
+import { BridgeFees } from "./bridgeFees";
+import { TokenChainLogo } from "./tokenChainLogo";
+
+export type BridgeFlowStatus =
+  | "approve-error"
+  | "approved"
+  | "approving"
+  | "idle"
+  | "send-error"
+  | "send-ready"
+  | "sending"
+  | "sent";
+
+type ActiveStatus = Exclude<BridgeFlowStatus, "idle">;
+
+const approveStepStatuses: Record<ActiveStatus, Step["status"]> = {
+  "approve-error": stepStatus.failed,
+  approved: stepStatus.completed,
+  approving: stepStatus.progress,
+  "send-error": stepStatus.completed,
+  "send-ready": stepStatus.completed,
+  sending: stepStatus.completed,
+  sent: stepStatus.completed,
+};
+
+const sendStepStatuses: Record<ActiveStatus, Step["status"]> = {
+  "approve-error": stepStatus.notReady,
+  approved: stepStatus.ready,
+  approving: stepStatus.notReady,
+  "send-error": stepStatus.failed,
+  "send-ready": stepStatus.ready,
+  sending: stepStatus.progress,
+  sent: stepStatus.completed,
+};
+
+const waitingStepStatuses: Record<ActiveStatus, Step["status"]> = {
+  "approve-error": stepStatus.notReady,
+  approved: stepStatus.notReady,
+  approving: stepStatus.notReady,
+  "send-error": stepStatus.notReady,
+  "send-ready": stepStatus.notReady,
+  sending: stepStatus.notReady,
+  sent: stepStatus.ready,
+};
+
+type Props = {
+  flowStatus: ActiveStatus;
+  fromAmount: string;
+  fromToken: BridgeableToken;
+  onClose: VoidFunction;
+  onRetry: VoidFunction;
+  showApproveStep: boolean;
+  toToken: BridgeableToken;
+} & Pick<
+  ComponentProps<typeof BridgeFees>,
+  "layerZeroFee" | "networkFee" | "total"
+>;
+
+export function BridgeSubmitDrawer({
+  flowStatus,
+  fromAmount,
+  fromToken,
+  layerZeroFee,
+  networkFee,
+  onClose,
+  onRetry,
+  showApproveStep,
+  total,
+  toToken,
+}: Props) {
+  const { t } = useTranslation();
+
+  const fromChain = allChains.find((c) => c.id === fromToken.chainId);
+  const toChain = allChains.find((c) => c.id === toToken.chainId);
+
+  const isError = flowStatus === "approve-error" || flowStatus === "send-error";
+
+  const steps: Step[] = [
+    {
+      description: t("pages.bridge.progress.send-description"),
+      status: sendStepStatuses[flowStatus],
+      title: t("pages.bridge.progress.send-title"),
+    },
+    {
+      description: t("pages.bridge.progress.waiting-description"),
+      status: waitingStepStatuses[flowStatus],
+      title: t("pages.bridge.progress.waiting-title"),
+    },
+  ];
+
+  if (showApproveStep) {
+    steps.unshift({
+      description: t("pages.bridge.progress.approve-description"),
+      status: approveStepStatuses[flowStatus],
+      title: t("pages.bridge.progress.approve-title"),
+    });
+  }
+
+  return (
+    <Drawer onClose={onClose}>
+      <div className="flex h-full flex-col">
+        <DrawerTitle>{t("pages.bridge.progress.title")}</DrawerTitle>
+
+        <div className="flex flex-col gap-10 border-y border-gray-200 bg-gray-50 p-6">
+          <div className="flex flex-col gap-2">
+            <p className="text-xsm text-gray-500">
+              {t("pages.bridge.form.you-are-sending")}
+            </p>
+            <div className="flex items-center gap-3">
+              <p className="flex items-center gap-x-2 text-4xl leading-10 font-semibold tracking-tight text-gray-900">
+                <span>{fromAmount}</span>
+                <span className="text-gray-500">{fromToken.symbol}</span>
+              </p>
+              <TokenChainLogo size="large" token={fromToken} />
+            </div>
+            {fromChain && (
+              <p className="text-xsm text-gray-500">
+                {t("pages.bridge.form.from-chain", { chain: fromChain.name })}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <p className="text-xsm text-gray-500">
+              {t("pages.bridge.form.you-will-receive")}
+            </p>
+            <div className="flex items-center gap-3">
+              <p className="flex items-center gap-x-2 text-4xl leading-10 font-semibold tracking-tight text-gray-900">
+                <span>{fromAmount}</span>
+                <span className="text-gray-500">{toToken.symbol}</span>
+              </p>
+              <TokenChainLogo size="large" token={toToken} />
+            </div>
+            {toChain && (
+              <p className="text-xsm text-gray-500">
+                {t("pages.bridge.form.on-chain", { chain: toChain.name })}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <DrawerFeesContainer>
+          <BridgeFees
+            layerZeroFee={layerZeroFee}
+            networkFee={networkFee}
+            total={total}
+          />
+        </DrawerFeesContainer>
+
+        <div className="flex-1" />
+
+        <div className="flex flex-col gap-2 px-6 pb-6">
+          <p className="text-caption text-gray-500">
+            {t("pages.bridge.progress.bridge-progress")}
+          </p>
+          <div className="border-t border-gray-200">
+            <VerticalStepper steps={steps} />
+          </div>
+        </div>
+
+        {isError && (
+          <div className="border-t border-gray-200 bg-gray-50 px-6 py-3 *:w-full">
+            <Button onClick={onRetry} size="small" variant="primary">
+              {t("pages.bridge.progress.retry")}
+            </Button>
+          </div>
+        )}
+      </div>
+    </Drawer>
+  );
+}

--- a/web/src/components/bridgeForm/bridgeSubmitDrawer.tsx
+++ b/web/src/components/bridgeForm/bridgeSubmitDrawer.tsx
@@ -7,7 +7,7 @@ import {
   stepStatus,
 } from "components/base/verticalStepper";
 import { DrawerFeesContainer } from "components/feesContainer";
-import { allChains } from "networks";
+import { getChainById } from "networks";
 import { type ComponentProps } from "react";
 import { useTranslation } from "react-i18next";
 import type { BridgeableToken } from "types";
@@ -84,8 +84,8 @@ export function BridgeSubmitDrawer({
 }: Props) {
   const { t } = useTranslation();
 
-  const fromChain = allChains.find((c) => c.id === fromToken.chainId);
-  const toChain = allChains.find((c) => c.id === toToken.chainId);
+  const fromChain = getChainById(fromToken.chainId);
+  const toChain = getChainById(toToken.chainId);
 
   const isError = flowStatus === "approve-error" || flowStatus === "send-error";
 
@@ -127,11 +127,9 @@ export function BridgeSubmitDrawer({
               </p>
               <TokenChainLogo size="large" token={fromToken} />
             </div>
-            {fromChain && (
-              <p className="text-xsm text-gray-500">
-                {t("pages.bridge.form.from-chain", { chain: fromChain.name })}
-              </p>
-            )}
+            <p className="text-xsm text-gray-500">
+              {t("pages.bridge.form.from-chain", { chain: fromChain.name })}
+            </p>
           </div>
 
           <div className="flex flex-col gap-2">
@@ -145,11 +143,9 @@ export function BridgeSubmitDrawer({
               </p>
               <TokenChainLogo size="large" token={toToken} />
             </div>
-            {toChain && (
-              <p className="text-xsm text-gray-500">
-                {t("pages.bridge.form.on-chain", { chain: toChain.name })}
-              </p>
-            )}
+            <p className="text-xsm text-gray-500">
+              {t("pages.bridge.form.on-chain", { chain: toChain.name })}
+            </p>
           </div>
         </div>
 

--- a/web/src/components/bridgeForm/bridgeTokenDropdown.tsx
+++ b/web/src/components/bridgeForm/bridgeTokenDropdown.tsx
@@ -1,6 +1,6 @@
 import { ChevronIcon } from "components/base/chevronIcon";
 import { Dropdown } from "components/base/dropdown";
-import { allChains } from "networks";
+import { getChainById } from "networks";
 import { useTranslation } from "react-i18next";
 import type { BridgeableToken } from "types";
 
@@ -14,14 +14,14 @@ type Props = {
 };
 
 const renderItem = function (token: BridgeableToken) {
-  const chain = allChains.find((c) => c.id === token.chainId);
+  const chain = getChainById(token.chainId);
   return (
     <>
       <div className="flex items-center gap-2">
         <TokenChainLogo token={token} />
         <span>{token.symbol}</span>
       </div>
-      <span className="text-gray-500">{chain?.name ?? token.name}</span>
+      <span className="text-gray-500">{chain.name}</span>
     </>
   );
 };

--- a/web/src/components/bridgeForm/index.tsx
+++ b/web/src/components/bridgeForm/index.tsx
@@ -283,7 +283,7 @@ function BridgeFormContent({ tokens }: ContentProps) {
         <BridgeSubmitButton
           inputError={inputError}
           isPending={bridgeMutation.isPending}
-          isPreviewError={isLayerZeroFeeError}
+          isPreviewError={isTotalFeeError}
         />
       </Form>
       <FormSection show={amountBigInt !== 0n}>

--- a/web/src/components/bridgeForm/index.tsx
+++ b/web/src/components/bridgeForm/index.tsx
@@ -123,6 +123,7 @@ function BridgeFormContent({ tokens }: ContentProps) {
 
   const balancesLoaded =
     nativeBalance !== undefined && fromTokenBalance !== undefined;
+  const dataReady = balancesLoaded && needsApproval !== undefined;
 
   const inputError = getInputError({
     amount: amountBigInt,
@@ -233,7 +234,7 @@ function BridgeFormContent({ tokens }: ContentProps) {
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    if (!inputError && account) {
+    if (!inputError && account && dataReady) {
       setStartedWithApproval(!!needsApproval);
       setFlowStatus(needsApproval ? "approving" : "send-ready");
       bridgeMutation.mutate();
@@ -282,6 +283,7 @@ function BridgeFormContent({ tokens }: ContentProps) {
       >
         <BridgeSubmitButton
           inputError={inputError}
+          isLoadingData={!!account && !dataReady}
           isPending={bridgeMutation.isPending}
           isPreviewError={isTotalFeeError}
         />

--- a/web/src/components/bridgeForm/index.tsx
+++ b/web/src/components/bridgeForm/index.tsx
@@ -1,21 +1,35 @@
 import { useDebounce } from "@hemilabs/react-hooks/useDebounce";
 import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
+import { useNeedsApproval } from "@hemilabs/react-hooks/useNeedsApproval";
 import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
 import { ApproveSection } from "components/approveSection";
 import { RenderFiatValue } from "components/base/fiatValue";
+import { Toast } from "components/base/toast";
 import { FormSection, FormSectionItem } from "components/feesContainer";
 import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
 import { ToTokenBalance } from "components/swapForm/toTokenBalance";
-import { getSwapErrors } from "components/swapForm/validation";
 import { TokenInput } from "components/tokenInput";
+import { useActivityTracking } from "hooks/useActivityTracking";
+import { useBridge } from "hooks/useBridge";
 import { useBridgeableTokens } from "hooks/useBridgeableTokens";
-import { type FormEvent, useReducer } from "react";
+import { useBridgeLayerZeroFee } from "hooks/useBridgeLayerZeroFee";
+import { useBridgeNetworkFee } from "hooks/useBridgeNetworkFee";
+import { useTotalBridgeSendFees } from "hooks/useTotalBridgeSendFees";
+import { allChains } from "networks";
+import { type FormEvent, useReducer, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { BridgeableToken } from "types";
 import { pickCounterpartToken } from "utils/bridge";
+import { getInputError } from "utils/inputError";
 import { parseTokenUnits } from "utils/token";
+import { useAccount } from "wagmi";
 
+import { BridgeFees } from "./bridgeFees";
 import { BridgeSubmitButton } from "./bridgeSubmitButton";
+import {
+  type BridgeFlowStatus,
+  BridgeSubmitDrawer,
+} from "./bridgeSubmitDrawer";
 import { BridgeTokenDropdown } from "./bridgeTokenDropdown";
 import { Form } from "./form";
 import { bridgeFormReducer, type BridgeFormState } from "./reducer";
@@ -36,6 +50,7 @@ type ContentProps = {
 
 function BridgeFormContent({ tokens }: ContentProps) {
   const { t } = useTranslation();
+  const { address: account } = useAccount();
   const [state, dispatch] = useReducer(
     bridgeFormReducer,
     tokens,
@@ -43,8 +58,16 @@ function BridgeFormContent({ tokens }: ContentProps) {
   );
   const { approve10x, fromInputValue, fromToken, toToken } = state;
 
+  const [flowStatus, setFlowStatus] = useState<BridgeFlowStatus>("idle");
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [startedWithApproval, setStartedWithApproval] = useState(false);
+  const [showToast, setShowToast] = useState(false);
+
   const debouncedInputValue = useDebounce(fromInputValue);
   const amountBigInt = parseTokenUnits(debouncedInputValue, fromToken);
+
+  const oftAddress = fromToken.oftAdapterAddress ?? fromToken.address;
+  const approveAmount = approve10x ? amountBigInt * 10n : undefined;
 
   const { data: fromTokenBalance } = useTokenBalance({
     address: fromToken.address,
@@ -53,13 +76,121 @@ function BridgeFormContent({ tokens }: ContentProps) {
   const { data: nativeBalanceData } = useNativeBalance(fromToken.chainId);
   const nativeBalance = nativeBalanceData?.value;
 
+  const { data: needsApproval } = useNeedsApproval({
+    amount: amountBigInt,
+    spender: oftAddress,
+    token: { address: fromToken.address, chainId: fromToken.chainId },
+  });
+
+  const { data: nativeFeeUsd, isError: isLayerZeroFeeError } =
+    useBridgeLayerZeroFee({
+      amount: amountBigInt,
+      destinationChainId: toToken.chainId,
+      oftAddress,
+      sourceChainId: fromToken.chainId,
+    });
+
+  const { data: networkFeeUsd, isError: isNetworkFeeError } =
+    useBridgeNetworkFee({
+      amount: amountBigInt,
+      approveAmount,
+      destinationChainId: toToken.chainId,
+      sourceToken: fromToken,
+    });
+
+  const { data: totalFeeUsd, isError: isTotalFeeError } =
+    useTotalBridgeSendFees({
+      amount: amountBigInt,
+      approveAmount,
+      destinationChainId: toToken.chainId,
+      sourceToken: fromToken,
+    });
+
+  const layerZeroFee = {
+    data: nativeFeeUsd,
+    isError: isLayerZeroFeeError,
+  };
+
+  const networkFee = {
+    data: networkFeeUsd,
+    isError: isNetworkFeeError,
+  };
+
+  const total = {
+    data: totalFeeUsd,
+    isError: isTotalFeeError,
+  };
+
   const balancesLoaded =
     nativeBalance !== undefined && fromTokenBalance !== undefined;
 
-  const inputError = getSwapErrors({
+  const inputError = getInputError({
     amount: amountBigInt,
     nativeBalance,
     tokenBalance: fromTokenBalance,
+  });
+
+  const fromChain = allChains.find((c) => c.id === fromToken.chainId);
+  const toChain = allChains.find((c) => c.id === toToken.chainId);
+
+  const { onCompleted, onFailed, onPending, onTransactionHash } =
+    useActivityTracking({
+      page: "bridge",
+      text: t("pages.bridge.activity.bridge-text", {
+        amount: fromInputValue,
+        fromChain: fromChain?.name ?? "",
+        symbol: fromToken.symbol,
+        toChain: toChain?.name ?? "",
+      }),
+      title: t("nav.bridge"),
+    });
+
+  const bridgeMutation = useBridge({
+    amount: amountBigInt,
+    approveAmount,
+    destinationChainId: toToken.chainId,
+    oftAddress,
+    onEmitter(emitter) {
+      emitter.on("user-signed-approval", () => setFlowStatus("approving"));
+      emitter.on("approve-transaction-succeeded", () =>
+        setFlowStatus("approved"),
+      );
+      emitter.on("approve-transaction-reverted", () =>
+        setFlowStatus("approve-error"),
+      );
+      emitter.on("user-signing-approval-error", () =>
+        setFlowStatus("approve-error"),
+      );
+      emitter.on("pre-send", () => setFlowStatus("send-ready"));
+      emitter.on("user-signed-send", function (hash) {
+        onTransactionHash(hash);
+        onPending();
+        setFlowStatus("sending");
+      });
+      emitter.on("send-transaction-succeeded", function () {
+        onCompleted();
+        setFlowStatus("sent");
+        setShowToast(true);
+      });
+      emitter.on("send-transaction-reverted", function () {
+        onFailed();
+        setFlowStatus("send-error");
+      });
+      emitter.on("user-signing-send-error", function () {
+        onFailed();
+        setFlowStatus("send-error");
+      });
+      emitter.on("send-failed", function () {
+        onFailed();
+        setFlowStatus("send-error");
+      });
+      emitter.on("send-failed-validation", function () {
+        onFailed();
+        setFlowStatus("send-error");
+      });
+    },
+    sourceChainId: fromToken.chainId,
+    sourceTokenAddress: fromToken.address,
   });
 
   const fromTokens = tokens.filter(
@@ -72,19 +203,11 @@ function BridgeFormContent({ tokens }: ContentProps) {
   );
 
   function handleFromTokenChange(token: BridgeableToken) {
-    dispatch({ payload: token, type: "SET_FROM_TOKEN" });
-    if (token.chainId === toToken.chainId) {
-      const nextTo = pickCounterpartToken({ token, tokens });
-      dispatch({ payload: nextTo, type: "SET_TO_TOKEN" });
-    }
+    dispatch({ payload: { token, tokens }, type: "SET_FROM_TOKEN" });
   }
 
   function handleToTokenChange(token: BridgeableToken) {
-    dispatch({ payload: token, type: "SET_TO_TOKEN" });
-    if (token.chainId === fromToken.chainId) {
-      const nextFrom = pickCounterpartToken({ token, tokens });
-      dispatch({ payload: nextFrom, type: "SET_FROM_TOKEN" });
-    }
+    dispatch({ payload: { token, tokens }, type: "SET_TO_TOKEN" });
   }
 
   function handleInputChange(value: string) {
@@ -103,8 +226,19 @@ function BridgeFormContent({ tokens }: ContentProps) {
     dispatch({ type: "TOGGLE_APPROVE_10X" });
   }
 
+  function handleRetry() {
+    setFlowStatus(startedWithApproval ? "approving" : "send-ready");
+    bridgeMutation.mutate();
+  }
+
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
+    if (!inputError && account) {
+      setStartedWithApproval(!!needsApproval);
+      setFlowStatus(needsApproval ? "approving" : "send-ready");
+      bridgeMutation.mutate();
+      setIsDrawerOpen(true);
+    }
   }
 
   return (
@@ -146,7 +280,11 @@ function BridgeFormContent({ tokens }: ContentProps) {
           />
         }
       >
-        <BridgeSubmitButton inputError={inputError} />
+        <BridgeSubmitButton
+          inputError={inputError}
+          isPending={bridgeMutation.isPending}
+          isPreviewError={isLayerZeroFeeError}
+        />
       </Form>
       <FormSection show={amountBigInt !== 0n}>
         <FormSectionItem>
@@ -155,7 +293,36 @@ function BridgeFormContent({ tokens }: ContentProps) {
             onToggle={handleToggleApprove10x}
           />
         </FormSectionItem>
+        <BridgeFees
+          layerZeroFee={layerZeroFee}
+          networkFee={networkFee}
+          sectionClassName="max-md:px-4 md:px-2"
+          total={total}
+        />
       </FormSection>
+      {isDrawerOpen && flowStatus !== "idle" && (
+        <BridgeSubmitDrawer
+          flowStatus={flowStatus}
+          fromAmount={fromInputValue}
+          fromToken={fromToken}
+          layerZeroFee={layerZeroFee}
+          networkFee={networkFee}
+          onClose={() => setIsDrawerOpen(false)}
+          onRetry={handleRetry}
+          showApproveStep={startedWithApproval}
+          total={total}
+          toToken={toToken}
+        />
+      )}
+      {showToast && (
+        <Toast
+          autoCloseMs={5000}
+          closable
+          description={t("pages.bridge.toast.bridge-description")}
+          onClose={() => setShowToast(false)}
+          title={t("pages.bridge.toast.bridge-title")}
+        />
+      )}
     </>
   );
 }

--- a/web/src/components/bridgeForm/index.tsx
+++ b/web/src/components/bridgeForm/index.tsx
@@ -15,7 +15,7 @@ import { useBridgeableTokens } from "hooks/useBridgeableTokens";
 import { useBridgeLayerZeroFee } from "hooks/useBridgeLayerZeroFee";
 import { useBridgeNetworkFee } from "hooks/useBridgeNetworkFee";
 import { useTotalBridgeSendFees } from "hooks/useTotalBridgeSendFees";
-import { allChains } from "networks";
+import { getChainById } from "networks";
 import { type FormEvent, useReducer, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { BridgeableToken } from "types";
@@ -130,17 +130,17 @@ function BridgeFormContent({ tokens }: ContentProps) {
     tokenBalance: fromTokenBalance,
   });
 
-  const fromChain = allChains.find((c) => c.id === fromToken.chainId);
-  const toChain = allChains.find((c) => c.id === toToken.chainId);
+  const fromChain = getChainById(fromToken.chainId);
+  const toChain = getChainById(toToken.chainId);
 
   const { onCompleted, onFailed, onPending, onTransactionHash } =
     useActivityTracking({
       page: "bridge",
       text: t("pages.bridge.activity.bridge-text", {
         amount: fromInputValue,
-        fromChain: fromChain?.name ?? "",
+        fromChain: fromChain.name,
         symbol: fromToken.symbol,
-        toChain: toChain?.name ?? "",
+        toChain: toChain.name,
       }),
       title: t("nav.bridge"),
     });

--- a/web/src/components/bridgeForm/reducer.ts
+++ b/web/src/components/bridgeForm/reducer.ts
@@ -1,4 +1,5 @@
 import type { BridgeableToken } from "types";
+import { pickCounterpartToken } from "utils/bridge";
 import { sanitizeAmount } from "utils/sanitizeAmount";
 
 export type BridgeFormState = {
@@ -8,10 +9,15 @@ export type BridgeFormState = {
   toToken: BridgeableToken;
 };
 
+type SetTokenPayload = {
+  token: BridgeableToken;
+  tokens: BridgeableToken[];
+};
+
 export type BridgeFormAction =
+  | { payload: SetTokenPayload; type: "SET_FROM_TOKEN" }
+  | { payload: SetTokenPayload; type: "SET_TO_TOKEN" }
   | { payload: string; type: "SET_FROM_INPUT_VALUE" }
-  | { payload: BridgeableToken; type: "SET_FROM_TOKEN" }
-  | { payload: BridgeableToken; type: "SET_TO_TOKEN" }
   | { type: "TOGGLE_APPROVE_10X" }
   | { type: "TOGGLE_TOKENS" };
 
@@ -27,10 +33,28 @@ export function bridgeFormReducer(
       }
       return { ...state, fromInputValue: result.value };
     }
-    case "SET_FROM_TOKEN":
-      return { ...state, fromToken: action.payload };
-    case "SET_TO_TOKEN":
-      return { ...state, toToken: action.payload };
+    case "SET_FROM_TOKEN": {
+      const { token, tokens } = action.payload;
+      if (token.chainId === state.toToken.chainId) {
+        return {
+          ...state,
+          fromToken: token,
+          toToken: pickCounterpartToken({ token, tokens }),
+        };
+      }
+      return { ...state, fromToken: token };
+    }
+    case "SET_TO_TOKEN": {
+      const { token, tokens } = action.payload;
+      if (token.chainId === state.fromToken.chainId) {
+        return {
+          ...state,
+          fromToken: pickCounterpartToken({ token, tokens }),
+          toToken: token,
+        };
+      }
+      return { ...state, toToken: token };
+    }
     case "TOGGLE_APPROVE_10X":
       return { ...state, approve10x: !state.approve10x };
     case "TOGGLE_TOKENS":

--- a/web/src/components/bridgeForm/tokenChainLogo.tsx
+++ b/web/src/components/bridgeForm/tokenChainLogo.tsx
@@ -1,20 +1,22 @@
 import { ChainLogo } from "components/chainLogo";
 import { TokenLogo } from "components/tokenLogo";
 import { allChains } from "networks";
+import type { ComponentProps } from "react";
 import type { Token } from "types";
 
 type Props = {
+  size?: ComponentProps<typeof TokenLogo>["size"];
   token: Token;
 };
 
-export const TokenChainLogo = function ({ token }: Props) {
+export const TokenChainLogo = function ({ size, token }: Props) {
   const chain = allChains.find((c) => c.id === token.chainId);
   return (
     <div className="relative">
-      <TokenLogo logoURI={token.logoURI} symbol={token.symbol} />
+      <TokenLogo logoURI={token.logoURI} size={size} symbol={token.symbol} />
       {chain && (
         <div className="absolute -right-1 -bottom-1">
-          <ChainLogo chain={chain} />
+          <ChainLogo chain={chain} size={size} />
         </div>
       )}
     </div>

--- a/web/src/components/bridgeForm/tokenChainLogo.tsx
+++ b/web/src/components/bridgeForm/tokenChainLogo.tsx
@@ -1,6 +1,6 @@
 import { ChainLogo } from "components/chainLogo";
 import { TokenLogo } from "components/tokenLogo";
-import { allChains } from "networks";
+import { getChainById } from "networks";
 import type { ComponentProps } from "react";
 import type { Token } from "types";
 
@@ -10,15 +10,13 @@ type Props = {
 };
 
 export const TokenChainLogo = function ({ size, token }: Props) {
-  const chain = allChains.find((c) => c.id === token.chainId);
+  const chain = getChainById(token.chainId);
   return (
     <div className="relative">
       <TokenLogo logoURI={token.logoURI} size={size} symbol={token.symbol} />
-      {chain && (
-        <div className="absolute -right-1 -bottom-1">
-          <ChainLogo chain={chain} size={size} />
-        </div>
-      )}
+      <div className="absolute -right-1 -bottom-1">
+        <ChainLogo chain={chain} size={size} />
+      </div>
     </div>
   );
 };

--- a/web/src/components/chainLogo/index.tsx
+++ b/web/src/components/chainLogo/index.tsx
@@ -18,16 +18,31 @@ const chainIcons = {
   [optimism.id]: OptimismIcon,
 };
 
-type Props = {
-  chain: Chain;
+const sizeClasses = {
+  base: "size-3",
+  large: "size-5",
+  small: "size-2.5",
+  xLarge: "size-7",
 };
 
-export const ChainLogo = function ({ chain }: Props) {
+const fallbackSizes = {
+  base: "xSmall",
+  large: "base",
+  small: "xSmall",
+  xLarge: "large",
+} as const;
+
+type Props = {
+  chain: Chain;
+  size?: keyof typeof sizeClasses;
+};
+
+export const ChainLogo = function ({ chain, size = "base" }: Props) {
   const Icon = chainIcons[chain.id as keyof typeof chainIcons];
   if (!Icon) {
     return (
       <DefaultTokenLogo
-        size="xSmall"
+        size={fallbackSizes[size]}
         symbol={chain.name.charAt(0).toUpperCase()}
       />
     );
@@ -35,7 +50,7 @@ export const ChainLogo = function ({ chain }: Props) {
   return (
     <div
       aria-label={chain.name}
-      className="size-3"
+      className={sizeClasses[size]}
       role="img"
       title={chain.name}
     >

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -22,6 +22,7 @@ import { type FormEvent, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
 import { applyBps } from "utils/fees";
+import { getInputError } from "utils/inputError";
 import { formatAmount } from "utils/token";
 import { parseUnits } from "viem";
 
@@ -33,7 +34,6 @@ import { type DepositFlowStatus, SwapDepositDrawer } from "./swapDepositDrawer";
 import { SwapFees } from "./swapFees";
 import { ToTokenBalance } from "./toTokenBalance";
 import { TreasuryReserves } from "./treasuryReserves";
-import { getSwapErrors } from "./validation";
 
 type Props = {
   amountBigInt: bigint;
@@ -175,7 +175,7 @@ export function Deposit({
 
   const nativeBalance = nativeBalanceData?.value;
 
-  const inputError = getSwapErrors({
+  const inputError = getInputError({
     amount: amountBigInt,
     nativeBalance,
     tokenBalance: fromTokenBalance,

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -22,6 +22,7 @@ import { type FormEvent, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
 import { applyBps } from "utils/fees";
+import { getInputError } from "utils/inputError";
 import { formatAmount } from "utils/token";
 import { isAddressEqual, parseUnits } from "viem";
 
@@ -33,7 +34,6 @@ import { SwapFees } from "./swapFees";
 import { type RedeemFlowStatus, SwapRedeemDrawer } from "./swapRedeemDrawer";
 import { ToTokenBalance } from "./toTokenBalance";
 import { TreasuryReserves } from "./treasuryReserves";
-import { getSwapErrors } from "./validation";
 
 type Props = {
   amountBigInt: bigint;
@@ -167,7 +167,7 @@ export function OneStepRedeem({
     tokenOut: toToken.address,
   });
 
-  const inputError = getSwapErrors({
+  const inputError = getInputError({
     amount: amountBigInt,
     maxWithdraw,
     nativeBalance,

--- a/web/src/components/swapForm/redeemQueue.tsx
+++ b/web/src/components/swapForm/redeemQueue.tsx
@@ -17,6 +17,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
 import { applyBps } from "utils/fees";
+import { getInputError } from "utils/inputError";
 import { formatAmount, parseTokenUnits } from "utils/token";
 import { formatUnits, isAddressEqual, parseUnits } from "viem";
 
@@ -26,7 +27,6 @@ import { type ClaimRedeemFlowStatus } from "./claimRedeemProgressDrawer";
 import { RedeemQueueEmptyState } from "./redeemQueueEmptyState";
 import { RedeemQueueTable } from "./redeemQueueTable";
 import { RedeemQueueToasts } from "./redeemQueueToasts";
-import { getSwapErrors } from "./validation";
 
 type Props = {
   peggedToken: TokenWithGateway;
@@ -98,7 +98,7 @@ function ActiveRedeemDrawer({
     isError: isPreviewError,
   });
 
-  const inputError = getSwapErrors({
+  const inputError = getInputError({
     amount: amountBigInt,
     maxWithdraw,
     nativeBalance,

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -19,6 +19,7 @@ import { useWithdrawalDelay } from "hooks/useWithdrawalDelay";
 import { type FormEvent, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
+import { getInputError } from "utils/inputError";
 import { getTokenListParams } from "utils/tokenList";
 import { isAddressEqual } from "viem";
 
@@ -32,7 +33,6 @@ import {
   SwapRequestRedeemDrawer,
 } from "./swapRequestRedeemDrawer";
 import { TreasuryReserves } from "./treasuryReserves";
-import { getSwapErrors } from "./validation";
 
 type Props = {
   amountBigInt: bigint;
@@ -157,7 +157,7 @@ export function TwoStepRedeem({
     peggedTokenAmount: amountBigInt,
   });
 
-  const inputError = getSwapErrors({
+  const inputError = getInputError({
     amount: amountBigInt,
     nativeBalance,
     tokenBalance: fromTokenBalance,

--- a/web/src/components/walletDrawer/walletDrawerContent.tsx
+++ b/web/src/components/walletDrawer/walletDrawerContent.tsx
@@ -51,7 +51,7 @@ function useBalanceInUsd() {
   return { isLoading: true };
 }
 
-const allFilters = ["borrow", "completed", "earn", "failed", "swap"];
+const allFilters = ["borrow", "bridge", "completed", "earn", "failed", "swap"];
 
 export function WalletDrawerContent() {
   const { address } = useAccount();
@@ -72,7 +72,10 @@ export function WalletDrawerContent() {
 
   const itemsWithHref = filteredActivities.map((a) => ({
     ...a,
-    href: `${explorerBaseUrl}/tx/${a.txHash}`,
+    href:
+      a.page === "bridge"
+        ? `https://layerzeroscan.com/tx/${a.txHash}`
+        : `${explorerBaseUrl}/tx/${a.txHash}`,
   }));
 
   const balanceParts = usd !== undefined ? splitDecimalParts(usd) : undefined;
@@ -120,6 +123,7 @@ export function WalletDrawerContent() {
                 label: t("pages.wallet.view-operations-from"),
                 options: [
                   { label: t("nav.borrow"), value: "borrow" },
+                  { label: t("nav.bridge"), value: "bridge" },
                   { label: t("nav.earn"), value: "earn" },
                   { label: t("nav.swap"), value: "swap" },
                 ],

--- a/web/src/fetchers/fetchBridgeLayerZeroFee.ts
+++ b/web/src/fetchers/fetchBridgeLayerZeroFee.ts
@@ -1,0 +1,55 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { previewBridgeQueryOptions } from "hooks/usePreviewBridge";
+import { tokenPricesOptions } from "hooks/useTokenPrices";
+import { weiToUsd } from "utils/fees";
+import type { Address, Chain, Client } from "viem";
+
+/**
+ * Returns the LayerZero native messaging fee for a bridge send, priced in
+ * USD using the source chain's native currency price.
+ */
+export const fetchBridgeLayerZeroFee = async function ({
+  amount,
+  client,
+  destinationChainId,
+  oftAddress,
+  queryClient,
+  recipient,
+  sourceChainId,
+}: {
+  amount: bigint;
+  client: Client;
+  destinationChainId: Chain["id"];
+  oftAddress: Address;
+  queryClient: QueryClient;
+  recipient: Address;
+  sourceChainId: Chain["id"];
+}) {
+  const sourceChain = client.chain;
+  if (!sourceChain) {
+    throw new Error("Client is missing a chain");
+  }
+
+  const [fee, prices] = await Promise.all([
+    queryClient.ensureQueryData(
+      previewBridgeQueryOptions({
+        amount,
+        client,
+        destinationChainId,
+        oftAddress,
+        recipient,
+        sourceChainId,
+      }),
+    ),
+    queryClient.ensureQueryData(tokenPricesOptions()),
+  ]);
+
+  const nativeSymbol = sourceChain.nativeCurrency.symbol.toUpperCase();
+  const rawPrice = prices[nativeSymbol];
+  const nativePrice = typeof rawPrice === "string" ? parseFloat(rawPrice) : NaN;
+  if (!Number.isFinite(nativePrice)) {
+    throw new Error(`Invalid ${nativeSymbol} price received from API`);
+  }
+
+  return weiToUsd({ ethPrice: nativePrice, wei: fee.nativeFee });
+};

--- a/web/src/fetchers/fetchBridgeNetworkFee.ts
+++ b/web/src/fetchers/fetchBridgeNetworkFee.ts
@@ -1,0 +1,137 @@
+import { estimateFeesQueryOptions } from "@hemilabs/react-hooks/useEstimateFees";
+import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
+import type { QueryClient } from "@tanstack/react-query";
+import { oftAbi } from "@vetro-protocol/bridge";
+import { encodeSend } from "@vetro-protocol/bridge/actions";
+import { previewBridgeQueryOptions } from "hooks/usePreviewBridge";
+import { tokenPricesOptions } from "hooks/useTokenPrices";
+import { config } from "providers/web3Provider";
+import type { BridgeableToken } from "types";
+import { createErc20AllowanceStateOverride } from "utils/erc20StateOverride";
+import { weiToUsd } from "utils/fees";
+import { type Address, type Chain, type Client } from "viem";
+import { estimateGas, readContract } from "viem/actions";
+
+import { estimateApprovalGasUnits } from "./estimateApprovalGasUnits";
+
+/**
+ * Returns the on-chain network fee for a bridge send (approval gas if the
+ * OFT requires it plus send gas), priced in USD using the source chain's
+ * native currency price. Throws if the amount exceeds the user's balance.
+ */
+export const fetchBridgeNetworkFee = async function ({
+  amount,
+  approveAmount,
+  client,
+  destinationChainId,
+  oftAddress,
+  owner,
+  queryClient,
+  recipient,
+  sourceChainId,
+  sourceToken,
+}: {
+  amount: bigint;
+  approveAmount: bigint | undefined;
+  client: Client;
+  destinationChainId: Chain["id"];
+  oftAddress: Address;
+  owner: Address;
+  queryClient: QueryClient;
+  recipient: Address;
+  sourceChainId: Chain["id"];
+  sourceToken: BridgeableToken;
+}) {
+  const sourceChain = client.chain;
+  if (!sourceChain) {
+    throw new Error("Client is missing a chain");
+  }
+
+  const balance = await queryClient.ensureQueryData(
+    tokenBalanceQueryOptions({
+      account: owner,
+      client,
+      token: sourceToken,
+    }),
+  );
+
+  if (amount > balance) {
+    throw new Error("Insufficient token balance");
+  }
+
+  const [fee, approvalRequired] = await Promise.all([
+    queryClient.ensureQueryData(
+      previewBridgeQueryOptions({
+        amount,
+        client,
+        destinationChainId,
+        oftAddress,
+        recipient,
+        sourceChainId,
+      }),
+    ),
+    readContract(client, {
+      abi: oftAbi,
+      address: oftAddress,
+      functionName: "approvalRequired",
+    }),
+  ]);
+
+  const approvalGasPromise = approvalRequired
+    ? estimateApprovalGasUnits({
+        amount,
+        approveAmount,
+        client,
+        owner,
+        queryClient,
+        spender: oftAddress,
+        token: sourceToken,
+      })
+    : Promise.resolve(0n);
+
+  const sendGasPromise = estimateGas(client, {
+    account: owner,
+    data: encodeSend({
+      amount,
+      destinationChainId,
+      fee,
+      recipient,
+      refundAddress: owner,
+    }),
+    stateOverride: approvalRequired
+      ? createErc20AllowanceStateOverride({
+          owner,
+          spender: oftAddress,
+          token: sourceToken,
+        })
+      : undefined,
+    to: oftAddress,
+    value: fee.nativeFee,
+  });
+
+  const [approvalGas, sendGas] = await Promise.all([
+    approvalGasPromise,
+    sendGasPromise,
+  ]);
+
+  const [networkFeeWei, prices] = await Promise.all([
+    queryClient.ensureQueryData(
+      estimateFeesQueryOptions({
+        chainId: sourceChain.id,
+        config,
+        gasUnits: approvalGas + sendGas,
+        queryClient,
+      }),
+    ),
+    queryClient.ensureQueryData(tokenPricesOptions()),
+  ]);
+
+  const nativeSymbol = sourceChain.nativeCurrency.symbol.toUpperCase();
+  const rawPrice = prices[nativeSymbol];
+  const nativePrice = typeof rawPrice === "string" ? parseFloat(rawPrice) : NaN;
+  if (!Number.isFinite(nativePrice)) {
+    throw new Error(`Invalid ${nativeSymbol} price received from API`);
+  }
+
+  return weiToUsd({ ethPrice: nativePrice, wei: networkFeeWei });
+};

--- a/web/src/fetchers/fetchTotalBridgeSendFees.ts
+++ b/web/src/fetchers/fetchTotalBridgeSendFees.ts
@@ -1,0 +1,63 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { bridgeLayerZeroFeeOptions } from "hooks/useBridgeLayerZeroFee";
+import { bridgeNetworkFeeOptions } from "hooks/useBridgeNetworkFee";
+import type { BridgeableToken } from "types";
+import type { Address, Chain, Client } from "viem";
+
+/**
+ * Total bridge send fees in USD: the network fee on the source chain plus
+ * the LayerZero native messaging fee.
+ */
+export const fetchTotalBridgeSendFees = async function ({
+  amount,
+  approveAmount,
+  client,
+  destinationChainId,
+  oftAddress,
+  owner,
+  queryClient,
+  recipient,
+  sourceChainId,
+  sourceToken,
+}: {
+  amount: bigint;
+  approveAmount: bigint | undefined;
+  client: Client;
+  destinationChainId: Chain["id"];
+  oftAddress: Address;
+  owner: Address;
+  queryClient: QueryClient;
+  recipient: Address;
+  sourceChainId: Chain["id"];
+  sourceToken: BridgeableToken;
+}) {
+  const [layerZeroFeeUsd, networkFeeUsd] = await Promise.all([
+    queryClient.ensureQueryData(
+      bridgeLayerZeroFeeOptions({
+        amount,
+        client,
+        destinationChainId,
+        oftAddress,
+        queryClient,
+        recipient,
+        sourceChainId,
+      }),
+    ),
+    queryClient.ensureQueryData(
+      bridgeNetworkFeeOptions({
+        amount,
+        approveAmount,
+        client,
+        destinationChainId,
+        oftAddress,
+        owner,
+        queryClient,
+        recipient,
+        sourceChainId,
+        sourceToken,
+      }),
+    ),
+  ]);
+
+  return layerZeroFeeUsd + networkFeeUsd;
+};

--- a/web/src/hooks/useBridge.ts
+++ b/web/src/hooks/useBridge.ts
@@ -1,0 +1,111 @@
+import { allowanceQueryKey } from "@hemilabs/react-hooks/useAllowance";
+import { useEnsureConnectedTo } from "@hemilabs/react-hooks/useEnsureConnectedTo";
+import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
+import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { SendEvents } from "@vetro-protocol/bridge";
+import { send } from "@vetro-protocol/bridge/actions";
+import type { EventEmitter } from "events";
+import type { Address, Chain } from "viem";
+import { useAccount, useWalletClient } from "wagmi";
+
+import { previewBridgeQueryKey } from "./usePreviewBridge";
+
+export const useBridge = function ({
+  amount,
+  approveAmount,
+  destinationChainId,
+  oftAddress,
+  onEmitter,
+  sourceChainId,
+  sourceTokenAddress,
+}: {
+  amount: bigint;
+  approveAmount?: bigint;
+  destinationChainId: Chain["id"];
+  oftAddress: Address;
+  onEmitter?: (emitter: EventEmitter<SendEvents>) => void;
+  sourceChainId: Chain["id"];
+  sourceTokenAddress: Address;
+}) {
+  const { address: account } = useAccount();
+  const { data: walletClient } = useWalletClient({ chainId: sourceChainId });
+  const ensureConnectedTo = useEnsureConnectedTo();
+  const queryClient = useQueryClient();
+  const updateNativeBalanceAfterReceipt =
+    useUpdateNativeBalanceAfterReceipt(sourceChainId);
+
+  const allowanceKey = allowanceQueryKey({
+    owner: account,
+    spender: oftAddress,
+    token: { address: sourceTokenAddress, chainId: sourceChainId },
+  });
+
+  const sourceBalanceKey = tokenBalanceQueryKey(
+    { address: sourceTokenAddress, chainId: sourceChainId },
+    account,
+  );
+
+  return useMutation({
+    async mutationFn() {
+      if (!account) {
+        throw new Error("No account connected");
+      }
+
+      await ensureConnectedTo(sourceChainId);
+
+      const { emitter, promise } = send(walletClient!, {
+        amount,
+        approveAmount,
+        destinationChainId,
+        oftAddress,
+        recipient: account,
+      });
+
+      onEmitter?.(emitter);
+
+      emitter.on("approve-transaction-reverted", function (receipt) {
+        queryClient.invalidateQueries({ queryKey: allowanceKey });
+        updateNativeBalanceAfterReceipt(receipt);
+      });
+      emitter.on("approve-transaction-succeeded", function (receipt) {
+        updateNativeBalanceAfterReceipt(receipt);
+        queryClient.invalidateQueries({ queryKey: allowanceKey });
+      });
+      emitter.on("send-transaction-reverted", function (receipt) {
+        updateNativeBalanceAfterReceipt(receipt);
+      });
+      emitter.on("send-transaction-succeeded", function (receipt) {
+        updateNativeBalanceAfterReceipt(receipt);
+
+        // optimistically deduct the bridged amount from the source balance
+        queryClient.setQueryData(
+          sourceBalanceKey,
+          (old: bigint) => old - amount,
+        );
+      });
+
+      return promise;
+    },
+    onSettled() {
+      queryClient.invalidateQueries({
+        queryKey: allowanceKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: sourceBalanceKey,
+      });
+
+      // Clear the cached fee quote — once the user inputs a new amount it
+      // has to be recalculated.
+      queryClient.removeQueries({
+        queryKey: previewBridgeQueryKey({
+          amount,
+          destinationChainId,
+          oftAddress,
+          recipient: account!,
+          sourceChainId,
+        }),
+      });
+    },
+  });
+};

--- a/web/src/hooks/useBridge.ts
+++ b/web/src/hooks/useBridge.ts
@@ -82,9 +82,8 @@ export const useBridge = function ({
         updateNativeBalanceAfterReceipt(receipt);
 
         // optimistically deduct the bridged amount from the source balance
-        queryClient.setQueryData(
-          sourceBalanceKey,
-          (old: bigint) => old - amount,
+        queryClient.setQueryData(sourceBalanceKey, (old: bigint | undefined) =>
+          old === undefined ? old : old - amount,
         );
       });
 

--- a/web/src/hooks/useBridge.ts
+++ b/web/src/hooks/useBridge.ts
@@ -51,10 +51,13 @@ export const useBridge = function ({
       if (!account) {
         throw new Error("No account connected");
       }
+      if (!walletClient) {
+        throw new Error("Wallet client is not ready");
+      }
 
       await ensureConnectedTo(sourceChainId);
 
-      const { emitter, promise } = send(walletClient!, {
+      const { emitter, promise } = send(walletClient, {
         amount,
         approveAmount,
         destinationChainId,

--- a/web/src/hooks/useBridgeLayerZeroFee.ts
+++ b/web/src/hooks/useBridgeLayerZeroFee.ts
@@ -1,0 +1,76 @@
+import {
+  type QueryClient,
+  queryOptions,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { fetchBridgeLayerZeroFee } from "fetchers/fetchBridgeLayerZeroFee";
+import type { Address, Chain, Client } from "viem";
+import { useAccount, usePublicClient } from "wagmi";
+
+export const bridgeLayerZeroFeeOptions = ({
+  amount,
+  client,
+  destinationChainId,
+  oftAddress,
+  queryClient,
+  recipient,
+  sourceChainId,
+}: {
+  amount: bigint;
+  client: Client | undefined;
+  destinationChainId: Chain["id"];
+  oftAddress: Address;
+  queryClient: QueryClient;
+  recipient: Address | undefined;
+  sourceChainId: Chain["id"];
+}) =>
+  queryOptions({
+    enabled: !!client && !!recipient && amount > 0n,
+    queryFn: () =>
+      fetchBridgeLayerZeroFee({
+        amount,
+        client: client!,
+        destinationChainId,
+        oftAddress,
+        queryClient,
+        recipient: recipient!,
+        sourceChainId,
+      }),
+    queryKey: [
+      "bridge-layerzero-fee",
+      sourceChainId,
+      destinationChainId,
+      oftAddress,
+      recipient,
+      amount.toString(),
+    ],
+  });
+
+export const useBridgeLayerZeroFee = function ({
+  amount,
+  destinationChainId,
+  oftAddress,
+  sourceChainId,
+}: {
+  amount: bigint;
+  destinationChainId: Chain["id"];
+  oftAddress: Address;
+  sourceChainId: Chain["id"];
+}) {
+  const { address: account } = useAccount();
+  const client = usePublicClient({ chainId: sourceChainId });
+  const queryClient = useQueryClient();
+
+  return useQuery(
+    bridgeLayerZeroFeeOptions({
+      amount,
+      client,
+      destinationChainId,
+      oftAddress,
+      queryClient,
+      recipient: account,
+      sourceChainId,
+    }),
+  );
+};

--- a/web/src/hooks/useBridgeNetworkFee.ts
+++ b/web/src/hooks/useBridgeNetworkFee.ts
@@ -1,0 +1,92 @@
+import {
+  type QueryClient,
+  queryOptions,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { fetchBridgeNetworkFee } from "fetchers/fetchBridgeNetworkFee";
+import type { BridgeableToken } from "types";
+import type { Address, Chain, Client } from "viem";
+import { useAccount, usePublicClient } from "wagmi";
+
+export const bridgeNetworkFeeOptions = ({
+  amount,
+  approveAmount,
+  client,
+  destinationChainId,
+  oftAddress,
+  owner,
+  queryClient,
+  recipient,
+  sourceChainId,
+  sourceToken,
+}: {
+  amount: bigint;
+  approveAmount: bigint | undefined;
+  client: Client | undefined;
+  destinationChainId: Chain["id"];
+  oftAddress: Address;
+  owner: Address | undefined;
+  queryClient: QueryClient;
+  recipient: Address | undefined;
+  sourceChainId: Chain["id"];
+  sourceToken: BridgeableToken;
+}) =>
+  queryOptions({
+    enabled: !!client && !!owner && !!recipient && amount > 0n,
+    queryFn: () =>
+      fetchBridgeNetworkFee({
+        amount,
+        approveAmount,
+        client: client!,
+        destinationChainId,
+        oftAddress,
+        owner: owner!,
+        queryClient,
+        recipient: recipient!,
+        sourceChainId,
+        sourceToken,
+      }),
+    queryKey: [
+      "bridge-network-fee",
+      sourceChainId,
+      destinationChainId,
+      oftAddress,
+      sourceToken.address,
+      owner,
+      recipient,
+      amount.toString(),
+      approveAmount?.toString(),
+    ],
+  });
+
+export const useBridgeNetworkFee = function ({
+  amount,
+  approveAmount,
+  destinationChainId,
+  sourceToken,
+}: {
+  amount: bigint;
+  approveAmount: bigint | undefined;
+  destinationChainId: Chain["id"];
+  sourceToken: BridgeableToken;
+}) {
+  const { address: owner } = useAccount();
+  const client = usePublicClient({ chainId: sourceToken.chainId });
+  const queryClient = useQueryClient();
+
+  return useQuery(
+    bridgeNetworkFeeOptions({
+      amount,
+      approveAmount,
+      client,
+      destinationChainId,
+      oftAddress: sourceToken.oftAdapterAddress ?? sourceToken.address,
+      owner,
+      queryClient,
+      recipient: owner,
+      sourceChainId: sourceToken.chainId,
+      sourceToken,
+    }),
+  );
+};

--- a/web/src/hooks/usePreviewBridge.ts
+++ b/web/src/hooks/usePreviewBridge.ts
@@ -1,0 +1,57 @@
+import { queryOptions } from "@tanstack/react-query";
+import { quoteSend } from "@vetro-protocol/bridge/actions";
+import type { Address, Chain, Client } from "viem";
+
+export const previewBridgeQueryKey = ({
+  amount,
+  destinationChainId,
+  oftAddress,
+  recipient,
+  sourceChainId,
+}: {
+  amount: bigint;
+  destinationChainId: Chain["id"];
+  oftAddress: Address;
+  recipient: Address;
+  sourceChainId: Chain["id"];
+}) => [
+  "preview-bridge",
+  sourceChainId,
+  destinationChainId,
+  oftAddress,
+  recipient,
+  amount.toString(),
+];
+
+export const previewBridgeQueryOptions = ({
+  amount,
+  client,
+  destinationChainId,
+  oftAddress,
+  recipient,
+  sourceChainId,
+}: {
+  amount: bigint;
+  client: Client;
+  destinationChainId: Chain["id"];
+  oftAddress: Address;
+  recipient: Address;
+  sourceChainId: Chain["id"];
+}) =>
+  queryOptions({
+    enabled: !!client && amount > 0n && !!recipient,
+    queryFn: () =>
+      quoteSend(client, {
+        amount,
+        destinationChainId,
+        oftAddress,
+        recipient,
+      }),
+    queryKey: previewBridgeQueryKey({
+      amount,
+      destinationChainId,
+      oftAddress,
+      recipient,
+      sourceChainId,
+    }),
+  });

--- a/web/src/hooks/useTotalBridgeSendFees.ts
+++ b/web/src/hooks/useTotalBridgeSendFees.ts
@@ -1,0 +1,50 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { fetchTotalBridgeSendFees } from "fetchers/fetchTotalBridgeSendFees";
+import type { BridgeableToken } from "types";
+import type { Chain } from "viem";
+import { useAccount, usePublicClient } from "wagmi";
+
+export const useTotalBridgeSendFees = function ({
+  amount,
+  approveAmount,
+  destinationChainId,
+  sourceToken,
+}: {
+  amount: bigint;
+  approveAmount: bigint | undefined;
+  destinationChainId: Chain["id"];
+  sourceToken: BridgeableToken;
+}) {
+  const { address: owner } = useAccount();
+  const client = usePublicClient({ chainId: sourceToken.chainId });
+  const queryClient = useQueryClient();
+
+  const oftAddress = sourceToken.oftAdapterAddress ?? sourceToken.address;
+
+  return useQuery({
+    enabled: !!client && !!owner && amount > 0n,
+    queryFn: () =>
+      fetchTotalBridgeSendFees({
+        amount,
+        approveAmount,
+        client: client!,
+        destinationChainId,
+        oftAddress,
+        owner: owner!,
+        queryClient,
+        recipient: owner!,
+        sourceChainId: sourceToken.chainId,
+        sourceToken,
+      }),
+    queryKey: [
+      "total-bridge-send-fees",
+      sourceToken.chainId,
+      destinationChainId,
+      oftAddress,
+      sourceToken.address,
+      owner,
+      amount.toString(),
+      approveAmount?.toString(),
+    ],
+  });
+};

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -174,15 +174,39 @@
       "you-are-depositing": "You are depositing as collateral"
     },
     "bridge": {
+      "activity": {
+        "bridge-text": "{{amount}} {{symbol}} from {{fromChain}} to {{toChain}}"
+      },
+      "fees": {
+        "layerzero-fee": "LayerZero fee"
+      },
       "form": {
         "action": "Bridge",
+        "from-chain": "from {{chain}}",
+        "on-chain": "on {{chain}}",
+        "preview-error": "Could not estimate fee",
         "you-are-sending": "You are sending",
         "you-will-receive": "You will receive"
+      },
+      "progress": {
+        "approve-description": "This lets the bridge contract spend this token.",
+        "approve-title": "Approve in wallet",
+        "bridge-progress": "Bridge progress",
+        "retry": "Retry",
+        "send-description": "Review the details and confirm the bridge in your wallet.",
+        "send-title": "Confirm in wallet",
+        "title": "Bridge in progress",
+        "waiting-description": "We're waiting for funds to arrive from the source chain — this can take a few minutes.",
+        "waiting-title": "Waiting for funds to arrive"
       },
       "select-chain": "Select chain",
       "select-from-chain": "Select source chain",
       "select-to-chain": "Select destination chain",
-      "title": "Bridge assets across chains"
+      "title": "Bridge assets across chains",
+      "toast": {
+        "bridge-description": "Your tokens are on their way to the destination chain.",
+        "bridge-title": "Bridge confirmed"
+      }
     },
     "earn": {
       "activity": {

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -174,15 +174,39 @@
       "you-are-depositing": "Está depositando como garantía"
     },
     "bridge": {
+      "activity": {
+        "bridge-text": "{{amount}} {{symbol}} de {{fromChain}} a {{toChain}}"
+      },
+      "fees": {
+        "layerzero-fee": "Tarifa LayerZero"
+      },
       "form": {
         "action": "Transferir",
+        "from-chain": "desde {{chain}}",
+        "on-chain": "en {{chain}}",
+        "preview-error": "No se pudo estimar la tarifa",
         "you-are-sending": "Estás enviando",
         "you-will-receive": "Recibirás"
+      },
+      "progress": {
+        "approve-description": "Esto permite al contrato del puente gastar este token.",
+        "approve-title": "Aprobar en la billetera",
+        "bridge-progress": "Progreso del puente",
+        "retry": "Reintentar",
+        "send-description": "Revise los detalles y confirme la transferencia en su billetera.",
+        "send-title": "Confirmar en la billetera",
+        "title": "Transferencia en curso",
+        "waiting-description": "Estamos esperando que los fondos lleguen desde la red de origen — esto puede tardar unos minutos.",
+        "waiting-title": "Esperando que lleguen los fondos"
       },
       "select-chain": "Seleccionar red",
       "select-from-chain": "Seleccionar red de origen",
       "select-to-chain": "Seleccionar red de destino",
-      "title": "Transfiera activos entre redes"
+      "title": "Transfiera activos entre redes",
+      "toast": {
+        "bridge-description": "Sus tokens están en camino a la red de destino.",
+        "bridge-title": "Transferencia confirmada"
+      }
     },
     "earn": {
       "activity": {

--- a/web/src/networks/index.ts
+++ b/web/src/networks/index.ts
@@ -1,3 +1,4 @@
+import type { Chain } from "viem";
 import { arbitrum, base, bsc, hemi, optimism } from "viem/chains";
 
 import { mainnet } from "./mainnet";
@@ -10,3 +11,11 @@ export const allChains = [
   optimism,
   bsc,
 ] as const;
+
+export const getChainById = function (chainId: Chain["id"]) {
+  const chain = allChains.find((c) => c.id === chainId);
+  if (!chain) {
+    throw new Error(`Chain with id ${chainId} not found`);
+  }
+  return chain;
+};

--- a/web/src/utils/inputError.ts
+++ b/web/src/utils/inputError.ts
@@ -1,6 +1,6 @@
 import type { InputError } from "components/tokenInput/utils";
 
-export function getSwapErrors({
+export function getInputError({
   amount,
   maxWithdraw,
   nativeBalance,

--- a/web/stories/chainLogo.stories.tsx
+++ b/web/stories/chainLogo.stories.tsx
@@ -12,6 +12,13 @@ const unknownChain = {
 } as unknown as Chain;
 
 const meta: Meta<typeof ChainLogo> = {
+  args: { size: "base" },
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["base", "large", "small", "xLarge"],
+    },
+  },
   component: ChainLogo,
   title: "Components/ChainLogo",
 };
@@ -45,4 +52,20 @@ export const Bsc: Story = {
 
 export const UnknownChain: Story = {
   args: { chain: unknownChain },
+};
+
+export const Small: Story = {
+  args: { chain: hemi, size: "small" },
+};
+
+export const Large: Story = {
+  args: { chain: hemi, size: "large" },
+};
+
+export const XLarge: Story = {
+  args: { chain: hemi, size: "xLarge" },
+};
+
+export const UnknownChainLarge: Story = {
+  args: { chain: unknownChain, size: "large" },
 };

--- a/web/test/components/bridgeForm/bridgeFormReducer.test.ts
+++ b/web/test/components/bridgeForm/bridgeFormReducer.test.ts
@@ -25,6 +25,17 @@ const mockToken2: BridgeableToken = {
   symbol: "VUSD",
 };
 
+const mockToken3: BridgeableToken = {
+  address: "0x8a654093e21703afc8d038FF253A3c974C5C2957",
+  chainId: 8453,
+  decimals: 18,
+  logoURI: "https://example.com/vusd.svg",
+  name: "Vetro USD",
+  symbol: "VUSD",
+};
+
+const tokens = [mockToken1, mockToken2, mockToken3];
+
 const createInitialState = (): BridgeFormState => ({
   approve10x: false,
   fromInputValue: "0",
@@ -69,26 +80,49 @@ describe("bridgeFormReducer", function () {
     expect(result.fromInputValue).toBe("0");
   });
 
-  it("SET_FROM_TOKEN changes source token", function () {
+  it("SET_FROM_TOKEN changes source token when chains do not conflict", function () {
     const state = createInitialState();
-    const newToken: BridgeableToken = { ...mockToken2, chainId: 8453 };
     const result = bridgeFormReducer(state, {
-      payload: newToken,
+      payload: { token: mockToken3, tokens },
       type: "SET_FROM_TOKEN",
     });
-    expect(result.fromToken).toBe(newToken);
+    expect(result.fromToken).toBe(mockToken3);
     expect(result.toToken).toBe(mockToken2);
   });
 
-  it("SET_TO_TOKEN changes target token", function () {
+  it("SET_FROM_TOKEN picks a counterpart for toToken when chains conflict", function () {
     const state = createInitialState();
-    const newToken: BridgeableToken = { ...mockToken1, chainId: 8453 };
+    // mockToken2 lives on the same chain as the current toToken (also mockToken2).
     const result = bridgeFormReducer(state, {
-      payload: newToken,
+      payload: { token: mockToken2, tokens },
+      type: "SET_FROM_TOKEN",
+    });
+    expect(result.fromToken).toBe(mockToken2);
+    // toToken must be reassigned to a token on a different chain.
+    expect(result.toToken.chainId).not.toBe(mockToken2.chainId);
+    expect(result.toToken.symbol).toBe(mockToken2.symbol);
+  });
+
+  it("SET_TO_TOKEN changes target token when chains do not conflict", function () {
+    const state = createInitialState();
+    const result = bridgeFormReducer(state, {
+      payload: { token: mockToken3, tokens },
       type: "SET_TO_TOKEN",
     });
-    expect(result.toToken).toBe(newToken);
+    expect(result.toToken).toBe(mockToken3);
     expect(result.fromToken).toBe(mockToken1);
+  });
+
+  it("SET_TO_TOKEN picks a counterpart for fromToken when chains conflict", function () {
+    const state = createInitialState();
+    // mockToken1 lives on the same chain as the current fromToken (also mockToken1).
+    const result = bridgeFormReducer(state, {
+      payload: { token: mockToken1, tokens },
+      type: "SET_TO_TOKEN",
+    });
+    expect(result.toToken).toBe(mockToken1);
+    expect(result.fromToken.chainId).not.toBe(mockToken1.chainId);
+    expect(result.fromToken.symbol).toBe(mockToken1.symbol);
   });
 
   it("TOGGLE_TOKENS swaps tokens and preserves input value", function () {

--- a/web/test/fetchers/fetchBridgeLayerZeroFee.test.ts
+++ b/web/test/fetchers/fetchBridgeLayerZeroFee.test.ts
@@ -1,0 +1,101 @@
+import { previewBridgeQueryKey } from "hooks/usePreviewBridge";
+import { tokenPricesOptions } from "hooks/useTokenPrices";
+import { type Address, type Client, parseUnits, zeroAddress } from "viem";
+import { bsc, hemi, mainnet } from "viem/chains";
+import { describe, expect, it, vi } from "vitest";
+
+import { fetchBridgeLayerZeroFee } from "../../src/fetchers/fetchBridgeLayerZeroFee";
+import { createTestQueryClient } from "../utils";
+
+vi.mock("hooks/useTokenPrices", () => ({
+  tokenPricesOptions: vi.fn().mockReturnValue({
+    queryFn: () => ({}),
+    queryKey: ["token-prices"],
+  }),
+}));
+
+const sourceChainId = mainnet.id;
+const destinationChainId = hemi.id;
+const oftAddress: Address = "0xFc8Acf5ef1E8839Ec94151740CfEd95D7E579Afb";
+
+describe("fetchBridgeLayerZeroFee", function () {
+  const mockRecipient = zeroAddress;
+
+  function createPrepopulatedQueryClient(nativeFee: bigint) {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      previewBridgeQueryKey({
+        amount: 100n,
+        destinationChainId,
+        oftAddress,
+        recipient: mockRecipient,
+        sourceChainId,
+      }),
+      { lzTokenFee: 0n, nativeFee },
+    );
+    return queryClient;
+  }
+
+  function mockPrices(prices: Record<string, string>) {
+    vi.mocked(tokenPricesOptions).mockReturnValue({
+      queryFn: () => prices,
+      queryKey: ["token-prices"],
+    } as never);
+  }
+
+  it("returns the LayerZero native fee in USD priced by source chain native symbol", async function () {
+    const nativeFee = 5_000_000_000_000_000n; // 0.005 ETH
+    const queryClient = createPrepopulatedQueryClient(nativeFee);
+    mockPrices({ ETH: "2000" });
+
+    const result = await fetchBridgeLayerZeroFee({
+      amount: 100n,
+      client: { chain: mainnet } as unknown as Client,
+      destinationChainId,
+      oftAddress,
+      queryClient,
+      recipient: mockRecipient,
+      sourceChainId,
+    });
+
+    // 0.005 ETH * $2000 = $10
+    expect(result).toBeCloseTo(10);
+  });
+
+  it("prices in BNB on BSC source chain", async function () {
+    const nativeFee = parseUnits("0.002", bsc.nativeCurrency.decimals);
+    const queryClient = createPrepopulatedQueryClient(nativeFee);
+    // ETH price intentionally set wildly different to prove BNB is used.
+    mockPrices({ BNB: "300", ETH: "2000" });
+
+    const result = await fetchBridgeLayerZeroFee({
+      amount: 100n,
+      client: { chain: bsc } as unknown as Client,
+      destinationChainId,
+      oftAddress,
+      queryClient,
+      recipient: mockRecipient,
+      sourceChainId,
+    });
+
+    // 0.002 BNB * $300 = $0.6
+    expect(result).toBeCloseTo(0.6);
+  });
+
+  it("throws when the native price is missing from the API", async function () {
+    const queryClient = createPrepopulatedQueryClient(1n);
+    mockPrices({ USDC: "1" });
+
+    await expect(
+      fetchBridgeLayerZeroFee({
+        amount: 100n,
+        client: { chain: mainnet } as unknown as Client,
+        destinationChainId,
+        oftAddress,
+        queryClient,
+        recipient: mockRecipient,
+        sourceChainId,
+      }),
+    ).rejects.toThrow("Invalid ETH price");
+  });
+});

--- a/web/test/fetchers/fetchBridgeLayerZeroFee.test.ts
+++ b/web/test/fetchers/fetchBridgeLayerZeroFee.test.ts
@@ -21,7 +21,10 @@ const oftAddress: Address = "0xFc8Acf5ef1E8839Ec94151740CfEd95D7E579Afb";
 describe("fetchBridgeLayerZeroFee", function () {
   const mockRecipient = zeroAddress;
 
-  function createPrepopulatedQueryClient(nativeFee: bigint) {
+  function createPrepopulatedQueryClient(
+    nativeFee: bigint,
+    chainId: number = sourceChainId,
+  ) {
     const queryClient = createTestQueryClient();
     queryClient.setQueryData(
       previewBridgeQueryKey({
@@ -29,7 +32,7 @@ describe("fetchBridgeLayerZeroFee", function () {
         destinationChainId,
         oftAddress,
         recipient: mockRecipient,
-        sourceChainId,
+        sourceChainId: chainId,
       }),
       { lzTokenFee: 0n, nativeFee },
     );
@@ -64,7 +67,7 @@ describe("fetchBridgeLayerZeroFee", function () {
 
   it("prices in BNB on BSC source chain", async function () {
     const nativeFee = parseUnits("0.002", bsc.nativeCurrency.decimals);
-    const queryClient = createPrepopulatedQueryClient(nativeFee);
+    const queryClient = createPrepopulatedQueryClient(nativeFee, bsc.id);
     // ETH price intentionally set wildly different to prove BNB is used.
     mockPrices({ BNB: "300", ETH: "2000" });
 
@@ -75,7 +78,7 @@ describe("fetchBridgeLayerZeroFee", function () {
       oftAddress,
       queryClient,
       recipient: mockRecipient,
-      sourceChainId,
+      sourceChainId: bsc.id,
     });
 
     // 0.002 BNB * $300 = $0.6

--- a/web/test/fetchers/fetchBridgeNetworkFee.test.ts
+++ b/web/test/fetchers/fetchBridgeNetworkFee.test.ts
@@ -1,0 +1,257 @@
+import { estimateFeesQueryOptions } from "@hemilabs/react-hooks/useEstimateFees";
+import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
+import { previewBridgeQueryKey } from "hooks/usePreviewBridge";
+import { tokenPricesOptions } from "hooks/useTokenPrices";
+import type { BridgeableToken } from "types";
+import { type Address, type Client, parseEther, zeroAddress } from "viem";
+import { estimateGas, readContract } from "viem/actions";
+import { bsc, hemi, mainnet } from "viem/chains";
+import { describe, expect, it, vi } from "vitest";
+
+import { estimateApprovalGasUnits } from "../../src/fetchers/estimateApprovalGasUnits";
+import { fetchBridgeNetworkFee } from "../../src/fetchers/fetchBridgeNetworkFee";
+import { createTestQueryClient } from "../utils";
+
+vi.mock("../../src/fetchers/estimateApprovalGasUnits", () => ({
+  estimateApprovalGasUnits: vi.fn(),
+}));
+
+vi.mock("@vetro-protocol/bridge/actions", () => ({
+  encodeSend: vi.fn().mockReturnValue("0x"),
+}));
+
+vi.mock("viem/actions", () => ({
+  estimateGas: vi.fn(),
+  readContract: vi.fn(),
+}));
+
+vi.mock("utils/erc20StateOverride", () => ({
+  createErc20AllowanceStateOverride: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("@hemilabs/react-hooks/useEstimateFees", () => ({
+  estimateFeesQueryOptions: vi.fn().mockReturnValue({
+    queryFn: () => 0n,
+    queryKey: ["estimate-fees"],
+  }),
+}));
+
+vi.mock("hooks/useTokenPrices", () => ({
+  tokenPricesOptions: vi.fn().mockReturnValue({
+    queryFn: () => ({}),
+    queryKey: ["token-prices"],
+  }),
+}));
+
+vi.mock("providers/web3Provider", () => ({
+  config: {},
+}));
+
+const sourceChainId = mainnet.id;
+const destinationChainId = hemi.id;
+const oftAddress: Address = "0xFc8Acf5ef1E8839Ec94151740CfEd95D7E579Afb";
+
+describe("fetchBridgeNetworkFee", function () {
+  const mockOwner = zeroAddress;
+  const mockRecipient = zeroAddress;
+  const mockClient = {
+    chain: mainnet,
+  } as unknown as Client;
+  // @ts-expect-error - only address and chainId are needed for these tests
+  const mockToken = {
+    address: zeroAddress,
+    chainId: sourceChainId,
+  } as BridgeableToken;
+
+  function createPrepopulatedQueryClient({
+    balance = 1000n,
+    nativeFee = 5n,
+  }: { balance?: bigint; nativeFee?: bigint } = {}) {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(
+      tokenBalanceQueryKey(
+        { address: zeroAddress, chainId: sourceChainId },
+        mockOwner,
+      ),
+      balance,
+    );
+    queryClient.setQueryData(
+      previewBridgeQueryKey({
+        amount: 100n,
+        destinationChainId,
+        oftAddress,
+        recipient: mockRecipient,
+        sourceChainId,
+      }),
+      { lzTokenFee: 0n, nativeFee },
+    );
+    return queryClient;
+  }
+
+  function mockNetworkFeeAndPrices({
+    networkFeeWei,
+    prices,
+  }: {
+    networkFeeWei: bigint;
+    prices: Record<string, string>;
+  }) {
+    vi.mocked(estimateFeesQueryOptions).mockReturnValue({
+      queryFn: () => networkFeeWei,
+      queryKey: ["estimate-fees"],
+    } as never);
+    vi.mocked(tokenPricesOptions).mockReturnValue({
+      queryFn: () => prices,
+      queryKey: ["token-prices"],
+    } as never);
+  }
+
+  it("returns USD from approval and send gas when approval is required", async function () {
+    const approvalGas = 46_000n;
+    const sendGas = 250_000n;
+    const networkFeeWei = parseEther("0.01");
+    const queryClient = createPrepopulatedQueryClient();
+
+    vi.mocked(readContract).mockResolvedValue(true);
+    vi.mocked(estimateApprovalGasUnits).mockResolvedValue(approvalGas);
+    vi.mocked(estimateGas).mockResolvedValue(sendGas);
+    mockNetworkFeeAndPrices({
+      networkFeeWei,
+      prices: { ETH: "2000" },
+    });
+
+    const result = await fetchBridgeNetworkFee({
+      amount: 100n,
+      approveAmount: 100n,
+      client: mockClient,
+      destinationChainId,
+      oftAddress,
+      owner: mockOwner,
+      queryClient,
+      recipient: mockRecipient,
+      sourceChainId,
+      sourceToken: mockToken,
+    });
+
+    // 0.01 ETH * $2000 = $20
+    expect(result).toBeCloseTo(20);
+    expect(estimateApprovalGasUnits).toHaveBeenCalledOnce();
+    expect(estimateFeesQueryOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ gasUnits: approvalGas + sendGas }),
+    );
+  });
+
+  it("skips approval gas when approval is not required", async function () {
+    const sendGas = 200_000n;
+    const networkFeeWei = parseEther("0.01");
+    const queryClient = createPrepopulatedQueryClient();
+
+    vi.mocked(readContract).mockResolvedValue(false);
+    vi.mocked(estimateGas).mockResolvedValue(sendGas);
+    mockNetworkFeeAndPrices({
+      networkFeeWei,
+      prices: { ETH: "2000" },
+    });
+
+    const result = await fetchBridgeNetworkFee({
+      amount: 100n,
+      approveAmount: undefined,
+      client: mockClient,
+      destinationChainId,
+      oftAddress,
+      owner: mockOwner,
+      queryClient,
+      recipient: mockRecipient,
+      sourceChainId,
+      sourceToken: mockToken,
+    });
+
+    expect(result).toBeCloseTo(20);
+    expect(estimateApprovalGasUnits).not.toHaveBeenCalled();
+    expect(estimateFeesQueryOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ gasUnits: sendGas }),
+    );
+  });
+
+  it("forwards the LayerZero native fee as the send tx value", async function () {
+    const nativeFee = 12_345n;
+    const queryClient = createPrepopulatedQueryClient({ nativeFee });
+
+    vi.mocked(readContract).mockResolvedValue(false);
+    vi.mocked(estimateGas).mockResolvedValue(180_000n);
+    mockNetworkFeeAndPrices({
+      networkFeeWei: 0n,
+      prices: { ETH: "2000" },
+    });
+
+    await fetchBridgeNetworkFee({
+      amount: 100n,
+      approveAmount: undefined,
+      client: mockClient,
+      destinationChainId,
+      oftAddress,
+      owner: mockOwner,
+      queryClient,
+      recipient: mockRecipient,
+      sourceChainId,
+      sourceToken: mockToken,
+    });
+
+    expect(estimateGas).toHaveBeenCalledWith(
+      mockClient,
+      expect.objectContaining({ to: oftAddress, value: nativeFee }),
+    );
+  });
+
+  it("prices in BNB on BSC source chain", async function () {
+    const sendGas = 200_000n;
+    const networkFeeWei = parseEther("0.01");
+    const queryClient = createPrepopulatedQueryClient();
+
+    vi.mocked(readContract).mockResolvedValue(false);
+    vi.mocked(estimateGas).mockResolvedValue(sendGas);
+    mockNetworkFeeAndPrices({
+      networkFeeWei,
+      prices: { BNB: "300", ETH: "2000" },
+    });
+
+    const bscClient = { chain: bsc } as unknown as Client;
+    const result = await fetchBridgeNetworkFee({
+      amount: 100n,
+      approveAmount: undefined,
+      client: bscClient,
+      destinationChainId,
+      oftAddress,
+      owner: mockOwner,
+      queryClient,
+      recipient: mockRecipient,
+      sourceChainId,
+      sourceToken: mockToken,
+    });
+
+    // 0.01 BNB * $300 = $3
+    expect(result).toBeCloseTo(3);
+  });
+
+  it("throws when amount exceeds token balance", async function () {
+    const queryClient = createPrepopulatedQueryClient({ balance: 50n });
+
+    await expect(
+      fetchBridgeNetworkFee({
+        amount: 100n,
+        approveAmount: 100n,
+        client: mockClient,
+        destinationChainId,
+        oftAddress,
+        owner: mockOwner,
+        queryClient,
+        recipient: mockRecipient,
+        sourceChainId,
+        sourceToken: mockToken,
+      }),
+    ).rejects.toThrow("Insufficient token balance");
+
+    expect(readContract).not.toHaveBeenCalled();
+    expect(estimateGas).not.toHaveBeenCalled();
+    expect(estimateApprovalGasUnits).not.toHaveBeenCalled();
+  });
+});

--- a/web/test/fetchers/fetchBridgeNetworkFee.test.ts
+++ b/web/test/fetchers/fetchBridgeNetworkFee.test.ts
@@ -65,14 +65,12 @@ describe("fetchBridgeNetworkFee", function () {
 
   function createPrepopulatedQueryClient({
     balance = 1000n,
+    chainId = sourceChainId,
     nativeFee = 5n,
-  }: { balance?: bigint; nativeFee?: bigint } = {}) {
+  }: { balance?: bigint; chainId?: number; nativeFee?: bigint } = {}) {
     const queryClient = createTestQueryClient();
     queryClient.setQueryData(
-      tokenBalanceQueryKey(
-        { address: zeroAddress, chainId: sourceChainId },
-        mockOwner,
-      ),
+      tokenBalanceQueryKey({ address: zeroAddress, chainId }, mockOwner),
       balance,
     );
     queryClient.setQueryData(
@@ -81,7 +79,7 @@ describe("fetchBridgeNetworkFee", function () {
         destinationChainId,
         oftAddress,
         recipient: mockRecipient,
-        sourceChainId,
+        sourceChainId: chainId,
       }),
       { lzTokenFee: 0n, nativeFee },
     );
@@ -205,7 +203,12 @@ describe("fetchBridgeNetworkFee", function () {
   it("prices in BNB on BSC source chain", async function () {
     const sendGas = 200_000n;
     const networkFeeWei = parseEther("0.01");
-    const queryClient = createPrepopulatedQueryClient();
+    const queryClient = createPrepopulatedQueryClient({ chainId: bsc.id });
+    // @ts-expect-error - only address and chainId are needed for these tests
+    const bscToken = {
+      address: zeroAddress,
+      chainId: bsc.id,
+    } as BridgeableToken;
 
     vi.mocked(readContract).mockResolvedValue(false);
     vi.mocked(estimateGas).mockResolvedValue(sendGas);
@@ -224,8 +227,8 @@ describe("fetchBridgeNetworkFee", function () {
       owner: mockOwner,
       queryClient,
       recipient: mockRecipient,
-      sourceChainId,
-      sourceToken: mockToken,
+      sourceChainId: bsc.id,
+      sourceToken: bscToken,
     });
 
     // 0.01 BNB * $300 = $3

--- a/web/test/fetchers/fetchTotalBridgeSendFees.test.ts
+++ b/web/test/fetchers/fetchTotalBridgeSendFees.test.ts
@@ -1,0 +1,86 @@
+import { bridgeLayerZeroFeeOptions } from "hooks/useBridgeLayerZeroFee";
+import { bridgeNetworkFeeOptions } from "hooks/useBridgeNetworkFee";
+import type { BridgeableToken } from "types";
+import { type Address, type Client, zeroAddress } from "viem";
+import { describe, expect, it, vi } from "vitest";
+
+import { fetchTotalBridgeSendFees } from "../../src/fetchers/fetchTotalBridgeSendFees";
+import { createTestQueryClient } from "../utils";
+
+vi.mock("hooks/useBridgeLayerZeroFee", () => ({
+  bridgeLayerZeroFeeOptions: vi.fn(),
+}));
+
+vi.mock("hooks/useBridgeNetworkFee", () => ({
+  bridgeNetworkFeeOptions: vi.fn(),
+}));
+
+const sourceChainId = 1;
+const destinationChainId = 43111;
+const oftAddress: Address = "0xFc8Acf5ef1E8839Ec94151740CfEd95D7E579Afb";
+
+describe("fetchTotalBridgeSendFees", function () {
+  const mockOwner = zeroAddress;
+  const mockRecipient = zeroAddress;
+  const mockClient = {} as unknown as Client;
+  // @ts-expect-error - only address and chainId are needed for these tests
+  const mockToken = {
+    address: zeroAddress,
+    chainId: sourceChainId,
+  } as BridgeableToken;
+
+  it("returns the sum of LayerZero and network fees in USD", async function () {
+    const layerZeroFeeUsd = 0.42;
+    const networkFeeUsd = 1.18;
+
+    vi.mocked(bridgeLayerZeroFeeOptions).mockReturnValue({
+      queryFn: () => layerZeroFeeUsd,
+      queryKey: ["bridge-layerzero-fee"],
+    } as never);
+    vi.mocked(bridgeNetworkFeeOptions).mockReturnValue({
+      queryFn: () => networkFeeUsd,
+      queryKey: ["bridge-network-fee"],
+    } as never);
+
+    const result = await fetchTotalBridgeSendFees({
+      amount: 100n,
+      approveAmount: undefined,
+      client: mockClient,
+      destinationChainId,
+      oftAddress,
+      owner: mockOwner,
+      queryClient: createTestQueryClient(),
+      recipient: mockRecipient,
+      sourceChainId,
+      sourceToken: mockToken,
+    });
+
+    expect(result).toBeCloseTo(layerZeroFeeUsd + networkFeeUsd);
+  });
+
+  it("propagates errors from the network fee fetcher", async function () {
+    vi.mocked(bridgeLayerZeroFeeOptions).mockReturnValue({
+      queryFn: () => 1,
+      queryKey: ["bridge-layerzero-fee"],
+    } as never);
+    vi.mocked(bridgeNetworkFeeOptions).mockReturnValue({
+      queryFn: () => Promise.reject(new Error("Insufficient token balance")),
+      queryKey: ["bridge-network-fee"],
+    } as never);
+
+    await expect(
+      fetchTotalBridgeSendFees({
+        amount: 100n,
+        approveAmount: undefined,
+        client: mockClient,
+        destinationChainId,
+        oftAddress,
+        owner: mockOwner,
+        queryClient: createTestQueryClient(),
+        recipient: mockRecipient,
+        sourceChainId,
+        sourceToken: mockToken,
+      }),
+    ).rejects.toThrow("Insufficient token balance");
+  });
+});

--- a/web/test/networks/index.test.ts
+++ b/web/test/networks/index.test.ts
@@ -1,0 +1,17 @@
+import { hemi } from "viem/chains";
+import { describe, expect, it } from "vitest";
+
+import { getChainById } from "../../src/networks";
+
+describe("getChainById", function () {
+  it("returns the chain when chainId exists in allChains", function () {
+    const result = getChainById(hemi.id);
+    expect(result).toBe(hemi);
+  });
+
+  it("throws when chainId is not found", function () {
+    expect(() => getChainById(999_999)).toThrow(
+      "Chain with id 999999 not found",
+    );
+  });
+});

--- a/web/test/utils/inputError.test.ts
+++ b/web/test/utils/inputError.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getSwapErrors } from "../../../src/components/swapForm/validation";
+import { getInputError } from "../../src/utils/inputError";
 
-describe("getSwapErrors", function () {
+describe("getInputError", function () {
   it("returns 'enter-amount' when amount is 0", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 0n,
       nativeBalance: 100n,
       tokenBalance: 1000n,
@@ -13,7 +13,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns 'insufficient-balance' when amount exceeds tokenBalance", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 2000n,
       nativeBalance: 100n,
       tokenBalance: 1000n,
@@ -22,7 +22,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns 'insufficient-gas' when nativeBalance is 0", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 500n,
       nativeBalance: 0n,
       tokenBalance: 1000n,
@@ -31,7 +31,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns undefined when all conditions are valid", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 500n,
       nativeBalance: 100n,
       tokenBalance: 1000n,
@@ -40,7 +40,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns undefined when tokenBalance is undefined and amount is valid", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 500n,
       nativeBalance: 100n,
       tokenBalance: undefined,
@@ -49,7 +49,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns undefined when nativeBalance is undefined and amount is valid", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 500n,
       nativeBalance: undefined,
       tokenBalance: 1000n,
@@ -58,7 +58,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns undefined when both balances are undefined and amount is valid", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 500n,
       nativeBalance: undefined,
       tokenBalance: undefined,
@@ -67,7 +67,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns undefined when amount equals tokenBalance", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 1000n,
       nativeBalance: 100n,
       tokenBalance: 1000n,
@@ -76,7 +76,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns 'insufficient-balance' when amount is 1 unit more than balance", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 1001n,
       nativeBalance: 100n,
       tokenBalance: 1000n,
@@ -85,7 +85,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns 'insufficient-gas' when nativeBalance is 0 and tokenBalance is undefined", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 500n,
       nativeBalance: 0n,
       tokenBalance: undefined,
@@ -94,7 +94,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns 'insufficient-treasury' when redeemPreview exceeds maxWithdraw", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 500n,
       maxWithdraw: 100n,
       nativeBalance: 100n,
@@ -105,7 +105,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns undefined when redeemPreview does not exceed maxWithdraw", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 500n,
       maxWithdraw: 300n,
       nativeBalance: 100n,
@@ -116,7 +116,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns undefined when maxWithdraw is undefined", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 500n,
       maxWithdraw: undefined,
       nativeBalance: 100n,
@@ -127,7 +127,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns undefined when redeemPreview is undefined", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 500n,
       maxWithdraw: 100n,
       nativeBalance: 100n,
@@ -138,7 +138,7 @@ describe("getSwapErrors", function () {
   });
 
   it("returns 'insufficient-balance' before 'insufficient-treasury' when both apply", function () {
-    const result = getSwapErrors({
+    const result = getInputError({
       amount: 2000n,
       maxWithdraw: 100n,
       nativeBalance: 100n,


### PR DESCRIPTION
### Description

Implements the bridge page on top of the previously merged `@vetro-protocol/bridge` package. Users can send VUSD across LayerZero-supported chains (Ethereum, Hemi, Arbitrum, Base, BSC, Optimism).

- Three React Query hooks compute USD fees: `useBridgeLayerZeroFee` (native messaging fee), `useBridgeNetworkFee` (gas for approval + send), and `useTotalBridgeSendFees` (sum). Native price is looked up by source chain symbol so BSC is priced in BNB.
- `useBridge` mutation orchestrates approve + send through the bridge package's event stream and invalidates the relevant balance / allowance / preview caches.
- `BridgeFees` shows the breakdown in USD; `BridgeSubmitDrawer` shows approve / send / waiting steps with retry on failure. The reducer resolves token counterparts internally so chain conflicts resolve in a single dispatch.
- Wallet drawer surfaces bridge activities under their own filter and links to layerzeroscan (the LayerZero message spans both chains).
- Generalizes the existing `getSwapErrors` validator into a shared `getInputError` util reused across swap + bridge.
- `ChainLogo` and `TokenChainLogo` now accept a `size` prop so the submit drawer can render larger badges.

**Commits:**

- 00861dc Add bridge to activity list page types
- 19fd34b Add size prop to ChainLogo and TokenChainLogo
- 078ef7d Generalize getSwapErrors into shared util
- 007e7f1 Resolve token counterpart inside bridge reducer
- 5714885 Add bridge send fee fetchers and hooks
- 0a52b2a Add bridge submit drawer and form wiring

See also this comment https://github.com/vetro-protocol/vetro-monorepo/pull/387#issuecomment-4389998453

### Screenshots

https://github.com/user-attachments/assets/2aa96126-7f91-4b2a-b054-7664b6714451

### Related issue(s)

Related to #338

### Checklist

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.