### PR TITLE
Add sVUSD to bridge page

### DIFF
--- a/web/src/components/base/fiatValue.tsx
+++ b/web/src/components/base/fiatValue.tsx
@@ -17,12 +17,12 @@ const RenderFiatValueUnsafe = function ({
 }: {
   customFormatter?: (amount: string) => string;
   queryStatus?: QueryStatus;
-  token: Token;
+  token: Token | undefined;
   value: bigint | undefined;
 }) {
   const { data: pricesData, status: pricesStatus } = usePrices();
 
-  if (value !== undefined && pricesData !== undefined) {
+  if (value !== undefined && pricesData !== undefined && token !== undefined) {
     const stringBalance = formatUnits(value, token.decimals);
     const price = getTokenPrice(token, pricesData);
 

--- a/web/src/components/base/shareTokenFiatValue.tsx
+++ b/web/src/components/base/shareTokenFiatValue.tsx
@@ -1,0 +1,68 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { RenderFiatValue } from "components/base/fiatValue";
+import { convertToAssetsQueryOptions } from "hooks/useConvertToAssets";
+import { useEthereumClient } from "hooks/useEthereumClient";
+import { vaultPeggedTokenQueryOptions } from "hooks/useVaultPeggedToken";
+import type { Token, TokenWithGateway } from "types";
+import { knownTokens } from "utils/tokenList";
+import { mainnet } from "viem/chains";
+
+type Props = {
+  token: Token;
+  value: bigint | undefined;
+};
+
+type Result = {
+  assetsValue: bigint;
+  peggedToken: TokenWithGateway;
+};
+
+// On mainnet, each share token entry's address is the staking vault contract
+// itself (the vault is an ERC-4626 ERC-20). So the mainnet-listed share token
+// with this symbol gives us the vault address directly.
+const findStakingVaultAddress = (shareSymbol: string) =>
+  knownTokens.find(
+    (t) =>
+      t.chainId === mainnet.id &&
+      t.symbol === shareSymbol &&
+      t.extensions?.isVaultShare,
+  )?.address;
+
+export function ShareTokenFiatValue({ token, value }: Props) {
+  const client = useEthereumClient();
+  const queryClient = useQueryClient();
+
+  const { data, status } = useQuery<Result>({
+    enabled: !!client && value !== undefined,
+    placeholderData: (prev) => prev,
+    async queryFn() {
+      const stakingVaultAddress = findStakingVaultAddress(token.symbol)!;
+      const [peggedToken, assetsValue] = await Promise.all([
+        queryClient.ensureQueryData(
+          vaultPeggedTokenQueryOptions({
+            client,
+            queryClient,
+            stakingVaultAddress,
+          }),
+        ),
+        queryClient.ensureQueryData(
+          convertToAssetsQueryOptions({
+            client,
+            shares: value,
+            stakingVaultAddress,
+          }),
+        ),
+      ]);
+      return { assetsValue, peggedToken };
+    },
+    queryKey: ["share-token-fiat", token.symbol, value?.toString()],
+  });
+
+  return (
+    <RenderFiatValue
+      queryStatus={status}
+      token={data?.peggedToken}
+      value={data?.assetsValue}
+    />
+  );
+}

--- a/web/src/components/bridgeForm/bridgeTokenFiatValue.tsx
+++ b/web/src/components/bridgeForm/bridgeTokenFiatValue.tsx
@@ -1,0 +1,15 @@
+import { RenderFiatValue } from "components/base/fiatValue";
+import { ShareTokenFiatValue } from "components/base/shareTokenFiatValue";
+import type { Token } from "types";
+
+type Props = {
+  token: Token;
+  value: bigint | undefined;
+};
+
+export function BridgeTokenFiatValue(props: Props) {
+  if (props.token.extensions?.isVaultShare) {
+    return <ShareTokenFiatValue {...props} />;
+  }
+  return <RenderFiatValue {...props} />;
+}

--- a/web/src/components/bridgeForm/form.tsx
+++ b/web/src/components/bridgeForm/form.tsx
@@ -1,5 +1,4 @@
 import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
-import { RenderFiatValue } from "components/base/fiatValue";
 import { SwapToggleButton } from "components/swapForm/swapToggleButton";
 import { TokenInput } from "components/tokenInput";
 import { Balance } from "components/tokenInput/balance";
@@ -7,6 +6,8 @@ import type { FormEvent, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import type { Token } from "types";
 import { formatAmount } from "utils/token";
+
+import { BridgeTokenFiatValue } from "./bridgeTokenFiatValue";
 
 type Props = {
   amountBigInt: bigint;
@@ -63,7 +64,7 @@ export function Form({
             }
             errorKey={errorKey}
             fiatValue={
-              <RenderFiatValue token={fromToken} value={amountBigInt} />
+              <BridgeTokenFiatValue token={fromToken} value={amountBigInt} />
             }
             label={t("pages.bridge.form.you-are-sending")}
             maxButton={maxButton}

--- a/web/src/components/bridgeForm/index.tsx
+++ b/web/src/components/bridgeForm/index.tsx
@@ -3,7 +3,6 @@ import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { useNeedsApproval } from "@hemilabs/react-hooks/useNeedsApproval";
 import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
 import { ApproveSection } from "components/approveSection";
-import { RenderFiatValue } from "components/base/fiatValue";
 import { Toast } from "components/base/toast";
 import { FormSection, FormSectionItem } from "components/feesContainer";
 import { SetMaxErc20Balance } from "components/setMaxErc20Balance";
@@ -32,6 +31,7 @@ import {
   BridgeSubmitDrawer,
 } from "./bridgeSubmitDrawer";
 import { BridgeTokenDropdown } from "./bridgeTokenDropdown";
+import { BridgeTokenFiatValue } from "./bridgeTokenFiatValue";
 import { Form } from "./form";
 import { bridgeFormReducer, type BridgeFormState } from "./reducer";
 
@@ -225,7 +225,8 @@ function BridgeFormContent({ tokens }: ContentProps) {
   });
 
   const fromTokens = tokens.filter(
-    (token) => token.chainId !== fromToken.chainId,
+    (token) =>
+      token.chainId !== fromToken.chainId || token.symbol !== fromToken.symbol,
   );
 
   const toTokens = tokens.filter(
@@ -297,7 +298,9 @@ function BridgeFormContent({ tokens }: ContentProps) {
           <TokenInput
             balance={<ToTokenBalance token={toToken} />}
             disabled
-            fiatValue={<RenderFiatValue token={toToken} value={amountBigInt} />}
+            fiatValue={
+              <BridgeTokenFiatValue token={toToken} value={amountBigInt} />
+            }
             label={t("pages.bridge.form.you-will-receive")}
             tokenSelector={
               <BridgeTokenDropdown

--- a/web/src/components/bridgeForm/reducer.ts
+++ b/web/src/components/bridgeForm/reducer.ts
@@ -35,25 +35,27 @@ export function bridgeFormReducer(
     }
     case "SET_FROM_TOKEN": {
       const { token, tokens } = action.payload;
-      if (token.chainId === state.toToken.chainId) {
-        return {
-          ...state,
-          fromToken: token,
-          toToken: pickCounterpartToken({ token, tokens }),
-        };
-      }
-      return { ...state, fromToken: token };
+      return {
+        ...state,
+        fromToken: token,
+        toToken: pickCounterpartToken({
+          current: state.toToken,
+          token,
+          tokens,
+        }),
+      };
     }
     case "SET_TO_TOKEN": {
       const { token, tokens } = action.payload;
-      if (token.chainId === state.fromToken.chainId) {
-        return {
-          ...state,
-          fromToken: pickCounterpartToken({ token, tokens }),
-          toToken: token,
-        };
-      }
-      return { ...state, toToken: token };
+      return {
+        ...state,
+        fromToken: pickCounterpartToken({
+          current: state.fromToken,
+          token,
+          tokens,
+        }),
+        toToken: token,
+      };
     }
     case "TOGGLE_APPROVE_10X":
       return { ...state, approve10x: !state.approve10x };

--- a/web/src/fetchers/fetchWithdrawGasUnits.ts
+++ b/web/src/fetchers/fetchWithdrawGasUnits.ts
@@ -1,6 +1,6 @@
-import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
 import type { QueryClient } from "@tanstack/react-query";
 import { stakingVaultAbi } from "@vetro-protocol/earn";
+import { stakedBalanceQueryOptions } from "hooks/useStakedBalance";
 import { canInstantWithdrawOptions } from "pages/earn/hooks/useCanInstantWithdraw";
 import {
   type Address,
@@ -9,7 +9,6 @@ import {
   encodeFunctionData,
 } from "viem";
 import { estimateGas } from "viem/actions";
-import { convertToAssets } from "viem-erc4626/actions";
 
 /**
  * Estimates gas units for an earn withdraw. Reads the instant withdraw
@@ -40,20 +39,15 @@ export const fetchWithdrawGasUnits = async function ({
         stakingVaultAddress,
       }),
     ),
-    queryClient
-      .ensureQueryData(
-        tokenBalanceQueryOptions({
-          account,
-          client,
-          token: { address: stakingVaultAddress, chainId },
-        }),
-      )
-      .then((shares) =>
-        convertToAssets(client, {
-          address: stakingVaultAddress,
-          shares,
-        }),
-      ),
+    queryClient.ensureQueryData(
+      stakedBalanceQueryOptions({
+        account,
+        chainId,
+        client,
+        queryClient,
+        stakingVaultAddress,
+      }),
+    ),
   ]);
 
   if (amount > stakedBalance) {

--- a/web/src/hooks/useConvertToAssets.ts
+++ b/web/src/hooks/useConvertToAssets.ts
@@ -1,0 +1,27 @@
+import { queryOptions } from "@tanstack/react-query";
+import type { Address, Client } from "viem";
+import { convertToAssets } from "viem-erc4626/actions";
+
+export const convertToAssetsQueryOptions = ({
+  client,
+  shares,
+  stakingVaultAddress,
+}: {
+  client: Client | undefined;
+  shares: bigint | undefined;
+  stakingVaultAddress: Address;
+}) =>
+  queryOptions({
+    enabled: !!client && shares !== undefined,
+    queryFn: () =>
+      convertToAssets(client!, {
+        address: stakingVaultAddress,
+        shares: shares!,
+      }),
+    queryKey: [
+      "convert-to-assets",
+      client?.chain?.id,
+      stakingVaultAddress,
+      shares?.toString(),
+    ],
+  });

--- a/web/src/hooks/useStakedBalance.ts
+++ b/web/src/hooks/useStakedBalance.ts
@@ -5,10 +5,10 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import { convertToAssetsQueryOptions } from "hooks/useConvertToAssets";
 import { useEthereumClient } from "hooks/useEthereumClient";
 import { useMainnet } from "hooks/useMainnet";
 import type { Address, Client } from "viem";
-import { convertToAssets } from "viem-erc4626/actions";
 import { useAccount } from "wagmi";
 
 export const stakedBalanceQueryKey = ({
@@ -44,10 +44,13 @@ export const stakedBalanceQueryOptions = ({
           token: { address: stakingVaultAddress, chainId },
         }),
       );
-      return convertToAssets(client!, {
-        address: stakingVaultAddress,
-        shares,
-      });
+      return queryClient.ensureQueryData(
+        convertToAssetsQueryOptions({
+          client,
+          shares,
+          stakingVaultAddress,
+        }),
+      );
     },
     queryKey: stakedBalanceQueryKey({
       account: account!,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -7,6 +7,10 @@ export type Token = {
   extensions?: {
     allowanceSlot?: bigint;
     balanceSlot?: number;
+    // When true, the token's fiat value is computed by converting shares to
+    // the vault's underlying asset (ERC-4626 convertToAssets) on the chain
+    // where the staking vault lives, then pricing the resulting asset.
+    isVaultShare?: boolean;
     // Use this to map which symbol should be used to map prices
     priceSymbol?: string;
   };

--- a/web/src/utils/bridge.ts
+++ b/web/src/utils/bridge.ts
@@ -1,13 +1,22 @@
 import type { BridgeableToken } from "types";
 
+const isValidCounterpart = ({
+  candidate,
+  token,
+}: {
+  candidate: BridgeableToken;
+  token: BridgeableToken;
+}) => candidate.symbol === token.symbol && candidate.chainId !== token.chainId;
+
 export const pickCounterpartToken = ({
+  current,
   token,
   tokens,
 }: {
+  current?: BridgeableToken;
   token: BridgeableToken;
   tokens: BridgeableToken[];
 }) =>
-  tokens.find(
-    (candidate) =>
-      candidate.symbol === token.symbol && candidate.chainId !== token.chainId,
-  )!;
+  current && isValidCounterpart({ candidate: current, token })
+    ? current
+    : tokens.find((candidate) => isValidCounterpart({ candidate, token }))!;

--- a/web/src/utils/bridgeableTokens.ts
+++ b/web/src/utils/bridgeableTokens.ts
@@ -1,3 +1,4 @@
+import { sVusdAddress } from "@vetro-protocol/earn";
 import type { Address, Chain } from "viem";
 import { arbitrum, base, bsc, hemi, mainnet, optimism } from "viem/chains";
 
@@ -38,6 +39,38 @@ export const bridgeableTokens: BridgeTokenChainEntry[] = [
   },
   {
     address: "0xb591169E6508983CC6618738cC73c9F09c38dE14",
+    chainId: optimism.id,
+    sharedDecimals: 6,
+  },
+  // sVUSD
+  {
+    address: sVusdAddress,
+    chainId: mainnet.id,
+    oftAdapterAddress: "0x968563eeD04e0289ccC79d7029bFc79F040605f0",
+    sharedDecimals: 6,
+  },
+  {
+    address: "0xfe875CC86cC6BC2E93ab330D6b2c408C3Cd79710",
+    chainId: hemi.id,
+    sharedDecimals: 6,
+  },
+  {
+    address: "0x50c580227764b621c0433bB6Ab756C781c495ce7",
+    chainId: arbitrum.id,
+    sharedDecimals: 6,
+  },
+  {
+    address: "0xb174750002068862Dfe7DF38F974a950F189386a",
+    chainId: base.id,
+    sharedDecimals: 6,
+  },
+  {
+    address: "0xC141B66eE4262Ba46Ea29578955C274fD4A96515",
+    chainId: bsc.id,
+    sharedDecimals: 6,
+  },
+  {
+    address: "0x92273Ca3356379C2fe870FE3805cc5e7aB6d19c6",
     chainId: optimism.id,
     sharedDecimals: 6,
   },

--- a/web/src/utils/tokenList.ts
+++ b/web/src/utils/tokenList.ts
@@ -160,6 +160,9 @@ export const knownTokens: Token[] = [
     address: sVetBtcAddress,
     chainId: mainnet.id,
     decimals: 18,
+    extensions: {
+      isVaultShare: true,
+    },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/svetbtc.svg",
     name: "Staked Vetro BTC",
     symbol: "svetBTC",
@@ -168,6 +171,77 @@ export const knownTokens: Token[] = [
     address: sVusdAddress,
     chainId: mainnet.id,
     decimals: 18,
+    extensions: {
+      // The sVUSD vault is an OZ 5.x upgradeable contract, which stores ERC20
+      // state in an ERC-7201 namespace ("openzeppelin.storage.ERC20") instead
+      // of at small sequential slots. Inside that struct, _balances is at
+      // offset 0 and _allowances at offset 1, so the slot below is
+      // `ERC20StorageLocation + 1` (see `ERC20Upgradeable.sol` in
+      // @openzeppelin/contracts-upgradeable v5).
+      allowanceSlot:
+        0x52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace01n,
+      isVaultShare: true,
+    },
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/svusd.svg",
+    name: "Staked Vetro USD",
+    symbol: "sVUSD",
+  },
+  {
+    address: "0x50c580227764b621c0433bB6Ab756C781c495ce7",
+    chainId: arbitrum.id,
+    decimals: 18,
+    extensions: {
+      allowanceSlot: 6n,
+      isVaultShare: true,
+    },
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/svusd.svg",
+    name: "Staked Vetro USD",
+    symbol: "sVUSD",
+  },
+  {
+    address: "0xb174750002068862Dfe7DF38F974a950F189386a",
+    chainId: base.id,
+    decimals: 18,
+    extensions: {
+      allowanceSlot: 6n,
+      isVaultShare: true,
+    },
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/svusd.svg",
+    name: "Staked Vetro USD",
+    symbol: "sVUSD",
+  },
+  {
+    address: "0xC141B66eE4262Ba46Ea29578955C274fD4A96515",
+    chainId: bsc.id,
+    decimals: 18,
+    extensions: {
+      allowanceSlot: 6n,
+      isVaultShare: true,
+    },
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/svusd.svg",
+    name: "Staked Vetro USD",
+    symbol: "sVUSD",
+  },
+  {
+    address: "0xfe875CC86cC6BC2E93ab330D6b2c408C3Cd79710",
+    chainId: hemi.id,
+    decimals: 18,
+    extensions: {
+      allowanceSlot: 6n,
+      isVaultShare: true,
+    },
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/svusd.svg",
+    name: "Staked Vetro USD",
+    symbol: "sVUSD",
+  },
+  {
+    address: "0x92273Ca3356379C2fe870FE3805cc5e7aB6d19c6",
+    chainId: optimism.id,
+    decimals: 18,
+    extensions: {
+      allowanceSlot: 6n,
+      isVaultShare: true,
+    },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/svusd.svg",
     name: "Staked Vetro USD",
     symbol: "sVUSD",

--- a/web/test/components/bridgeForm/bridgeFormReducer.test.ts
+++ b/web/test/components/bridgeForm/bridgeFormReducer.test.ts
@@ -37,7 +37,34 @@ const mockToken3: BridgeableToken = {
   symbol: "VUSD",
 };
 
-const tokens = [mockToken1, mockToken2, mockToken3];
+const mockSvusdToken1: BridgeableToken = {
+  address: "0x476310E34D2810f7d79C43A74E4D79405bd7a925",
+  chainId: 1,
+  decimals: 18,
+  logoURI: "https://example.com/svusd.svg",
+  name: "Staked Vetro USD",
+  oftAdapterAddress: "0x968563eeD04e0289ccC79d7029bFc79F040605f0",
+  sharedDecimals: 6,
+  symbol: "sVUSD",
+};
+
+const mockSvusdToken2: BridgeableToken = {
+  address: "0x50c580227764b621c0433bB6Ab756C781c495ce7",
+  chainId: 42161,
+  decimals: 18,
+  logoURI: "https://example.com/svusd.svg",
+  name: "Staked Vetro USD",
+  sharedDecimals: 6,
+  symbol: "sVUSD",
+};
+
+const tokens = [
+  mockToken1,
+  mockToken2,
+  mockToken3,
+  mockSvusdToken1,
+  mockSvusdToken2,
+];
 
 const createInitialState = (): BridgeFormState => ({
   approve10x: false,
@@ -106,6 +133,21 @@ describe("bridgeFormReducer", function () {
     expect(result.toToken.symbol).toBe(mockToken2.symbol);
   });
 
+  it("SET_FROM_TOKEN picks a counterpart for toToken when symbol differs even if chains do not conflict", function () {
+    // Start with VUSD on chain 1 (from) / VUSD on chain 42161 (to).
+    // Switch from-token to sVUSD on chain 8453 — chains don't collide with
+    // the current toToken (42161), but the symbol no longer matches.
+    const state = createInitialState();
+    const newFrom: BridgeableToken = { ...mockSvusdToken2, chainId: 8453 };
+    const result = bridgeFormReducer(state, {
+      payload: { token: newFrom, tokens },
+      type: "SET_FROM_TOKEN",
+    });
+    expect(result.fromToken).toBe(newFrom);
+    expect(result.toToken.symbol).toBe("sVUSD");
+    expect(result.toToken.chainId).not.toBe(newFrom.chainId);
+  });
+
   it("SET_TO_TOKEN changes target token when chains do not conflict", function () {
     const state = createInitialState();
     const result = bridgeFormReducer(state, {
@@ -126,6 +168,21 @@ describe("bridgeFormReducer", function () {
     expect(result.toToken).toBe(mockToken1);
     expect(result.fromToken.chainId).not.toBe(mockToken1.chainId);
     expect(result.fromToken.symbol).toBe(mockToken1.symbol);
+  });
+
+  it("SET_TO_TOKEN picks a counterpart for fromToken when symbol differs even if chains do not conflict", function () {
+    // Start with VUSD on chain 1 (from) / VUSD on chain 42161 (to).
+    // Switch to-token to sVUSD on chain 8453 — chains don't collide with the
+    // current fromToken (1), but the symbol no longer matches.
+    const state = createInitialState();
+    const newTo: BridgeableToken = { ...mockSvusdToken2, chainId: 8453 };
+    const result = bridgeFormReducer(state, {
+      payload: { token: newTo, tokens },
+      type: "SET_TO_TOKEN",
+    });
+    expect(result.toToken).toBe(newTo);
+    expect(result.fromToken.symbol).toBe("sVUSD");
+    expect(result.fromToken.chainId).not.toBe(newTo.chainId);
   });
 
   it("TOGGLE_TOKENS swaps tokens and preserves input value", function () {

--- a/web/test/utils/bridge.test.ts
+++ b/web/test/utils/bridge.test.ts
@@ -44,4 +44,35 @@ describe("pickCounterpartToken", function () {
       first,
     );
   });
+
+  it("preserves the current counterpart when it is still valid", function () {
+    const token = makeToken("VUSD", 1);
+    const current = makeToken("VUSD", 8453);
+    const otherChain = makeToken("VUSD", 42161);
+    expect(
+      pickCounterpartToken({
+        current,
+        token,
+        tokens: [otherChain, current],
+      }),
+    ).toBe(current);
+  });
+
+  it("re-picks when the current counterpart's symbol no longer matches", function () {
+    const token = makeToken("sVUSD", 42161);
+    const current = makeToken("VUSD", 8453);
+    const match = makeToken("sVUSD", 1);
+    expect(
+      pickCounterpartToken({ current, token, tokens: [current, match] }),
+    ).toBe(match);
+  });
+
+  it("re-picks when the current counterpart is on the same chain as the source", function () {
+    const token = makeToken("VUSD", 8453);
+    const current = makeToken("VUSD", 8453);
+    const match = makeToken("VUSD", 42161);
+    expect(
+      pickCounterpartToken({ current, token, tokens: [current, match] }),
+    ).toBe(match);
+  });
 });


### PR DESCRIPTION
### Description

Adds sVUSD to the bridge page so users can move staked Vetro USD across Ethereum, Hemi, Arbitrum, Base, BSC and Optimism via LayerZero OFT. The mainnet entry carries the OFT adapter; the other chains use the OFT token directly.

The fiat preview converts sVUSD shares to VUSD on-chain via ERC-4626 `convertToAssets` against the mainnet vault, then prices the result through the existing `<RenderFiatValue>` — same conversion pattern the Earn page already uses. Share tokens are tagged with a new `isVaultShare` extension; a tiny `<BridgeTokenFiatValue>` dispatcher branches between vault and plain tokens.

As part of the work, a shared `convertToAssetsQueryOptions` primitive is extracted and `useStakedBalance` + `fetchWithdrawGasUnits` are routed through it, so every ERC-4626 share→asset conversion now flows through a single cached query.

Also fixes a cross-symbol pairing bug surfaced by the new tokens: `pickCounterpartToken` now takes the current counterpart and re-picks on symbol mismatch as well as chain collision, and the source dropdown filter excludes only the exact selected `(chain, symbol)` pair instead of the whole chain.

### Screenshots

<img width="941" height="676" alt="image" src="https://github.com/user-attachments/assets/e3ae1825-67be-4270-aac5-49233c89dd6a" />


### Related issue(s)

Closes #415
Related to #352 (we now need to add the Search modal for tokens)

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.