### PR TITLE
Update h1–h3 font weights to medium

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -129,16 +129,16 @@ If text-4xl is 2.25 rem => 4, then here 2.5 rem => 4.4 */
 }
 
 @utility text-h1 {
-  @apply text-4.4xl font-semibold tracking-[-1.6px];
+  @apply text-4.4xl font-medium tracking-[-1.6px];
 }
 
 @utility text-h2 {
-  @apply text-4xl font-semibold tracking-[-0.72px];
+  @apply text-4xl font-medium tracking-[-0.72px];
 }
 
 @utility text-h3 {
   /* override line height from tailwind */
-  @apply text-2xl leading-[28px] font-semibold tracking-[-0.24px];
+  @apply text-2xl leading-[28px] font-medium tracking-[-0.24px];
 }
 
 @utility text-h4 {


### PR DESCRIPTION
### Description

Update the `text-h1`, `text-h2`, and `text-h3` utilities in `web/src/index.css` from `font-semibold` to `font-medium` (500) to better match the Vetro marketing site.

### Screenshots

<img width="816" height="356" alt="image" src="https://github.com/user-attachments/assets/adb5bbae-05d8-4f7a-955e-4b1d669259c8" />


### Related issue(s)

Closes #407

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.