### PR TITLE
Bump prettier-plugin-tailwindcss to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "knip": "6.9.0",
     "lint-staged": "16.2.7",
     "prettier": "3.8.3",
-    "prettier-plugin-tailwindcss": "0.7.2"
+    "prettier-plugin-tailwindcss": "0.8.0"
   },
   "private": true,
   "packageManager": "pnpm@10.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ importers:
         specifier: 3.8.3
         version: 3.8.3
       prettier-plugin-tailwindcss:
-        specifier: 0.7.2
-        version: 0.7.2(prettier@3.8.3)
+        specifier: 0.8.0
+        version: 0.8.0(prettier@3.8.3)
 
   api:
     dependencies:
@@ -6904,8 +6904,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-plugin-tailwindcss@0.7.2:
-    resolution: {integrity: sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==}
+  prettier-plugin-tailwindcss@0.8.0:
+    resolution: {integrity: sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==}
     engines: {node: '>=20.19'}
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
@@ -16353,7 +16353,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-tailwindcss@0.7.2(prettier@3.8.3):
+  prettier-plugin-tailwindcss@0.8.0(prettier@3.8.3):
     dependencies:
       prettier: 3.8.3
 


### PR DESCRIPTION
### Description

Bumps `prettier-plugin-tailwindcss` from `0.7.2` to `0.8.0`.

Mostly a refactor release from the Tailwind Labs / oxc maintainers: source migrated to TS, build system swapped from esbuild+tsup to tsdown, dynamic plugin loading replaces eager imports, and `recast` / `ast-types` / `jsesc` are dropped in favor of a smaller custom dynamic-JS attribute handler. No new runtime dependencies (the plugin still ships with peer-deps only) and no new install-time hooks. Audited via `/review-dep-update` — code-level review and supply-chain scan both came back clean.

Upstream compare: https://github.com/tailwindlabs/prettier-plugin-tailwindcss/compare/v0.7.2...v0.8.0

### Screenshots

N/A — dev tooling.

### Related issue(s)

Closes #
Related to #

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.