### PR TITLE
Trim OFT dust client-side so bridge sends and previews are honest

### DIFF
--- a/web/src/components/bridgeForm/bridgeSubmitDrawer.tsx
+++ b/web/src/components/bridgeForm/bridgeSubmitDrawer.tsx
@@ -64,6 +64,7 @@ type Props = {
   onClose: VoidFunction;
   onRetry: VoidFunction;
   showApproveStep: boolean;
+  toAmount: string;
   toToken: BridgeableToken;
 } & Pick<
   ComponentProps<typeof BridgeFees>,
@@ -79,6 +80,7 @@ export function BridgeSubmitDrawer({
   onClose,
   onRetry,
   showApproveStep,
+  toAmount,
   total,
   toToken,
 }: Props) {
@@ -138,7 +140,7 @@ export function BridgeSubmitDrawer({
             </p>
             <div className="flex items-center gap-3">
               <p className="flex items-center gap-x-2 text-4xl leading-10 font-semibold tracking-tight text-gray-900">
-                <span>{fromAmount}</span>
+                <span>{toAmount}</span>
                 <span className="text-gray-500">{toToken.symbol}</span>
               </p>
               <TokenChainLogo size="large" token={toToken} />

--- a/web/src/components/bridgeForm/index.tsx
+++ b/web/src/components/bridgeForm/index.tsx
@@ -166,8 +166,8 @@ function BridgeFormContent({ tokens }: ContentProps) {
     useActivityTracking({
       page: "bridge",
       text: t("pages.bridge.activity.bridge-text", {
-        amount: fromInputValue,
-        count: Number(fromInputValue),
+        amount: toAmountDisplay,
+        count: Number(toAmountDisplay),
         symbol: fromToken.symbol,
       }),
       title: `${t("nav.bridge")} · ${t("pages.bridge.activity.bridge-title", {

--- a/web/src/components/bridgeForm/index.tsx
+++ b/web/src/components/bridgeForm/index.tsx
@@ -21,7 +21,8 @@ import { useTranslation } from "react-i18next";
 import type { BridgeableToken } from "types";
 import { pickCounterpartToken } from "utils/bridge";
 import { getInputError } from "utils/inputError";
-import { parseTokenUnits } from "utils/token";
+import { parseTokenUnits, removeOftDust } from "utils/token";
+import { formatUnits } from "viem";
 import { useAccount } from "wagmi";
 
 import { BridgeFees } from "./bridgeFees";
@@ -44,6 +45,27 @@ function getInitialState(tokens: BridgeableToken[]): BridgeFormState {
   };
 }
 
+function getBridgeInputError({
+  amountBigInt,
+  fromTokenBalance,
+  nativeBalance,
+  parsedAmount,
+}: {
+  amountBigInt: bigint;
+  fromTokenBalance: bigint | undefined;
+  nativeBalance: bigint | undefined;
+  parsedAmount: bigint;
+}) {
+  if (parsedAmount > 0n && amountBigInt === 0n) {
+    return "amount-too-small-to-bridge" as const;
+  }
+  return getInputError({
+    amount: amountBigInt,
+    nativeBalance,
+    tokenBalance: fromTokenBalance,
+  });
+}
+
 type ContentProps = {
   tokens: BridgeableToken[];
 };
@@ -64,7 +86,12 @@ function BridgeFormContent({ tokens }: ContentProps) {
   const [showToast, setShowToast] = useState(false);
 
   const debouncedInputValue = useDebounce(fromInputValue);
-  const amountBigInt = parseTokenUnits(debouncedInputValue, fromToken);
+  const parsedAmount = parseTokenUnits(debouncedInputValue, fromToken);
+  const amountBigInt = removeOftDust({
+    amount: parsedAmount,
+    token: fromToken,
+  });
+  const toAmountDisplay = formatUnits(amountBigInt, fromToken.decimals);
 
   const oftAddress = fromToken.oftAdapterAddress ?? fromToken.address;
   const approveAmount = approve10x ? amountBigInt * 10n : undefined;
@@ -125,10 +152,11 @@ function BridgeFormContent({ tokens }: ContentProps) {
     nativeBalance !== undefined && fromTokenBalance !== undefined;
   const dataReady = balancesLoaded && needsApproval !== undefined;
 
-  const inputError = getInputError({
-    amount: amountBigInt,
+  const inputError = getBridgeInputError({
+    amountBigInt,
+    fromTokenBalance,
     nativeBalance,
-    tokenBalance: fromTokenBalance,
+    parsedAmount,
   });
 
   const fromChain = getChainById(fromToken.chainId);
@@ -279,7 +307,7 @@ function BridgeFormContent({ tokens }: ContentProps) {
                 value={toToken}
               />
             }
-            value={fromInputValue}
+            value={toAmountDisplay}
           />
         }
       >
@@ -314,8 +342,9 @@ function BridgeFormContent({ tokens }: ContentProps) {
           onClose={() => setIsDrawerOpen(false)}
           onRetry={handleRetry}
           showApproveStep={startedWithApproval}
-          total={total}
+          toAmount={toAmountDisplay}
           toToken={toToken}
+          total={total}
         />
       )}
       {showToast && (

--- a/web/src/components/tokenInput/utils.ts
+++ b/web/src/components/tokenInput/utils.ts
@@ -1,4 +1,5 @@
 const inputErrors = [
+  "amount-too-small-to-bridge",
   "enter-amount",
   "exceeds-debt",
   "insufficient-balance",

--- a/web/src/hooks/useBridgeableTokens.ts
+++ b/web/src/hooks/useBridgeableTokens.ts
@@ -11,11 +11,12 @@ export const useBridgeableTokens = () =>
         address,
         chainId,
         oftAdapterAddress,
+        sharedDecimals,
       }) {
         const token = knownTokens.find(
           (t) => isAddressEqual(t.address, address) && t.chainId === chainId,
         );
-        return token ? [{ ...token, oftAdapterAddress }] : [];
+        return token ? [{ ...token, oftAdapterAddress, sharedDecimals }] : [];
       }),
     [],
   );

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "amount-too-small-to-bridge": "Amount too small to bridge",
     "approve-10x": "Approve 10x",
     "approve-10x-tooltip": "Approves up to 10× your transaction amount, reducing future approval steps. You can revoke it anytime.",
     "charts": {

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "amount-too-small-to-bridge": "Cantidad demasiado pequeña para hacer bridge",
     "approve-10x": "Aprobar 10x",
     "approve-10x-tooltip": "Apruebe hasta 10× el monto de su transacción, reduciendo futuros pasos de aprobación. Puede revocarlo en cualquier momento.",
     "charts": {

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "amount-too-small-to-bridge": "Cantidad demasiado pequeña para hacer bridge",
+    "amount-too-small-to-bridge": "Cantidad demasiado pequeña para transferir",
     "approve-10x": "Aprobar 10x",
     "approve-10x-tooltip": "Apruebe hasta 10× el monto de su transacción, reduciendo futuros pasos de aprobación. Puede revocarlo en cualquier momento.",
     "charts": {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -17,4 +17,7 @@ export type Token = {
 
 export type TokenWithGateway = Token & { gatewayAddress: Address };
 
-export type BridgeableToken = Token & { oftAdapterAddress?: Address };
+export type BridgeableToken = Token & {
+  oftAdapterAddress?: Address;
+  sharedDecimals: number;
+};

--- a/web/src/utils/bridgeableTokens.ts
+++ b/web/src/utils/bridgeableTokens.ts
@@ -5,6 +5,7 @@ type BridgeTokenChainEntry = {
   address: Address;
   chainId: Chain["id"];
   oftAdapterAddress?: Address;
+  sharedDecimals: number;
 };
 
 export const bridgeableTokens: BridgeTokenChainEntry[] = [
@@ -13,25 +14,31 @@ export const bridgeableTokens: BridgeTokenChainEntry[] = [
     address: "0xCa83DDE9c22254f58e771bE5E157773212AcBAc3",
     chainId: mainnet.id,
     oftAdapterAddress: "0xFc8Acf5ef1E8839Ec94151740CfEd95D7E579Afb",
+    sharedDecimals: 6,
   },
   {
     address: "0xD3599AE62EE280709A22268a46d23164214e345B",
     chainId: hemi.id,
+    sharedDecimals: 6,
   },
   {
     address: "0xCE2c108fB49551f6d27BBb529Ad1938835ac3574",
     chainId: arbitrum.id,
+    sharedDecimals: 6,
   },
   {
     address: "0x8a654093e21703afc8d038FF253A3c974C5C2957",
     chainId: base.id,
+    sharedDecimals: 6,
   },
   {
     address: "0x10061d0593441Ff74536158592e1Be3F4C7B180C",
     chainId: bsc.id,
+    sharedDecimals: 6,
   },
   {
     address: "0xb591169E6508983CC6618738cC73c9F09c38dE14",
     chainId: optimism.id,
+    sharedDecimals: 6,
   },
 ];

--- a/web/src/utils/token.ts
+++ b/web/src/utils/token.ts
@@ -1,4 +1,4 @@
-import type { Token } from "types";
+import type { BridgeableToken, Token } from "types";
 import { formatUnits, parseUnits as viemParseUnits } from "viem";
 
 export const getTokenPrice = function (
@@ -27,6 +27,25 @@ export const parseTokenUnits = function (amount: string, token: Token) {
     : whole;
   return viemParseUnits(normalizedAmount, token.decimals);
 };
+
+// Trims an amount to the boundary the source OFT applies via `_removeDust`
+// before sending. Pre-trimming client-side keeps "you will receive" honest
+// and lets the bridge package's default `minAmountLD = amount` slippage
+// check pass on-chain (without the trim, any non-zero dust reverts with
+// SlippageExceeded). Assumes 1:1 bridging (no token-level OFT fees in
+// `oftFeeDetails`); if a token with such fees is added, replace this with
+// an on-chain `quoteOFT` call.
+export function removeOftDust({
+  amount,
+  token,
+}: {
+  amount: bigint;
+  token: Pick<BridgeableToken, "decimals" | "sharedDecimals">;
+}) {
+  if (token.decimals <= token.sharedDecimals) return amount;
+  const conversionRate = 10n ** BigInt(token.decimals - token.sharedDecimals);
+  return (amount / conversionRate) * conversionRate;
+}
 
 type FormatAmountParams = {
   amount: bigint | undefined;

--- a/web/test/components/bridgeForm/bridgeFormReducer.test.ts
+++ b/web/test/components/bridgeForm/bridgeFormReducer.test.ts
@@ -13,6 +13,7 @@ const mockToken1: BridgeableToken = {
   logoURI: "https://example.com/vusd.svg",
   name: "Vetro USD",
   oftAdapterAddress: "0xFc8Acf5ef1E8839Ec94151740CfEd95D7E579Afb",
+  sharedDecimals: 6,
   symbol: "VUSD",
 };
 
@@ -22,6 +23,7 @@ const mockToken2: BridgeableToken = {
   decimals: 18,
   logoURI: "https://example.com/vusd.svg",
   name: "Vetro USD",
+  sharedDecimals: 6,
   symbol: "VUSD",
 };
 
@@ -31,6 +33,7 @@ const mockToken3: BridgeableToken = {
   decimals: 18,
   logoURI: "https://example.com/vusd.svg",
   name: "Vetro USD",
+  sharedDecimals: 6,
   symbol: "VUSD",
 };
 

--- a/web/test/utils/token.test.ts
+++ b/web/test/utils/token.test.ts
@@ -1,5 +1,10 @@
 import type { Token } from "types";
-import { formatAmount, getTokenPrice, parseTokenUnits } from "utils/token";
+import {
+  formatAmount,
+  getTokenPrice,
+  parseTokenUnits,
+  removeOftDust,
+} from "utils/token";
 import { parseUnits as viemParseUnits } from "viem";
 import { describe, expect, it } from "vitest";
 
@@ -228,6 +233,52 @@ describe("utils/token", function () {
         token.decimals,
       );
       expect(parseTokenUnits(largeDecimalAmount, token)).toEqual(expected);
+    });
+  });
+
+  describe("removeOftDust", function () {
+    it("returns the amount unchanged when decimals equal sharedDecimals", function () {
+      const amount = viemParseUnits("1.234567", 6);
+      expect(
+        removeOftDust({ amount, token: { decimals: 6, sharedDecimals: 6 } }),
+      ).toEqual(amount);
+    });
+
+    it("returns the amount unchanged when decimals are less than sharedDecimals", function () {
+      const amount = 1234n;
+      expect(
+        removeOftDust({ amount, token: { decimals: 4, sharedDecimals: 6 } }),
+      ).toEqual(amount);
+    });
+
+    it("trims sub-shared-decimal dust on an 18-decimal token", function () {
+      const amount = viemParseUnits("1.000000000000000123", 18);
+      const expected = viemParseUnits("1", 18);
+      expect(
+        removeOftDust({ amount, token: { decimals: 18, sharedDecimals: 6 } }),
+      ).toEqual(expected);
+    });
+
+    it("trims sub-shared-decimal dust on an 8-decimal token", function () {
+      const amount = viemParseUnits("1.23456789", 8);
+      const expected = viemParseUnits("1.234567", 8);
+      expect(
+        removeOftDust({ amount, token: { decimals: 8, sharedDecimals: 6 } }),
+      ).toEqual(expected);
+    });
+
+    it("returns 0n when the entire amount is below the dust threshold", function () {
+      const amount = 100_000n; // 1e5 wei on an 18-decimal token
+      expect(
+        removeOftDust({ amount, token: { decimals: 18, sharedDecimals: 6 } }),
+      ).toEqual(0n);
+    });
+
+    it("preserves clean values that need no trimming", function () {
+      const amount = viemParseUnits("1.5", 18);
+      expect(
+        removeOftDust({ amount, token: { decimals: 18, sharedDecimals: 6 } }),
+      ).toEqual(amount);
     });
   });
 });


### PR DESCRIPTION
### Description

LayerZero OFT v2 contracts truncate amounts to `sharedDecimals` (6) when bridging. Today the bridge form has two related problems for any token where `decimals > sharedDecimals` (VUSD on five chains, WETH on mainnet, vetBTC on mainnet, plus the BTC variants at 8 decimals):

1. The drawer's "you will receive" displays the user's literal input even when the destination will receive a smaller amount after dust truncation.
2. `useBridge` calls the bridge package's `send` without setting `minAmount`, so the package defaults `minAmountLD = amount`. The OFT contract's `_debitView` then enforces `amountReceivedLD >= minAmountLD`, which fails for any input with sub-shared-decimal dust — the source-chain transaction reverts with `SlippageExceeded` before any LayerZero message is dispatched.

This PR trims dust client-side via a new `removeOftDust({ amount, token })` helper in `web/src/utils/token.ts`, applied once in `BridgeFormContent` right after `parseTokenUnits`. Every downstream consumer (fee fetchers, `useBridge`, the drawer, the destination `TokenInput`) sees the dust-clean value, so:

- `_removeDust(amount)` is a no-op on-chain, `amountSentLD = amountReceivedLD = minAmountLD`, and the slippage check passes trivially. No bridge-package changes needed.
- The destination `TokenInput` and the drawer's "you will receive" both reflect what the user actually receives.

The drawer keeps `fromAmount` (the user's literal input) for "you are sending"; a new `toAmount` prop carries the dust-trimmed value to "you will receive". The discrepancy is intentional — it tells the user that some dust isn't bridged.

`sharedDecimals` is a required field on `BridgeableToken`, populated `6` per entry in `web/src/utils/bridgeableTokens.ts` (LayerZero v2 default; `tsc` enforces it for new entries). A new `amount-too-small-to-bridge` input error surfaces when the user's parsed amount is positive but the trim rounds it to zero.

We also considered using the OFT v2 `quoteOFT(SendParam)` view to read `amountReceivedLD` on-chain, but rejected it: `quoteOFT` itself is gated by the same `_debitView` slippage check, so the only safe `minAmountLD` for a preview is `0n`, at which point the receipt reduces to `_removeDust(amount)` — computable client-side without an RPC round-trip.

### Screenshots

_To be added._

### Related issue(s)

Closes #389

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.