### PR TITLE
Block exotic subdeps and transitive install scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,8 @@ minimumReleaseAgeExclude:
   - "viem-erc20"
   - "viem-erc4626"
 
+onlyBuiltDependencies: []
+
 packages:
   - "api"
   - "landing"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+blockExoticSubdeps: true
 minimumReleaseAge: 10080 # 7 days in minutes
 minimumReleaseAgeExclude:
   - "@hemilabs/*"


### PR DESCRIPTION
### Description

Two-step hardening of pnpm install policy:

- `blockExoticSubdeps: true` — pnpm rejects transitive dependencies that reference non-registry protocols (git, http, file, etc.). Direct deps in `package.json` files are unaffected; only sub-dependencies pulled in via the resolution graph are blocked. Supported in pnpm ≥ 10.18 (repo is on 10.28.1).
- `onlyBuiltDependencies: []` — explicit empty allowlist for transitive install/postinstall scripts. Same blocked-by-default behavior pnpm 10 ships with, but now version-controlled rather than inherited from pnpm defaults, so future additions surface as reviewable diffs.

Audited the nine current transitive deps with install scripts (`@parcel/watcher`, `@sentry/cli`, `bufferutil`, `esbuild`, `keccak`, `sharp`, `unrs-resolver`, `utf-8-validate`, `workerd`) — each is a native-binding or platform-binary package that uses optional-dependency platform sub-packages for the actual binary, so blocking their own install scripts is a no-op for normal use. Verified by running `pnpm install` cleanly.

**Commits:**

- 98c63ac Enable pnpm blockExoticSubdeps
- ac89a91 Block transitive install scripts by default

### Screenshots

N/A

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.