### PR TITLE
security: fix prettier argument injection in claude hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "git diff --name-only | grep -E '\\.(css|html|json|jsx?|md|scss|svg|tsx?|yml|yaml)$' | xargs -r pnpm exec prettier --write"
+            "command": "git diff --name-only -z | grep -zE '\\.(css|html|json|jsx?|md|scss|svg|tsx?|yml|yaml)$' | xargs -0 -r pnpm exec prettier --write --"
           }
         ]
       }


### PR DESCRIPTION
### Description

A Claude `PostToolUse` hook was introduced in https://github.com/vetro-protocol/vetro-monorepo/commit/d11be39b39c82a275fe9550283a452112fc5bd24 that automatically runs `prettier` on files after the `Write` or `Edit` tool is used.

The added hook pipes `git diff --name-only` through `grep`/`xargs` to `prettier --write` without NUL-safe filename handling or an option terminator (`--`). A tracked path starting with `--` (e.g., `--plugin=./malicious.js`) survives the grep filter and is parsed by Prettier as a CLI option rather than a filename.

With Prettier 3.8.1, this allows loading an arbitrary repository JavaScript file as a Prettier plugin, executing attacker-controlled code on the developer's machine whenever the hook fires after a Claude Write/Edit tool call.

This fix modifies the hook command to:
1. Use `git diff -z` to NUL-delimit filenames, eliminating whitespace/newline injection.
2. Use `grep -z` and `xargs -0` to propagate NUL delimiters through the pipeline.
3. Add `--` before filenames in `prettier` command to terminate option parsing, so dash-prefixed paths are treated as files, not options.

### Screenshots

N/A

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to internal SecOps security tasks: SEC-49 SEC-50

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
