### PR TITLE
Make @vetro-protocol packages publishable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ build/
 .next/
 out/
 storybook-static/
+_esm/
+_types/
 
 # Landing TailwindCSS generated stylesheet
 landing/public/style.css

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ out/
 storybook-static/
 _esm/
 _types/
+packages/*/LICENSE
 
 # Landing TailwindCSS generated stylesheet
 landing/public/style.css

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -15,6 +15,7 @@
     "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",
     "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
     "clean": "rm -rf ./_esm ./_types",
+    "prepack": "cp ../../LICENSE LICENSE",
     "prepublishOnly": "pnpm clean && pnpm build:esm && pnpm build:types",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,8 +1,21 @@
 {
   "name": "@vetro-protocol/bridge",
-  "version": "1.0.0",
+  "version": "1.0.0-beta",
+  "description": "Vetro Protocol bridge actions for viem (LayerZero V2 OFT).",
+  "license": "MIT",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "_esm",
+    "_types",
+    "src"
+  ],
   "scripts": {
     "build": "tsc --noEmit",
+    "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",
+    "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
+    "clean": "rm -rf ./_esm ./_types",
+    "prepublishOnly": "pnpm clean && pnpm build:esm && pnpm build:types",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },
@@ -12,6 +25,7 @@
   },
   "devDependencies": {
     "@tsconfig/node24": "24.0.4",
+    "@types/node": "24.1.0",
     "@vitest/coverage-v8": "4.0.18",
     "typescript": "5.9.3",
     "viem": "2.44.4",
@@ -20,7 +34,27 @@
   "peerDependencies": {
     "viem": "^2.x"
   },
-  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "default": "./_esm/index.js",
+        "types": "./_types/index.d.ts"
+      },
+      "./actions": {
+        "default": "./_esm/actions/index.js",
+        "types": "./_types/actions/index.d.ts"
+      },
+      "./package.json": "./package.json"
+    },
+    "main": "./_esm/index.js",
+    "provenance": true,
+    "types": "./_types/index.d.ts"
+  },
   "type": "module",
   "exports": {
     ".": {
@@ -30,6 +64,8 @@
     "./actions": {
       "types": "./src/actions/index.ts",
       "default": "./src/actions/index.ts"
-    }
-  }
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false
 }

--- a/packages/bridge/tsconfig.build.json
+++ b/packages/bridge/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/earn/package.json
+++ b/packages/earn/package.json
@@ -15,6 +15,7 @@
     "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",
     "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
     "clean": "rm -rf ./_esm ./_types",
+    "prepack": "cp ../../LICENSE LICENSE",
     "prepublishOnly": "pnpm clean && pnpm build:esm && pnpm build:types",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"

--- a/packages/earn/package.json
+++ b/packages/earn/package.json
@@ -1,8 +1,21 @@
 {
   "name": "@vetro-protocol/earn",
-  "version": "1.0.0",
+  "version": "1.0.0-beta",
+  "description": "Vetro Protocol staking-vault actions for viem.",
+  "license": "MIT",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "_esm",
+    "_types",
+    "src"
+  ],
   "scripts": {
     "build": "tsc --noEmit",
+    "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",
+    "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
+    "clean": "rm -rf ./_esm ./_types",
+    "prepublishOnly": "pnpm clean && pnpm build:esm && pnpm build:types",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },
@@ -12,6 +25,7 @@
   },
   "devDependencies": {
     "@tsconfig/node24": "24.0.4",
+    "@types/node": "24.1.0",
     "@vitest/coverage-v8": "4.0.18",
     "typescript": "5.9.3",
     "viem": "2.44.4",
@@ -20,7 +34,27 @@
   "peerDependencies": {
     "viem": "^2.x"
   },
-  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "default": "./_esm/index.js",
+        "types": "./_types/index.d.ts"
+      },
+      "./actions": {
+        "default": "./_esm/actions/index.js",
+        "types": "./_types/actions/index.d.ts"
+      },
+      "./package.json": "./package.json"
+    },
+    "main": "./_esm/index.js",
+    "provenance": true,
+    "types": "./_types/index.d.ts"
+  },
   "type": "module",
   "exports": {
     ".": {
@@ -30,6 +64,8 @@
     "./actions": {
       "types": "./src/actions/index.ts",
       "default": "./src/actions/index.ts"
-    }
-  }
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false
 }

--- a/packages/earn/tsconfig.build.json
+++ b/packages/earn/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,8 +1,21 @@
 {
   "name": "@vetro-protocol/gateway",
-  "version": "1.0.0",
+  "version": "1.0.0-beta",
+  "description": "Vetro Protocol gateway actions for viem.",
+  "license": "MIT",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "_esm",
+    "_types",
+    "src"
+  ],
   "scripts": {
     "build": "tsc --noEmit",
+    "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",
+    "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
+    "clean": "rm -rf ./_esm ./_types",
+    "prepublishOnly": "pnpm clean && pnpm build:esm && pnpm build:types",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },
@@ -12,6 +25,7 @@
   },
   "devDependencies": {
     "@tsconfig/node24": "24.0.4",
+    "@types/node": "24.1.0",
     "@vitest/coverage-v8": "4.0.18",
     "typescript": "5.9.3",
     "viem": "2.44.4",
@@ -20,7 +34,27 @@
   "peerDependencies": {
     "viem": "^2.x"
   },
-  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "default": "./_esm/index.js",
+        "types": "./_types/index.d.ts"
+      },
+      "./actions": {
+        "default": "./_esm/actions/index.js",
+        "types": "./_types/actions/index.d.ts"
+      },
+      "./package.json": "./package.json"
+    },
+    "main": "./_esm/index.js",
+    "provenance": true,
+    "types": "./_types/index.d.ts"
+  },
   "type": "module",
   "exports": {
     ".": {
@@ -30,6 +64,8 @@
     "./actions": {
       "types": "./src/actions/index.ts",
       "default": "./src/actions/index.ts"
-    }
-  }
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false
 }

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -15,6 +15,7 @@
     "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",
     "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
     "clean": "rm -rf ./_esm ./_types",
+    "prepack": "cp ../../LICENSE LICENSE",
     "prepublishOnly": "pnpm clean && pnpm build:esm && pnpm build:types",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"

--- a/packages/gateway/tsconfig.build.json
+++ b/packages/gateway/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/treasury/package.json
+++ b/packages/treasury/package.json
@@ -1,8 +1,21 @@
 {
   "name": "@vetro-protocol/treasury",
-  "version": "1.0.0",
+  "version": "1.0.0-beta",
+  "description": "Vetro Protocol treasury actions for viem.",
+  "license": "MIT",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "_esm",
+    "_types",
+    "src"
+  ],
   "scripts": {
     "build": "tsc --noEmit",
+    "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",
+    "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
+    "clean": "rm -rf ./_esm ./_types",
+    "prepublishOnly": "pnpm clean && pnpm build:esm && pnpm build:types",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },
@@ -16,7 +29,27 @@
   "peerDependencies": {
     "viem": "^2.x"
   },
-  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "default": "./_esm/index.js",
+        "types": "./_types/index.d.ts"
+      },
+      "./actions": {
+        "default": "./_esm/actions/index.js",
+        "types": "./_types/actions/index.d.ts"
+      },
+      "./package.json": "./package.json"
+    },
+    "main": "./_esm/index.js",
+    "provenance": true,
+    "types": "./_types/index.d.ts"
+  },
   "type": "module",
   "exports": {
     ".": {
@@ -26,6 +59,8 @@
     "./actions": {
       "types": "./src/actions/index.ts",
       "default": "./src/actions/index.ts"
-    }
-  }
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false
 }

--- a/packages/treasury/package.json
+++ b/packages/treasury/package.json
@@ -15,6 +15,7 @@
     "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",
     "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
     "clean": "rm -rf ./_esm ./_types",
+    "prepack": "cp ../../LICENSE LICENSE",
     "prepublishOnly": "pnpm clean && pnpm build:esm && pnpm build:types",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"

--- a/packages/treasury/tsconfig.build.json
+++ b/packages/treasury/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,9 +130,12 @@ importers:
       '@tsconfig/node24':
         specifier: 24.0.4
         version: 24.0.4
+      '@types/node':
+        specifier: 24.1.0
+        version: 24.1.0
       '@vitest/coverage-v8':
         specifier: 4.0.18
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4))
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -141,7 +144,7 @@ importers:
         version: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       vitest:
         specifier: 4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4)
 
   packages/earn:
     dependencies:
@@ -155,9 +158,12 @@ importers:
       '@tsconfig/node24':
         specifier: 24.0.4
         version: 24.0.4
+      '@types/node':
+        specifier: 24.1.0
+        version: 24.1.0
       '@vitest/coverage-v8':
         specifier: 4.0.18
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4))
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -166,7 +172,7 @@ importers:
         version: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       vitest:
         specifier: 4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4)
 
   packages/gateway:
     dependencies:
@@ -180,9 +186,12 @@ importers:
       '@tsconfig/node24':
         specifier: 24.0.4
         version: 24.0.4
+      '@types/node':
+        specifier: 24.1.0
+        version: 24.1.0
       '@vitest/coverage-v8':
         specifier: 4.0.18
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4))
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -191,7 +200,7 @@ importers:
         version: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       vitest:
         specifier: 4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4)
 
   packages/linear-least-squares-regression:
     devDependencies:
@@ -12048,6 +12057,20 @@ snapshots:
       vite: 7.3.1(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.18
+      ast-v8-to-istanbul: 0.3.10
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.1
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4)
 
   '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.4))':
     dependencies:


### PR DESCRIPTION
### Description

Prepares the four viem-extension packages (`bridge`, `earn`, `gateway`, `treasury`) for publication to npm under `@vetro-protocol/*`. This covers Tasks A, B, and B.5 of #423; the release scripts, publish workflow, and first publish (Tasks E–I) come in follow-up PRs.

**What's in this PR**

- Each package flips `private: true` → `private: false`, bumps to `1.0.0-beta`, and gains the npm metadata required for publishing (license, description, sideEffects, files, engines, publishConfig).
- A new `tsconfig.build.json` per package (extends the existing config, scopes to `src/**/*.ts`, enables emit) drives the new `build:esm` / `build:types` scripts. The day-to-day `pnpm build` stays as `tsc --noEmit` so it keeps type-checking src + test + vitest.config.ts.
- `prepublishOnly` chains `clean && build:esm && build:types`, so `pnpm publish` produces the compiled output automatically.
- `_esm/` and `_types/` added to root `.gitignore`.
- `@types/node` added as a devDep to `bridge`, `earn`, `gateway` (treasury doesn't import Node builtins). Until now it was resolved transitively via vitest; once the build narrows include to `src/`, the implicit reference is gone.

**Workspace vs. published resolution (publishConfig override)**

Top-level `exports` keeps pointing at `./src/*.ts`, so workspace consumers — `web` and `api` — resolve to TypeScript source directly. No emit step needed for dev; edits to a package are picked up immediately on the next `tsc` / Vite HMR.

`publishConfig.main` / `publishConfig.types` / `publishConfig.exports` are substituted into the `package.json` *inside the published tarball* by `pnpm publish`. So npm consumers only ever see the compiled `_esm/index.js` / `_types/index.d.ts` paths. Verified by `pnpm pack` + inspecting the extracted tarball's manifest.

This only works because we publish via `pnpm publish`. Plain `npm publish` does not honor publishConfig field-replacement for exports/main/types.

**Initial publish strategy**

The very first publish will be done manually from a laptop while we shake out npm scope / token / tarball-contents issues. That's why each package starts at `1.0.0-beta` — published under the `beta` dist-tag, so `pnpm add @vetro-protocol/<pkg>` (without `@beta`) won't accidentally pick it up. After the publish workflow lands in a follow-up PR and we've verified the end-to-end automation, we bump to `1.0.0` and the `latest` tag takes over.

Provenance is enabled via `publishConfig.provenance: true`. The manual bootstrap will need `--no-provenance` since OIDC isn't available off-CI; every subsequent (workflow-driven) publish gets attested automatically.

**What's still pending (tracked on #423)**

- Task C: full tarball file-list check (manifest substitution and dry-run already verified; only the `tar -tzf` contents diff still open).
- Task E: `scripts/release.sh` — cuts the draft GitHub Release.
- Task E.5: `scripts/publish-changed.sh` — called from the workflow.
- Task F: `.github/workflows/publish.yml`.
- Task G: `RELEASING.md`.
- Task H: first manual publish to npm (1.0.0-beta).
- Task I: end-to-end verification of the automation.

**Related work**

[hemilabs/.github#28](https://github.com/hemilabs/.github/pull/28) — `ci: publish via pnpm when selected`. Required so the publish workflow (coming in a follow-up PR per Task F of #423) can drive `pnpm publish` from the shared `setup-node-env` composite action.

**Commits**

- df79e0f Make @vetro-protocol packages publishable
- cbd717f Add _esm/ and _types/ to gitignore

### Screenshots

N/A (no UI changes).

### Related issue(s)

Related to #423

### Checklist

- [x] Manual testing passed. (`pnpm build`/`build:esm`/`build:types` clean on all four; `pnpm -F web build` clean from a fresh state; tarball manifest contains compiled paths via publishConfig substitution.)
- [x] Automated tests added, or N/A. — N/A (metadata + build-tooling change; existing vitest suites unchanged.)
- [x] Documentation updated, or N/A. — Issue #423 body kept in sync; `RELEASING.md` comes in a follow-up PR per the issue.
- [x] Environment variables set in CI, or N/A. — N/A (`NPM_TOKEN` is required for the publish workflow, which lands in a follow-up PR).