### PR TITLE
Stop analytics crash on unknown treasury token

### DIFF
--- a/web/src/hooks/useWhitelistedTokensByGateway.ts
+++ b/web/src/hooks/useWhitelistedTokensByGateway.ts
@@ -27,7 +27,7 @@ export const whitelistedTokensByGatewayOptions = ({
         queryClient,
       }),
     queryKey: ["whitelisted-tokens", client?.chain?.id, gatewayAddress],
-    staleTime: Infinity,
+    staleTime: 60 * 60 * 1000, // 1 hour
   });
 
 export const useWhitelistedTokensByGateway = function (

--- a/web/src/pages/analytics/utils.ts
+++ b/web/src/pages/analytics/utils.ts
@@ -21,15 +21,8 @@ const colorPalette = [
 export const assignColor = (index: number) =>
   colorPalette[index % colorPalette.length] ?? "bg-gray-400";
 
-const findToken = function (tokenAddress: Address, whitelistedTokens: Token[]) {
-  const token = whitelistedTokens.find((t) =>
-    isAddressEqual(t.address, tokenAddress),
-  );
-  if (!token) {
-    throw new Error(`Token not found in whitelist: ${tokenAddress}`);
-  }
-  return token;
-};
+const findToken = (tokenAddress: Address, whitelistedTokens: Token[]) =>
+  whitelistedTokens.find((t) => isAddressEqual(t.address, tokenAddress));
 
 // Transforms /analytics/treasury response into TVL allocation items.
 // withdrawable includes idle funds + deployed strategies (vs totalDebt = strategies only).
@@ -42,17 +35,26 @@ export const toTvlItems = ({
   treasuryTokens: TreasuryToken[];
   whitelistedTokens: Token[];
 }) =>
-  treasuryTokens.map(function ({ tokenAddress, withdrawable }, index) {
+  treasuryTokens.flatMap(function ({ tokenAddress, withdrawable }, index) {
     const token = findToken(tokenAddress, whitelistedTokens);
+    if (!token) {
+      return [];
+    }
     const { decimals, symbol } = token;
 
-    return {
-      amount: tokenAmountToUsd({ amount: BigInt(withdrawable), prices, token }),
-      color: assignColor(index),
-      label: symbol,
-      logoURI: token.logoURI,
-      tooltip: `${formatNumber(formatUnits(BigInt(withdrawable), decimals))} ${symbol}`,
-    };
+    return [
+      {
+        amount: tokenAmountToUsd({
+          amount: BigInt(withdrawable),
+          prices,
+          token,
+        }),
+        color: assignColor(index),
+        label: symbol,
+        logoURI: token.logoURI,
+        tooltip: `${formatNumber(formatUnits(BigInt(withdrawable), decimals))} ${symbol}`,
+      },
+    ];
   });
 
 // Transforms /analytics/treasury response into yield allocation items,
@@ -70,6 +72,9 @@ export const toYieldItems = function ({
 
   for (const { activeStrategies, tokenAddress } of treasuryTokens) {
     const token = findToken(tokenAddress, whitelistedTokens);
+    if (!token) {
+      continue;
+    }
 
     for (const { name, totalDebt } of activeStrategies) {
       const amount = tokenAmountToUsd({
@@ -144,6 +149,7 @@ export const toReserveBufferAmount = function ({
 
   for (const { tokenAddress, totalDebt, withdrawable } of treasuryTokens) {
     const token = findToken(tokenAddress, whitelistedTokens);
+    if (!token) continue;
 
     amount += tokenAmountToUsd({
       amount: BigInt(withdrawable) - BigInt(totalDebt),

--- a/web/src/pages/earn/components/stakeDrawer/stakeDrawerContent.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeDrawerContent.tsx
@@ -90,9 +90,9 @@ export function StakeDrawerContent({
           onInputChange={handleInputChange}
           onSuccess={onSuccess}
           onWithdrawStepChange={handleWithdrawStepChange}
-          withdrawStep={state.withdrawStep}
           peggedToken={peggedToken}
           stakingVaultAddress={stakingVaultAddress}
+          withdrawStep={state.withdrawStep}
         />
       )}
     </div>

--- a/web/test/pages/analytics/utils.test.ts
+++ b/web/test/pages/analytics/utils.test.ts
@@ -155,16 +155,27 @@ describe("pages/analytics/utils", function () {
       expect(result).toBeCloseTo(1);
     });
 
-    it("throws when a treasury token's address isn't whitelisted", function () {
-      expect(() =>
-        toReserveBufferAmount({
-          prices,
-          treasuryTokens: [
-            { ...baseTreasuryToken, tokenAddress: USDC_ADDRESS },
-          ],
-          whitelistedTokens: [usdtToken],
-        }),
-      ).toThrow(`Token not found in whitelist: ${USDC_ADDRESS}`);
+    it("skips treasury tokens missing from the whitelist", function () {
+      // USDT contributes $100; the unknown USDC entry is ignored.
+      const result = toReserveBufferAmount({
+        prices,
+        treasuryTokens: [
+          {
+            ...baseTreasuryToken,
+            totalDebt: "900000000",
+            withdrawable: "1000000000",
+          },
+          {
+            ...baseTreasuryToken,
+            tokenAddress: USDC_ADDRESS,
+            totalDebt: "0",
+            withdrawable: "1000000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken],
+      });
+
+      expect(result).toBeCloseTo(100);
     });
   });
 
@@ -188,16 +199,23 @@ describe("pages/analytics/utils", function () {
       expect(items[0]?.label).toBe("USDT");
     });
 
-    it("throws when a treasury token's address isn't whitelisted", function () {
-      expect(() =>
-        toTvlItems({
-          prices,
-          treasuryTokens: [
-            { ...baseTreasuryToken, tokenAddress: USDC_ADDRESS },
-          ],
-          whitelistedTokens: [usdtToken],
-        }),
-      ).toThrow(`Token not found in whitelist: ${USDC_ADDRESS}`);
+    it("skips treasury tokens missing from the whitelist", function () {
+      // USDT yields one item; the unknown USDC entry is omitted from the output.
+      const items = toTvlItems({
+        prices,
+        treasuryTokens: [
+          { ...baseTreasuryToken, withdrawable: "1000000000" },
+          {
+            ...baseTreasuryToken,
+            tokenAddress: USDC_ADDRESS,
+            withdrawable: "1000000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken],
+      });
+
+      expect(items).toHaveLength(1);
+      expect(items[0]?.label).toBe("USDT");
     });
   });
 
@@ -277,16 +295,34 @@ describe("pages/analytics/utils", function () {
       expect(items[0]?.amount).toBeCloseTo(500);
     });
 
-    it("throws when a treasury token's address isn't whitelisted", function () {
-      expect(() =>
-        toYieldItems({
-          prices,
-          treasuryTokens: [
-            { ...baseTreasuryToken, tokenAddress: USDC_ADDRESS },
-          ],
-          whitelistedTokens: [usdtToken],
-        }),
-      ).toThrow(`Token not found in whitelist: ${USDC_ADDRESS}`);
+    it("skips treasury tokens missing from the whitelist", function () {
+      // USDT yields one strategy; the unknown USDC entry's strategies are skipped.
+      const items = toYieldItems({
+        prices,
+        treasuryTokens: [
+          {
+            ...baseTreasuryToken,
+            activeStrategies: [
+              { name: "USDT Strategy", totalDebt: "500000000" },
+            ],
+            totalDebt: "500000000",
+            withdrawable: "500000000",
+          },
+          {
+            ...baseTreasuryToken,
+            activeStrategies: [
+              { name: "USDC Strategy", totalDebt: "200000000" },
+            ],
+            tokenAddress: USDC_ADDRESS,
+            totalDebt: "200000000",
+            withdrawable: "200000000",
+          },
+        ],
+        whitelistedTokens: [usdtToken],
+      });
+
+      expect(items).toHaveLength(1);
+      expect(items[0]?.label).toBe("USDT Strategy");
     });
   });
 


### PR DESCRIPTION
### Description

`TvlCard` and `YieldCard` render by joining two queries that should match 1:1 by token address: `useAnalyticsTreasury` (API, auto-refetches every 5 min) and `useWhitelistedTokensByGateway` (on-chain, was `staleTime: Infinity`). When a token is newly whitelisted on-chain mid-session, the API picks it up but the cached on-chain hook doesn't, and `findToken` throws — crashing the analytics page. Confirmed in #409: hemiBTC was whitelisted ~12h before the Sentry error fired.

Addressed in two parts:

1. **Defensive**: `findToken` now returns `Token | undefined`; `toTvlItems` / `toYieldItems` / `toReserveBufferAmount` skip entries that can't be resolved instead of throwing. The token disappears briefly from the chart rather than crashing the page.
2. **Freshness**: `useWhitelistedTokensByGateway` now uses `staleTime: 1h` instead of `Infinity`, restoring window-focus and remount refetches so newly-whitelisted tokens make it into the on-chain hook within a reasonable window.

**Commits:**

- 4425148 Lower whitelisted tokens staleTime to 1 hour
- f167c61 Stop analytics crash on unknown treasury token

### Screenshots

N/A — no visual change in the steady state.

### Related issue(s)

Closes #409

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.