### PR TITLE
Automate @vetro-protocol package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish to npm
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: hemilabs/actions/setup-node-env@8f87619b7f0122c39e14a32514ab3e4e0d4c3966 # v2.3.0
+        with:
+          package-manager: pnpm
+      - name: Publish changed packages
+        run: ./scripts/publish-changed.sh
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,54 @@
+# Releasing `@vetro-protocol/*` packages
+
+The `bridge`, `earn`, `gateway`, and `treasury` packages are published to npm under the `@vetro-protocol` scope. Releases are aggregated: one umbrella git tag and one GitHub Release cover every package whose version was bumped since the last release.
+
+## Per-PR rule
+
+A PR that touches a publishable package's source must bump that package's `"version"` in the same PR. Pick the right level:
+
+- `1.0.0-beta` → `1.0.0-beta.1`, `1.0.0-beta.2`, … while the package is in beta
+- `1.0.0-beta` → `1.0.0` for the stable cut
+- `1.0.0` → `1.0.1` / `1.1.0` / `2.0.0` after that, following SemVer
+
+A PR that touches only non-publishable code (web, api, configs, tests, docs) does not need a version bump.
+
+## Cutting a release
+
+From a clean checkout of `master`:
+
+```sh
+./scripts/release.sh
+```
+
+The script:
+
+1. Finds the previous `YYYYMMDD_N` tag (if any) and walks every `"private": false` package under `packages/`.
+2. Skips packages whose `version` is unchanged.
+3. Generates per-package release notes from PRs merged into `master` that touched the package path.
+4. Picks a tag of the form `YYYYMMDD_N`, where `N` starts at `1` and increments if the date already has a release (e.g. `20260519_1`, then `20260519_2`).
+5. Prompts for confirmation, then pushes the tag and creates a **draft** GitHub Release with the aggregated notes.
+
+The release is intentionally a draft. Review the notes on GitHub, edit if needed, then click **Publish release**.
+
+## What happens on publish
+
+Publishing the GitHub Release fires `.github/workflows/publish.yml`, which runs `scripts/publish-changed.sh`. That script:
+
+- Walks every `"private": false` package.
+- Compares each `version` against npm via `npm view`.
+- Publishes only versions that are not yet on npm.
+- Adds a `--tag <prerelease>` dist-tag when the version has a prerelease suffix (e.g. `1.0.0-beta` → `--tag beta`). Stable versions go to `latest`.
+
+The script is idempotent — re-publishing the same release (or re-running the workflow) is safe: anything already on npm is skipped.
+
+## First-time setup
+
+- The npm org `@vetro-protocol` must exist with publish rights for the publisher.
+- Repo secret `NPM_TOKEN` must be set (used as `NODE_AUTH_TOKEN` in the workflow). Provenance requires a granular access token with the right scopes.
+- Each script must be executable: `chmod +x scripts/*.sh`.
+
+## Troubleshooting
+
+- **The workflow ran but published nothing.** Expected when no `version` has changed since the previous npm publish. The log shows `Skipping <pkg> (version X already on npm)` for each one.
+- **The draft release lists fewer packages than expected.** A package only appears if its `version` in `package.json` differs from the version at the previous release tag. Bump the version, commit, re-run `release.sh`.
+- **Provenance fails.** The workflow needs `id-token: write` (already set) and an npm token with provenance scope.

--- a/packages/earn/README.md
+++ b/packages/earn/README.md
@@ -1,0 +1,101 @@
+# @vetro-protocol/earn
+
+Vetro Protocol staking-vault actions for viem. Wraps the `sVUSD` and `svetBTC` staking vaults with `deposit` / `requestWithdraw` / `requestRedeem` / `claimWithdraw` / `cancelWithdraw` flows, ERC20 approval included.
+
+## Installation
+
+```sh
+pnpm add @vetro-protocol/earn viem viem-erc20
+```
+
+## Vault addresses
+
+The package exports the canonical staking-vault addresses:
+
+```ts
+import {
+  sVetBtcAddress,
+  sVusdAddress,
+  stakingVaultAddresses,
+} from "@vetro-protocol/earn";
+```
+
+## Usage
+
+```ts
+import { deposit, getCooldownDuration } from "@vetro-protocol/earn/actions";
+import { sVusdAddress } from "@vetro-protocol/earn";
+import { createPublicClient, createWalletClient, custom, http } from "viem";
+import { mainnet } from "viem/chains";
+
+const publicClient = createPublicClient({ chain: mainnet, transport: http() });
+const walletClient = createWalletClient({
+  chain: mainnet,
+  transport: custom(window.ethereum),
+});
+
+// Read the cooldown duration
+const cooldown = await getCooldownDuration(publicClient, {
+  address: sVusdAddress,
+});
+
+// Deposit underlying assets into the vault (approval handled automatically)
+const { emitter, promise } = deposit(walletClient, {
+  assets: 1_000_000_000_000_000_000n,
+  receiver: "0x...",
+  token: "0x...", // underlying ERC20 (e.g. VUSD)
+  vaultAddress: sVusdAddress,
+});
+
+emitter.on("user-signed-deposit", (hash) => console.log("tx hash:", hash));
+emitter.on("deposit-transaction-succeeded", (receipt) =>
+  console.log("deposited:", receipt),
+);
+
+await promise;
+```
+
+The same actions are available via `.extend()` factories (`earnPublicActions()`, `earnWalletActions()`) for callers who prefer viem's extension pattern.
+
+## Withdrawal model
+
+The staking vault uses a cooldown. The flow is:
+
+1. `requestWithdraw({ assets, owner, vaultAddress })` or `requestRedeem({ shares, owner, vaultAddress })` — opens a request and starts the cooldown.
+2. `claimWithdraw({ requestId, address })` (or `claimWithdrawBatch` for multiple) — claims the assets once the cooldown has elapsed.
+3. `cancelWithdraw({ requestId, address })` — cancels a pending request before claiming.
+
+Use the public actions to inspect state: `getCooldownDuration`, `getCooldownEnabled`, `getActiveRequestIds`, `getPendingRequests`, `getClaimableRequests`, `getRequestDetails`, `getTotalAssetsInCooldown`, `getInstantWithdrawWhitelist`, `getYieldDistributor`.
+
+## Events
+
+Every wallet action returns `{ emitter, promise }` (via `to-promise-event`). The emitter fires a granular lifecycle:
+
+- `pre-approve` → `user-signed-approval` → `approve-transaction-succeeded` / `approve-transaction-reverted` (only when an ERC20 approval is needed)
+- `pre-<action>` → `user-signed-<action>` → `<action>-transaction-succeeded` / `<action>-transaction-reverted`
+- `user-signing-<action>-error` if the user rejects in the wallet
+- `<action>-failed-validation` if input validation fails (payload is a human-readable reason)
+- `unexpected-error` for anything that escapes
+- `<action>-settled` always emitted in the `finally` block
+
+Event-map types are exported per action: `DepositEvents`, `RequestRedeemEvents`, `RequestWithdrawEvents`, `ClaimWithdrawEvents`, `ClaimWithdrawBatchEvents`, `CancelWithdrawEvents`.
+
+## API
+
+Public actions (take a `Client`):
+
+- `getActiveRequestIds`, `getClaimableRequests`, `getCooldownDuration`, `getCooldownEnabled`, `getInstantWithdrawWhitelist`, `getPendingRequests`, `getRequestDetails`, `getTotalAssetsInCooldown`, `getYieldDistributor`
+
+Wallet actions (take a `WalletClient`, return `{ emitter, promise }`):
+
+- `deposit`, `requestRedeem`, `requestWithdraw`, `claimWithdraw`, `claimWithdrawBatch`, `cancelWithdraw`
+
+Encoders (return ABI-encoded calldata):
+
+- `encodeDeposit`, `encodeRequestRedeem`, `encodeRequestWithdraw`, `encodeClaimWithdraw`, `encodeClaimWithdrawBatch`, `encodeCancelWithdraw`
+
+Extension factories:
+
+- `earnPublicActions()`, `earnWalletActions()`
+
+Also exported: `stakingVaultAbi`, `sVusdAddress`, `sVetBtcAddress`, `stakingVaultAddresses`, and the `CooldownRequest` type.

--- a/packages/gateway/README.md
+++ b/packages/gateway/README.md
@@ -1,0 +1,106 @@
+# @vetro-protocol/gateway
+
+Vetro Protocol gateway actions for viem. Wraps the VUSD and vetBTC gateways with `deposit` / `redeem` / `requestRedeem` / `cancelRedeemRequest` flows, ERC20 approval included.
+
+## Installation
+
+```sh
+pnpm add @vetro-protocol/gateway viem viem-erc20
+```
+
+## Gateway addresses
+
+The package exports the canonical gateway addresses and their peg-base metadata:
+
+```ts
+import { gatewayAddresses, gateways } from "@vetro-protocol/gateway";
+
+// gateways is an array of { address, pegBaseSymbol } entries:
+//   { address: "0xDaD5…16F", pegBaseSymbol: "USD" }   // VUSD
+//   { address: "0xCBA2…faB", pegBaseSymbol: "BTC" }   // vetBTC
+```
+
+Pass the address you want directly as `gatewayAddress` to any wallet action.
+
+## Usage
+
+```ts
+import { deposit, getMintFee } from "@vetro-protocol/gateway/actions";
+import { gateways } from "@vetro-protocol/gateway";
+import { createPublicClient, createWalletClient, custom, http } from "viem";
+import { mainnet } from "viem/chains";
+
+const publicClient = createPublicClient({ chain: mainnet, transport: http() });
+const walletClient = createWalletClient({
+  chain: mainnet,
+  transport: custom(window.ethereum),
+});
+
+const vusdGateway = gateways.find((g) => g.pegBaseSymbol === "USD")!.address;
+
+// Quote the protocol fee for a given deposit
+const fee = await getMintFee(publicClient, {
+  address: vusdGateway,
+  amountIn: 1_000_000n,
+});
+
+// Deposit collateral, mint the pegged token (approval handled automatically)
+const { emitter, promise } = deposit(walletClient, {
+  amountIn: 1_000_000n,
+  gatewayAddress: vusdGateway,
+  minPeggedTokenOut: 950_000n,
+  receiver: "0x...",
+  tokenIn: "0x...", // e.g. USDC
+});
+
+emitter.on("user-signed-deposit", (hash) => console.log("tx hash:", hash));
+emitter.on("deposit-transaction-succeeded", (receipt) =>
+  console.log("minted:", receipt),
+);
+
+await promise;
+```
+
+The same actions are available via `.extend()` factories (`gatewayPublicActions()`, `gatewayWalletActions()`) for callers who prefer viem's extension pattern.
+
+## Redeem model
+
+Redeeming the pegged token back to collateral has two modes:
+
+- **Instant** — if the account is on the instant-redeem whitelist (or withdrawal delay is disabled), `redeem` settles in one transaction.
+- **Delayed** — otherwise, call `requestRedeem` to open a request, wait for the configured `withdrawalDelay`, then `redeem` claims the collateral. `cancelRedeemRequest` cancels a pending request.
+
+Use the public actions to inspect state: `getMintFee`, `getRedeemFee`, `previewDeposit`, `previewRedeem`, `getMaxWithdraw`, `getPeggedToken`, `getTreasury`, `getWithdrawalDelay`, `getWithdrawalDelayEnabled`, `isInstantRedeemWhitelisted`, `getRedeemRequest`.
+
+## Events
+
+Every wallet action returns `{ emitter, promise }` (via `to-promise-event`). The emitter fires a granular lifecycle:
+
+- `pre-approve` → `user-signed-approval` → `approve-transaction-succeeded` / `approve-transaction-reverted` (only when an ERC20 approval is needed)
+- `pre-<action>` → `user-signed-<action>` → `<action>-transaction-succeeded` / `<action>-transaction-reverted`
+- `user-signing-<action>-error` if the user rejects in the wallet
+- `<action>-failed-validation` if input validation fails (payload is a human-readable reason)
+- `unexpected-error` for anything that escapes
+- `<action>-settled` always emitted in the `finally` block
+
+Event-map types are exported per action: `DepositEvents`, `RedeemEvents`, `RequestRedeemEvents`, `CancelRedeemRequestEvents`.
+
+## API
+
+Public actions (take a `Client`):
+
+- `getMaxWithdraw`, `getMintFee`, `getPeggedToken`, `getRedeemFee`, `getRedeemRequest`, `getTreasury`, `getWithdrawalDelay`, `getWithdrawalDelayEnabled`, `isInstantRedeemWhitelisted`, `previewDeposit`, `previewRedeem`
+
+Wallet actions (take a `WalletClient`, return `{ emitter, promise }`):
+
+- `deposit`, `redeem`, `requestRedeem`, `cancelRedeemRequest`
+
+Encoders (return ABI-encoded calldata):
+
+- `encodeDeposit`, `encodeRedeem`, `encodeRequestRedeem`, `encodeCancelRedeemRequest`
+
+Extension factories:
+
+- `gatewayPublicActions()`, `gatewayWalletActions()`
+
+Also exported: `gatewayAbi`, `gatewayAddresses`, `gateways`, and the `Gateway` type.

--- a/packages/treasury/README.md
+++ b/packages/treasury/README.md
@@ -1,0 +1,58 @@
+# @vetro-protocol/treasury
+
+Read-only viem actions for the Vetro Protocol treasury contract. Provides oracle prices, per-token configuration, the whitelist, and per-token withdrawable balances.
+
+## Installation
+
+```sh
+pnpm add @vetro-protocol/treasury viem
+```
+
+## Usage
+
+```ts
+import {
+  getPrice,
+  getWhitelistedTokens,
+} from "@vetro-protocol/treasury/actions";
+import { createPublicClient, http } from "viem";
+import { mainnet } from "viem/chains";
+
+const publicClient = createPublicClient({ chain: mainnet, transport: http() });
+
+// Caller provides the treasury contract address
+const treasuryAddress = "0x...";
+
+const whitelisted = await getWhitelistedTokens(publicClient, {
+  address: treasuryAddress,
+});
+
+const price = await getPrice(publicClient, {
+  address: treasuryAddress,
+  token: whitelisted[0],
+});
+```
+
+The same actions are available via `.extend()` factory (`treasuryPublicActions()`) for callers who prefer viem's extension pattern:
+
+```ts
+import { treasuryPublicActions } from "@vetro-protocol/treasury";
+
+const client = publicClient.extend(treasuryPublicActions());
+const price = await client.getPrice({ address: treasuryAddress, token });
+```
+
+## API
+
+Public actions (take a `Client`):
+
+- `getPrice({ address, token })` — current oracle price for `token`.
+- `getTokenConfig({ address, token })` — per-token configuration struct.
+- `getWhitelistedTokens({ address })` — array of whitelisted token addresses.
+- `getWithdrawable({ address, token })` — withdrawable balance for `token`.
+
+Extension factory:
+
+- `treasuryPublicActions()` — wires the read actions onto a viem client via `.extend()`.
+
+Also exported: `treasuryAbi`.

--- a/scripts/publish-changed.sh
+++ b/scripts/publish-changed.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publish to npm every "private": false package under packages/ whose local
+# version is ahead of what's on npm. Invoked by .github/workflows/publish.yml
+# when a GitHub Release is published. Idempotent: packages already at the
+# local version on npm are skipped, so re-runs are safe.
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required but not installed. See https://jqlang.org/download/" >&2
+  exit 1
+fi
+
+for pkg_dir in packages/*/; do
+  pkg_dir=${pkg_dir%/}
+  publishable=$(jq -r '.private == false' "${pkg_dir}/package.json")
+  [ "$publishable" = "true" ] || continue
+
+  pkg_name=$(jq -r '.name' "${pkg_dir}/package.json")
+  local_version=$(jq -r '.version' "${pkg_dir}/package.json")
+
+  existing=$(npm view "${pkg_name}@${local_version}" version 2>/dev/null || echo "")
+  if [ "$existing" = "$local_version" ]; then
+    echo "Skipping $pkg_name (version $local_version already on npm)"
+    continue
+  fi
+
+  # Compute the dist-tag from a prerelease suffix: 1.0.0-beta.1 → beta, 1.0.0 → ""
+  dist_tag=""
+  if [[ "$local_version" == *-* ]]; then
+    pre="${local_version#*-}"
+    dist_tag="${pre%%.*}"
+  fi
+  tag_args=()
+  [ -n "$dist_tag" ] && tag_args=(--tag "$dist_tag")
+
+  echo "Publishing $pkg_name@$local_version${dist_tag:+ (--tag $dist_tag)}"
+  pnpm -F "$pkg_name" publish --access public --provenance --no-git-checks "${tag_args[@]}"
+done

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,7 +16,18 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-LAST_RELEASE_TAG=$(git describe --tags --abbrev=0 --match "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_*" 2>/dev/null || echo "")
+# Source of truth for release tags is the remote — don't assume local has them.
+LAST_RELEASE_TAG=$(git ls-remote --tags --refs origin \
+  | awk '{sub(/^refs\/tags\//, "", $2); print $2}' \
+  | grep -E '^[0-9]{8}_[0-9]+$' \
+  | sort -V \
+  | tail -1 || true)
+
+# Fetch the tag's commit locally so `git show <tag>:` and `git log <tag>..HEAD` work below.
+if [ -n "$LAST_RELEASE_TAG" ]; then
+  git fetch origin --quiet --force "refs/tags/${LAST_RELEASE_TAG}:refs/tags/${LAST_RELEASE_TAG}"
+fi
+
 NOTES=""
 CHANGED=()
 
@@ -84,7 +95,9 @@ fi
 DATE=$(date -u +%Y%m%d)
 N=1
 NEW_TAG="${DATE}_${N}"
-while git rev-parse -q --verify "refs/tags/${NEW_TAG}" >/dev/null; do
+# Check tag collisions against the remote, not local, so concurrent releases by
+# other maintainers (whose tags haven't been fetched locally) don't slip past.
+while git ls-remote --tags --exit-code origin "refs/tags/${NEW_TAG}" >/dev/null 2>&1; do
   N=$((N + 1))
   NEW_TAG="${DATE}_${N}"
 done

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI is required but not installed. See https://cli.github.com/" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "error: gh CLI is not authenticated. Run 'gh auth login' first." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required but not installed. See https://jqlang.org/download/" >&2
+  exit 1
+fi
+
+LAST_RELEASE_TAG=$(git describe --tags --abbrev=0 --match "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_*" 2>/dev/null || echo "")
+NOTES=""
+CHANGED=()
+
+# Build GitHub-style per-package notes from PRs merged into master that touched the path.
+# Uses --first-parent so each PR is one line (the merge commit) and feature-branch commits
+# don't show as separate entries. Direct-to-master commits (no PR) fall back to subject + SHA.
+# Create a draft release with these notes. Manual publish on GitHub UI
+build_pkg_notes() {
+  local pkg_dir=$1
+  local range
+  if [ -n "$LAST_RELEASE_TAG" ]; then
+    range="${LAST_RELEASE_TAG}..HEAD"
+  else
+    range="HEAD"
+  fi
+
+  while IFS='|' read -r sha subject; do
+    if [[ "$subject" =~ ^Merge\ pull\ request\ \#([0-9]+) ]]; then
+      local pr=${BASH_REMATCH[1]}
+      if ! gh pr view "$pr" --json number,title,author \
+            --jq '"- \(.title) by @\(.author.login) in #\(.number)"' 2>/dev/null; then
+        echo "- PR #${pr} (info unavailable)"
+      fi
+    elif [ -n "$subject" ]; then
+      echo "- ${subject} (${sha:0:7})"
+    fi
+  done < <(git log $range --first-parent --pretty='%H|%s' -- "${pkg_dir}/")
+}
+
+for pkg_dir in packages/*/; do
+  pkg_dir=${pkg_dir%/}
+  publishable=$(jq -r '.private == false' "${pkg_dir}/package.json")
+  [ "$publishable" = "true" ] || continue
+
+  pkg_name=$(jq -r '.name' "${pkg_dir}/package.json")
+  local_version=$(jq -r '.version' "${pkg_dir}/package.json")
+
+  if [ -n "$LAST_RELEASE_TAG" ]; then
+    prev_version=$(git show "${LAST_RELEASE_TAG}:${pkg_dir}/package.json" 2>/dev/null \
+      | jq -r '.version // ""' 2>/dev/null \
+      || echo "")
+  else
+    prev_version=""
+  fi
+
+  if [ "$local_version" = "$prev_version" ]; then
+    echo "Skipping ${pkg_name} (still at ${local_version})"
+    continue
+  fi
+
+  pkg_notes=$(build_pkg_notes "$pkg_dir")
+
+  CHANGED+=("${pkg_name}@${local_version}")
+  NOTES+="## ${pkg_name}@${local_version}${prev_version:+ (was ${prev_version})}
+${pkg_notes}
+
+"
+done
+
+if [ ${#CHANGED[@]} -eq 0 ]; then
+  echo "No publishable packages have a new version since ${LAST_RELEASE_TAG:-(initial)}. Nothing to release."
+  exit 0
+fi
+
+DATE=$(date -u +%Y%m%d)
+N=1
+NEW_TAG="${DATE}_${N}"
+while git rev-parse -q --verify "refs/tags/${NEW_TAG}" >/dev/null; do
+  N=$((N + 1))
+  NEW_TAG="${DATE}_${N}"
+done
+
+echo "Packages to release: ${CHANGED[*]}"
+echo "Tag: ${NEW_TAG}"
+echo
+echo "Notes:"
+echo "$NOTES"
+echo
+read -rp "Create draft release ${NEW_TAG}? [y/N] " ok
+[ "$ok" = "y" ] || exit 1
+
+git tag "${NEW_TAG}"
+git push origin "${NEW_TAG}"
+gh release create "${NEW_TAG}" --title "${NEW_TAG}" --notes "$NOTES" --draft
+
+echo
+echo "Draft release created. Review at:"
+gh release view "${NEW_TAG}" --json url --jq .url
+echo
+echo "When ready, click 'Publish release' on GitHub. That fires the workflow and publishes to npm."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -96,7 +96,7 @@ echo "Notes:"
 echo "$NOTES"
 echo
 read -rp "Create draft release ${NEW_TAG}? [y/N] " ok
-[ "$ok" = "y" ] || exit 1
+[ "$ok" = "y" ] || exit 0
 
 git tag "${NEW_TAG}"
 git push origin "${NEW_TAG}"


### PR DESCRIPTION
### Description

Automates the release flow for the four publishable `@vetro-protocol` packages (`bridge`, `earn`, `gateway`, `treasury`). Picks up where #424 left off — that PR made the packages publishable; this one adds the scripts, workflow, and docs that automate the cut + publish.

**What's in this PR**

- `scripts/release.sh` — run locally from a clean `master`. Walks `packages/*` for `"private": false` packages, skips those whose `version` is unchanged since the last `YYYYMMDD_N` tag, builds per-package release notes from PRs merged into `master` that touched the package path, then pushes a fresh `YYYYMMDD_N` tag and creates a **draft** GitHub Release.
- `scripts/publish-changed.sh` — invoked by the workflow on `release: published`. Walks the same packages, asks npm whether `<pkg>@<local-version>` is already on the registry, and `pnpm publish`es only the missing ones. Derives the dist-tag from a prerelease suffix (`1.0.0-beta.1` → `--tag beta`), so stable versions go to `latest` and prereleases never clobber it. Idempotent — re-running the workflow is safe. Publishes with `--provenance` (belt-and-suspenders alongside `publishConfig.provenance: true`).
- `.github/workflows/publish.yml` — fires on `release: [published]`, grants `id-token: write` for provenance, runs the publish script with `NPM_TOKEN`.
- `RELEASING.md` — documents the per-PR version-bump rule and the cut/publish flow.
- READMEs for `earn`, `gateway`, `treasury` (these surface on the npm package pages). `bridge` already had one.

This covers Tasks E, E.5, F, G of #423. Tasks H (first manual publish) and I (end-to-end verification) remain.

### Screenshots

N/A (no UI changes).

### Related issue(s)

Related to #423

### Checklist

- [x] Manual testing passed. — Logic-traced both scripts against current repo state (package walk, tag pick, version-existence check, dist-tag derivation, notes format).
- [x] Automated tests added, or N/A. — N/A (shell scripts + workflow; exercised end-to-end by the release flow).
- [x] Documentation updated, or N/A. — `RELEASING.md` added; per-package READMEs added for `earn`, `gateway`, `treasury`.
- [x] Environment variables set in CI, or N/A. — `NPM_TOKEN` repo secret required (granular token with provenance scope).