### PR TITLE
Update prod ORIGINS to use beta.vetro.org

### DIFF
--- a/api/worker-configuration.d.ts
+++ b/api/worker-configuration.d.ts
@@ -6,20 +6,20 @@ declare namespace Cloudflare {
 		mainModule: typeof import("./src/index");
 	}
 	interface StagingEnv {
+		CUSTOM_RPC_URL_MAINNET: string;
 		ORIGINS: "https://vetro.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev";
 		SUBGRAPH_ID: "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6";
 		SUBGRAPH_URL_TEMPLATE: "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID";
-		CUSTOM_RPC_URL_MAINNET: string;
 	}
 	interface ProductionEnv {
-		ORIGINS: "https://app.vetro.org,https://demo.vetro.org";
+		CUSTOM_RPC_URL_MAINNET: string;
+		ORIGINS: "https://app.vetro.org,https://beta.vetro.org";
 		SUBGRAPH_ID: "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6";
 		SUBGRAPH_URL_TEMPLATE: "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID";
-		CUSTOM_RPC_URL_MAINNET: string;
 	}
 	interface Env {
 		CUSTOM_RPC_URL_MAINNET: string;
-		ORIGINS: "https://vetro.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev" | "https://app.vetro.org,https://demo.vetro.org" | "http://localhost:5173";
+		ORIGINS: "https://vetro.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev" | "https://app.vetro.org,https://beta.vetro.org" | "http://localhost:5173";
 		SUBGRAPH_ID?: "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6";
 		SUBGRAPH_URL_TEMPLATE: "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID" | "http://localhost:8000/subgraphs/name/vetro-app-subgraph";
 		MERKL_OPPORTUNITY_SVETBTC?: "";

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -40,7 +40,7 @@
       },
       "vars": {
         "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
-        "ORIGINS": "https://app.vetro.org,https://demo.vetro.org",
+        "ORIGINS": "https://app.vetro.org,https://beta.vetro.org",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
       },


### PR DESCRIPTION
### Description

Replace `demo.vetro.org` with `beta.vetro.org` in the production `ORIGINS` allow-list for the `vetro-api` worker. The companion update to `worker-configuration.d.ts` is the regenerated output of `wrangler types` for the new value.

### Screenshots

N/A

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.