### PR TITLE
Improve bridge activity tracking entries

### DIFF
--- a/web/src/components/bridgeForm/index.tsx
+++ b/web/src/components/bridgeForm/index.tsx
@@ -139,11 +139,12 @@ function BridgeFormContent({ tokens }: ContentProps) {
       page: "bridge",
       text: t("pages.bridge.activity.bridge-text", {
         amount: fromInputValue,
-        fromChain: fromChain.name,
         symbol: fromToken.symbol,
-        toChain: toChain.name,
       }),
-      title: t("nav.bridge"),
+      title: `${t("nav.bridge")} · ${t("pages.bridge.activity.bridge-title", {
+        fromChain: fromChain.name,
+        toChain: toChain.name,
+      })}`,
     });
 
   const bridgeMutation = useBridge({

--- a/web/src/components/bridgeForm/index.tsx
+++ b/web/src/components/bridgeForm/index.tsx
@@ -139,6 +139,7 @@ function BridgeFormContent({ tokens }: ContentProps) {
       page: "bridge",
       text: t("pages.bridge.activity.bridge-text", {
         amount: fromInputValue,
+        count: Number(fromInputValue),
         symbol: fromToken.symbol,
       }),
       title: `${t("nav.bridge")} · ${t("pages.bridge.activity.bridge-title", {

--- a/web/src/components/walletDrawer/walletDrawerContent.tsx
+++ b/web/src/components/walletDrawer/walletDrawerContent.tsx
@@ -61,7 +61,7 @@ export function WalletDrawerContent() {
   const { t } = useTranslation();
   const [selectedFilters, setSelectedFilters] = useState(allFilters);
 
-  const activities = useActivities(address, chain.id);
+  const activities = useActivities(address);
   const explorerBaseUrl = chain.blockExplorers!.default.url;
 
   const filteredActivities = activities.filter(

--- a/web/src/hooks/useActivityTracking.ts
+++ b/web/src/hooks/useActivityTracking.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from "react";
-import { useAccount, useChainId } from "wagmi";
+import { useAccount } from "wagmi";
 
 import type { ActivityPage } from "../components/base/activityList/types";
 import { addActivity, updateActivity } from "../stores/activityStore";
@@ -13,7 +13,6 @@ type Params = {
 
 export function useActivityTracking({ page, text, title }: Params) {
   const { address: account } = useAccount();
-  const chainId = useChainId();
   const txHashRef = useRef<string | undefined>(undefined);
 
   const onPending = useCallback(
@@ -21,7 +20,7 @@ export function useActivityTracking({ page, text, title }: Params) {
       if (!account || !txHashRef.current) {
         return;
       }
-      addActivity(account, chainId, {
+      addActivity(account, {
         date: unixNowTimestamp(),
         page,
         status: "pending",
@@ -30,7 +29,7 @@ export function useActivityTracking({ page, text, title }: Params) {
         txHash: txHashRef.current,
       });
     },
-    [account, chainId, page, text, title],
+    [account, page, text, title],
   );
 
   const onCompleted = useCallback(
@@ -38,12 +37,12 @@ export function useActivityTracking({ page, text, title }: Params) {
       if (!txHashRef.current || !account) {
         return;
       }
-      updateActivity(account, chainId, txHashRef.current, {
+      updateActivity(account, txHashRef.current, {
         status: "completed",
       });
       txHashRef.current = undefined;
     },
-    [account, chainId],
+    [account],
   );
 
   const onFailed = useCallback(
@@ -51,12 +50,12 @@ export function useActivityTracking({ page, text, title }: Params) {
       if (!txHashRef.current || !account) {
         return;
       }
-      updateActivity(account, chainId, txHashRef.current, {
+      updateActivity(account, txHashRef.current, {
         status: "failed",
       });
       txHashRef.current = undefined;
     },
-    [account, chainId],
+    [account],
   );
 
   const onTransactionHash = useCallback(function onTransactionHash(

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -175,7 +175,8 @@
     },
     "bridge": {
       "activity": {
-        "bridge-text": "{{amount}} {{symbol}} from {{fromChain}} to {{toChain}}"
+        "bridge-text": "{{amount}} {{symbol}} bridged",
+        "bridge-title": "{{fromChain}} → {{toChain}}"
       },
       "fees": {
         "layerzero-fee": "LayerZero fee"

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -175,7 +175,8 @@
     },
     "bridge": {
       "activity": {
-        "bridge-text": "{{amount}} {{symbol}} bridged",
+        "bridge-text_one": "{{amount}} {{symbol}} transferido",
+        "bridge-text_other": "{{amount}} {{symbol}} transferidos",
         "bridge-title": "{{fromChain}} → {{toChain}}"
       },
       "fees": {

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -175,7 +175,8 @@
     },
     "bridge": {
       "activity": {
-        "bridge-text": "{{amount}} {{symbol}} de {{fromChain}} a {{toChain}}"
+        "bridge-text": "{{amount}} {{symbol}} bridged",
+        "bridge-title": "{{fromChain}} → {{toChain}}"
       },
       "fees": {
         "layerzero-fee": "Tarifa LayerZero"

--- a/web/src/stores/activityStore.ts
+++ b/web/src/stores/activityStore.ts
@@ -1,5 +1,5 @@
 import { useSyncExternalStore } from "react";
-import type { Address, Chain } from "viem";
+import type { Address } from "viem";
 
 import type { Activity } from "../components/base/activityList/types";
 
@@ -14,11 +14,11 @@ function notify() {
 
 const normalize = (address: Address) => address.toLowerCase();
 
-const storageKey = (address: Address, chainId: Chain["id"]) =>
-  `${storageKeyPrefix}${chainId}:${normalize(address)}`;
+const storageKey = (address: Address) =>
+  `${storageKeyPrefix}${normalize(address)}`;
 
-function read(address: Address, chainId: Chain["id"]) {
-  const key = storageKey(address, chainId);
+function read(address: Address) {
+  const key = storageKey(address);
   if (cache.has(key)) {
     return cache.get(key)!;
   }
@@ -32,8 +32,8 @@ function read(address: Address, chainId: Chain["id"]) {
   }
 }
 
-function write(address: Address, chainId: Chain["id"], activities: Activity[]) {
-  const key = storageKey(address, chainId);
+function write(address: Address, activities: Activity[]) {
+  const key = storageKey(address);
   cache.set(key, activities);
   try {
     localStorage.setItem(key, JSON.stringify(activities));
@@ -43,26 +43,18 @@ function write(address: Address, chainId: Chain["id"], activities: Activity[]) {
   notify();
 }
 
-export function addActivity(
-  address: Address,
-  chainId: Chain["id"],
-  activity: Activity,
-) {
-  write(address, chainId, [activity, ...read(address, chainId)]);
+export function addActivity(address: Address, activity: Activity) {
+  write(address, [activity, ...read(address)]);
 }
 
 export function updateActivity(
   address: Address,
-  chainId: Chain["id"],
   txHash: string,
   updates: Partial<Omit<Activity, "txHash">>,
 ) {
   write(
     address,
-    chainId,
-    read(address, chainId).map((a) =>
-      a.txHash === txHash ? { ...a, ...updates } : a,
-    ),
+    read(address).map((a) => (a.txHash === txHash ? { ...a, ...updates } : a)),
   );
 }
 
@@ -71,12 +63,9 @@ function subscribe(cb: () => void) {
   return () => subscribers.delete(cb);
 }
 
-export const useActivities = (
-  address: Address | undefined,
-  chainId: Chain["id"],
-): Activity[] =>
+export const useActivities = (address: Address | undefined): Activity[] =>
   useSyncExternalStore(
     subscribe,
-    () => (address ? read(address, chainId) : empty),
+    () => (address ? read(address) : empty),
     () => empty,
   );


### PR DESCRIPTION
### Description

Improve the bridge activity feed entry so the route between chains lives in the title (using the `Bridge · {fromChain} → {toChain}` pattern already used by Borrow and Earn) and the text reads as a clean action summary (`{amount} {symbol} bridged`), matching the Figma reference. As part of the cleanup, `chainId` was dropped from the activity tracking storage since it was no longer used.

**Commits:**

- fc4fc40 Drop chainId from activity tracking storage - needed so all notifications appear correctly
- 6e3976a Refine bridge activity title and text

### Screenshots

<img width="894" height="370" alt="image" src="https://github.com/user-attachments/assets/00939753-5002-4347-91bd-a022490d76da" />

### Related issue(s)

Closes #390

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.