### PR TITLE
Limit setup script to mainnet

### DIFF
--- a/web/scripts/setup.ts
+++ b/web/scripts/setup.ts
@@ -29,7 +29,7 @@ const setupSymbols = [
 ];
 
 const tokens = knownTokens
-  .filter((t) => setupSymbols.includes(t.symbol))
+  .filter((t) => t.chainId === mainnet.id && setupSymbols.includes(t.symbol))
   .map((t) => ({
     address: t.address,
     balanceSlot: t.extensions!.balanceSlot!,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR updates the `setup` script to limit it to `mainnet`, as the chain I forked the most (I haven't forked any other). This wasn't a problem until we added the tokens from other chains for the bridge page, so now the script fails unless limited to mainnet.

If I ever need to fork other chains, I could make the chainId a parameter defaulting to mainnet. Not needed today.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

No changes to users

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
