### PR TITLE
Remove bridge feature flag

### DIFF
--- a/web/.env
+++ b/web/.env
@@ -1,4 +1,3 @@
-VITE_FEATURE_BRIDGE_ENABLED="false"
 VITE_PORTAL_API_URL="https://portal-api.hemi.xyz"
 VITE_RPC_URL_MAINNET="https://eth.drpc.org"
 VITE_VETRO_API_URL="https://vetro-api.letshamsterdance.xyz"

--- a/web/README.md
+++ b/web/README.md
@@ -8,14 +8,13 @@ Built with React, Viem, Wagmi, and Tailwind CSS.
 
 Vite only exposes variables prefixed with `VITE_` to the client bundle. Set these in `web/.env` (or a `.env.local` override) before running `dev` or `build`.
 
-| Variable                      | Required | Description                                                                                    |
-| ----------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `VITE_DEPLOY_ENV`             | No       | Set to `"production"` to hide source maps from browsers. Any other value serves them publicly. |
-| `VITE_FEATURE_BRIDGE_ENABLED` | No       | When `"true"`, the `/bridge` route and its nav entry are rendered. Defaults to false.          |
-| `VITE_PORTAL_API_URL`         | Yes      | Hemi Portal API base URL (used for token prices).                                              |
-| `VITE_RPC_URL_MAINNET`        | No       | RPC URL for Ethereum mainnet. Falls back to viem's default when unset.                         |
-| `VITE_SENTRY_DSN`             | No       | Sentry DSN. When unset, Sentry is disabled.                                                    |
-| `VITE_VETRO_API_URL`          | Yes      | Vetro backend API base URL (analytics, APR history, exit tickets, rewards, etc.).              |
+| Variable               | Required | Description                                                                                    |
+| ---------------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `VITE_DEPLOY_ENV`      | No       | Set to `"production"` to hide source maps from browsers. Any other value serves them publicly. |
+| `VITE_PORTAL_API_URL`  | Yes      | Hemi Portal API base URL (used for token prices).                                              |
+| `VITE_RPC_URL_MAINNET` | No       | RPC URL for Ethereum mainnet. Falls back to viem's default when unset.                         |
+| `VITE_SENTRY_DSN`      | No       | Sentry DSN. When unset, Sentry is disabled.                                                    |
+| `VITE_VETRO_API_URL`   | Yes      | Vetro backend API base URL (analytics, APR history, exit tickets, rewards, etc.).              |
 
 The following variables are read at build time (not baked into the bundle) and only matter in CI/CD:
 

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -3,7 +3,6 @@ import { AppLayout, MainContent } from "components/base/appLayout";
 import { AppViewport } from "components/base/appViewport";
 import { ErrorBoundary } from "components/base/errorBoundary";
 import { Header } from "components/header";
-import { featureFlags } from "featureFlags";
 import { I18nInitializer } from "i18n/config";
 import { NuqsAdapter } from "nuqs/adapters/react-router/v7";
 import { Analytics } from "pages/analytics";
@@ -74,9 +73,7 @@ function LanguageRoutes() {
             <Route element={<Earn />} path="earn" />
             <Route element={<Borrow />} path="borrow" />
             <Route element={<BorrowMarketDetails />} path="borrow/:marketId" />
-            {featureFlags.bridgeEnabled && (
-              <Route element={<Bridge />} path="bridge" />
-            )}
+            <Route element={<Bridge />} path="bridge" />
             <Route element={<Analytics />} path="analytics" />
             <Route element={<Faq />} path="faq" />
           </Route>

--- a/web/src/components/navbar/links.tsx
+++ b/web/src/components/navbar/links.tsx
@@ -1,4 +1,3 @@
-import { featureFlags } from "featureFlags";
 import { useTranslation } from "react-i18next";
 
 import { I18nLink } from "../base/i18nLink";
@@ -11,11 +10,7 @@ import { SwapIcon } from "./swapIcon";
 
 export const navLinks = [
   { href: "/swap", Icon: SwapIcon, translationKey: "nav.swap" },
-  ...(featureFlags.bridgeEnabled
-    ? ([
-        { href: "/bridge", Icon: BridgeIcon, translationKey: "nav.bridge" },
-      ] as const)
-    : ([] as const)),
+  { href: "/bridge", Icon: BridgeIcon, translationKey: "nav.bridge" },
   { href: "/earn", Icon: EarnIcon, translationKey: "nav.earn" },
   { href: "/borrow", Icon: BorrowIcon, translationKey: "nav.borrow" },
   { href: "/analytics", Icon: AnalyticsIcon, translationKey: "nav.analytics" },

--- a/web/src/featureFlags.ts
+++ b/web/src/featureFlags.ts
@@ -1,3 +1,0 @@
-export const featureFlags = {
-  bridgeEnabled: import.meta.env.VITE_FEATURE_BRIDGE_ENABLED === "true",
-};


### PR DESCRIPTION
### Description

The Bridge feature is complete, so the `VITE_FEATURE_BRIDGE_ENABLED` toggle and its `featureFlags` module are no longer needed. The bridge route and navbar link are now always rendered.

### Screenshots

N/A — flag removal; no visual changes beyond `/bridge` and its nav entry now always being available.

### Related issue(s)

Closes #338

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.