### PR TITLE
Add fade-and-slide animation to tooltip

### DIFF
--- a/web/src/components/tooltip/index.tsx
+++ b/web/src/components/tooltip/index.tsx
@@ -11,6 +11,9 @@ type Props = {
 };
 
 const getTooltipContainer = (node: HTMLElement) => node.parentElement!;
+// motionName is the prefix rc-motion uses to toggle the
+// `vetro-tooltip-{appear,enter,leave}[-active]` classes that tooltip.css targets.
+const motion = { motionName: "vetro-tooltip" };
 
 export const Tooltip = ({
   children,
@@ -20,6 +23,7 @@ export const Tooltip = ({
 }: Props) => (
   <RcTooltip
     getTooltipContainer={useParentContainer ? getTooltipContainer : undefined}
+    motion={motion}
     overlay={
       <div className="text-b-medium max-w-xs rounded-md bg-gray-900 px-1.5 py-1 text-white">
         {content}

--- a/web/src/components/tooltip/tooltip.css
+++ b/web/src/components/tooltip/tooltip.css
@@ -18,3 +18,31 @@
   min-height: 0;
   padding: 0;
 }
+
+/* Transform targets the inner content, not .rc-tooltip itself: rc-trigger
+   re-aligns the wrapper via getBoundingClientRect after motion ends, and a
+   wrapper-level translateY shifts that rect, causing a post-animation snap. */
+.vetro-tooltip-appear .rc-tooltip-content,
+.vetro-tooltip-enter .rc-tooltip-content {
+  opacity: 0;
+  transform: translateY(4px);
+}
+
+.vetro-tooltip-appear-active .rc-tooltip-content,
+.vetro-tooltip-enter-active .rc-tooltip-content {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.vetro-tooltip-leave-active .rc-tooltip-content {
+  opacity: 0;
+  transform: translateY(4px);
+}
+
+.vetro-tooltip-appear-active .rc-tooltip-content,
+.vetro-tooltip-enter-active .rc-tooltip-content,
+.vetro-tooltip-leave-active .rc-tooltip-content {
+  transition:
+    opacity 100ms ease,
+    transform 100ms ease;
+}

--- a/web/src/components/tooltip/tooltip.css
+++ b/web/src/components/tooltip/tooltip.css
@@ -46,3 +46,14 @@
     opacity 100ms ease,
     transform 100ms ease;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .vetro-tooltip-appear .rc-tooltip-content,
+  .vetro-tooltip-enter .rc-tooltip-content,
+  .vetro-tooltip-appear-active .rc-tooltip-content,
+  .vetro-tooltip-enter-active .rc-tooltip-content,
+  .vetro-tooltip-leave-active .rc-tooltip-content {
+    transform: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
### Description

Hovering a Tooltip now fades and slides the content in/out over 100ms, matching the design in #346.

The animation is wired through rc-motion's `motionName` prop, which toggles `vetro-tooltip-{appear,enter,leave}[-active]` classes on the popup; `tooltip.css` defines the transitions for those classes. The transform targets `.rc-tooltip-content` (the inner wrapper) rather than `.rc-tooltip` itself, because rc-trigger re-aligns the outer wrapper via `getBoundingClientRect` after motion ends — a wrapper-level `translateY` would shift that rect and produce a post-animation snap.

### Screenshots

<!-- video to be added -->

https://github.com/user-attachments/assets/2e0ecaf7-5b09-4b44-8bb3-8d00322bb4be


### Related issue(s)

Closes #346

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.