### PR TITLE
Set up npm release flow for packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           package-manager: pnpm
       - name: Publish package
-        run: ./scripts/publish-package.sh "${TAG%@*}"
+        run: ./scripts/publish-package.sh "${TAG%@*}" "${TAG#*@}"
         env:
           TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,5 +24,4 @@ jobs:
       - name: Publish package
         run: ./scripts/publish-package.sh "${TAG%@*}"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to npm
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    permissions:
+      contents: read
+      id-token: write # for npm provenance
+    if: |
+      startsWith(github.event.release.tag_name, 'bridge@')
+      || startsWith(github.event.release.tag_name, 'earn@')
+      || startsWith(github.event.release.tag_name, 'gateway@')
+      || startsWith(github.event.release.tag_name, 'treasury@')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: hemilabs/actions/setup-node-env@8f87619b7f0122c39e14a32514ab3e4e0d4c3966 # v2.3.0
+        with:
+          package-manager: pnpm
+      - name: Publish package
+        run: ./scripts/publish-package.sh "${TAG%@*}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,56 @@
+# Releasing packages
+
+This monorepo publishes four packages to npm under `@vetro-protocol/*`:
+
+- `@vetro-protocol/bridge`
+- `@vetro-protocol/earn`
+- `@vetro-protocol/gateway`
+- `@vetro-protocol/treasury`
+
+A package is publishable only if its `package.json` literally contains `"private": false`. Apps (`web`, `api`, `landing`, `subgraph`) stay private and never publish.
+
+## Versioning
+
+Bump a package's `version` only when you want to publish a new one. Changes that don't need to ship to npm — including refactors, tests, and edits consumed only by `web` / `api` — can land on `master` without touching `version`. `web` and `api` resolve via `workspace:*`, so they always pick up the latest source regardless of the package's declared version.
+
+When you do want to publish, bump the version in the PR that contains the change you want to ship (or in a follow-up PR before running the release script).
+
+## Cutting a release
+
+From `master`, after the package's `version` has been bumped in `package.json`, run the release script (`scripts/release.sh`) for that package. It:
+
+- Pulls the latest tags from origin so its checks aren't affected by local repo state.
+- Refuses to continue if a release for this package version already exists on the remote — prompting you to bump the version.
+- Composes release notes from the PRs that touched the package's directory since the previous release of the same package. The first GitHub release of a package falls back to a short "Initial release" placeholder instead of dumping the full history.
+- After your confirmation, creates the tag, pushes it, and opens a **draft** GitHub Release.
+
+Nothing has hit npm yet. Review the draft on GitHub and edit the notes if you want. When ready, click **"Publish release"** — that's the only thing that fires the npm publish.
+
+## What happens after you publish the draft
+
+`.github/workflows/publish.yml` fires on `release: published`. It:
+
+1. Allowlists tag prefixes `bridge@`, `earn@`, `gateway@`, `treasury@` at the job level — non-package releases (e.g. `web@<date>`, `vetro-app-subgraph@<version>`) are ignored here.
+2. Extracts the package name from the tag (`bridge@1.0.1` → `bridge`).
+3. Runs `./scripts/publish-package.sh <pkg>`, which reads the version from `packages/<pkg>/package.json` and runs `pnpm publish` (with `prepublishOnly` chaining the clean + emit step).
+
+The publish script is **idempotent**: if `<name>@<version>` is already on npm, it logs a skip and exits 0. Re-running a workflow on the same release is a no-op.
+
+### Dist-tags
+
+- A version containing `-` publishes under a dist-tag derived from the prerelease identifier:
+  - `1.0.0-beta` → `--tag beta`
+  - `1.0.0-rc.1` → `--tag rc`
+- Stable versions (no `-`) publish under the default `latest` tag.
+
+So `pnpm add @vetro-protocol/<pkg>` always pulls the latest stable. Beta users opt in with `@vetro-protocol/<pkg>@beta`.
+
+### Provenance
+
+The workflow has `id-token: write` so npm provenance attestations are generated when `publishConfig.provenance` is `true` in a package's `package.json`. Manual local publishes don't get provenance (no OIDC token outside CI).
+
+## Adding a new publishable package
+
+1. Set `"private": false` in its `package.json` and add `publishConfig` (mirror an existing publishable package).
+2. Add its name to the `if:` allowlist in `.github/workflows/publish.yml`.
+3. First publish: either run `./scripts/release.sh <pkg>` on `master`, or do a one-time manual `pnpm -F @vetro-protocol/<pkg> publish` to claim the name on npm.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,12 +45,13 @@ The publish script is **idempotent**: if `<name>@<version>` is already on npm, i
 
 So `pnpm add @vetro-protocol/<pkg>` always pulls the latest stable. Beta users opt in with `@vetro-protocol/<pkg>@beta`.
 
-### Provenance
+### Authentication & provenance
 
-The workflow has `id-token: write` so npm provenance attestations are generated when `publishConfig.provenance` is `true` in a package's `package.json`. Manual local publishes don't get provenance (no OIDC token outside CI).
+The workflow does not use an `NPM_TOKEN`. It authenticates to npm via **trusted publishing**: each package on npmjs.com has a trusted-publisher entry pointing at this repo and `.github/workflows/publish.yml`, and `pnpm publish` exchanges the GitHub Actions OIDC token for a short-lived registry token at publish time. That same `id-token: write` permission also signs the npm provenance attestation when `publishConfig.provenance` is `true` in a package's `package.json`.
 
 ## Adding a new publishable package
 
-1. Set `"private": false` in its `package.json` and add `publishConfig` (mirror an existing publishable package).
-2. Add its name to the `if:` allowlist in `.github/workflows/publish.yml`.
-3. First publish: either run `./scripts/release.sh <pkg>` on `master`, or do a one-time manual `pnpm -F @vetro-protocol/<pkg> publish` to claim the name on npm.
+1. On npmjs.com, configure a trusted publisher for the new package: org = `vetro-protocol` (GitHub), repo = this repo, workflow = `publish.yml`. Without this the CI publish will fail authentication.
+2. Set `"private": false` in its `package.json` and add `publishConfig` (mirror an existing publishable package).
+3. Add its name to the `if:` allowlist in `.github/workflows/publish.yml`.
+4. First publish: either run `./scripts/release.sh <pkg>` on `master`, or do a one-time manual `pnpm -F @vetro-protocol/<pkg> publish` to claim the name on npm.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,7 +32,7 @@ Nothing has hit npm yet. Review the draft on GitHub and edit the notes if you wa
 
 1. Allowlists tag prefixes `bridge@`, `earn@`, `gateway@`, `treasury@` at the job level — non-package releases (e.g. `web@<date>`, `vetro-app-subgraph@<version>`) are ignored here.
 2. Extracts the package name from the tag (`bridge@1.0.1` → `bridge`).
-3. Runs `./scripts/publish-package.sh <pkg>`, which reads the version from `packages/<pkg>/package.json` and runs `pnpm publish` (with `prepublishOnly` chaining the clean + emit step).
+3. Runs `./scripts/publish-package.sh <pkg> <version>` (both derived from the tag), which fails fast if `<version>` doesn't match `packages/<pkg>/package.json`, then runs `pnpm publish` (with `prepublishOnly` chaining the clean + emit step).
 
 The publish script is **idempotent**: if `<name>@<version>` is already on npm, it logs a skip and exits 0. Re-running a workflow on the same release is a no-op.
 

--- a/packages/earn/README.md
+++ b/packages/earn/README.md
@@ -1,0 +1,75 @@
+# @vetro-protocol/earn
+
+Vetro Protocol staking-vault actions for viem clients. Wraps the `sVUSD` and `sVetBTC` ERC-4626 vaults with their deposit, cooldown, and withdraw flows.
+
+## Installation
+
+```sh
+pnpm add @vetro-protocol/earn viem viem-erc20
+```
+
+## Overview
+
+- Targets the two whitelisted staking vaults — `sVUSD` and `sVetBTC` — exported as `sVusdAddress`, `sVetBtcAddress`, and the combined `stakingVaultAddresses` list.
+- `deposit` runs the full ERC-4626 deposit: on-chain allowance check, approval if needed, then `deposit(assets, receiver)`. Each step emits through an `EventEmitter`.
+- Withdrawals follow the vault's cooldown protocol: `requestRedeem` / `requestWithdraw` opens a cooldown, `claimWithdraw` / `claimWithdrawBatch` finalises it once the cooldown elapses, and `cancelWithdraw` aborts an open request.
+- Read actions (`getCooldownDuration`, `getCooldownEnabled`, `getInstantWithdrawWhitelist`, `getPendingRequests`, `getActiveRequestIds`, `getClaimableRequests`, `getRequestDetails`, `getTotalAssetsInCooldown`, `getYieldDistributor`) cover the data needed to drive a UI around the flows above.
+
+## Usage
+
+```ts
+import {
+  deposit,
+  getPendingRequests,
+  sVusdAddress,
+} from "@vetro-protocol/earn";
+import { createPublicClient, createWalletClient, custom, http } from "viem";
+import { hemi } from "viem/chains";
+
+const publicClient = createPublicClient({ chain: hemi, transport: http() });
+const walletClient = createWalletClient({
+  chain: hemi,
+  transport: custom(window.ethereum),
+});
+
+// Stake VUSD into sVUSD (approval handled automatically).
+const { emitter, promise } = deposit(walletClient, {
+  assets: 1_000_000_000_000_000_000n,
+  receiver: "0x...",
+  token: "0x...", // underlying VUSD address
+  vaultAddress: sVusdAddress,
+});
+
+emitter.on("user-signed-deposit", (hash) => console.log("tx hash:", hash));
+emitter.on("deposit-transaction-succeeded", (receipt) =>
+  console.log("deposited:", receipt),
+);
+
+await promise;
+
+// Inspect any pending withdraw requests for the user.
+const pending = await getPendingRequests(publicClient, {
+  account: "0x...",
+  address: sVusdAddress,
+});
+```
+
+The same actions are also available via `.extend()` factories (`earnPublicActions()`, `earnWalletActions()`) for callers who prefer viem's extension pattern.
+
+## API
+
+- Public actions (reads):
+  - `getActiveRequestIds(client, params)` — open withdraw request IDs for an account.
+  - `getClaimableRequests(client, params)` — request IDs whose cooldown has elapsed.
+  - `getCooldownDuration(client, params)` — cooldown length in seconds.
+  - `getCooldownEnabled(client, params)` — whether the cooldown is enforced.
+  - `getInstantWithdrawWhitelist(client, params)` — accounts allowed to bypass cooldown.
+  - `getPendingRequests(client, params)` — full pending-request structs for an account.
+  - `getRequestDetails(client, params)` — details for a specific request ID.
+  - `getTotalAssetsInCooldown(client, params)` — assets locked across all pending requests.
+  - `getYieldDistributor(client, params)` — address of the vault's yield distributor.
+- Wallet actions (writes): `deposit`, `requestRedeem`, `requestWithdraw`, `claimWithdraw`, `claimWithdrawBatch`, `cancelWithdraw`. Each returns `{ emitter, promise }`.
+- `earnPublicActions()` / `earnWalletActions()` — viem extension factories that wire the same actions onto a client via `.extend()`.
+- `stakingVaultAbi` — the minimal ABI subset used by the package.
+- Constants: `sVusdAddress`, `sVetBtcAddress`, `stakingVaultAddresses`.
+- Types: `CancelWithdrawEvents`, `ClaimWithdrawBatchEvents`, `ClaimWithdrawEvents`, `CooldownRequest`, `DepositEvents`, `RequestRedeemEvents`, `RequestWithdrawEvents`.

--- a/packages/gateway/README.md
+++ b/packages/gateway/README.md
@@ -1,0 +1,75 @@
+# @vetro-protocol/gateway
+
+Vetro Protocol gateway actions for viem clients. Mints pegged tokens (VUSD, vetBTC) from whitelisted underlying assets and handles redemptions back out.
+
+## Installation
+
+```sh
+pnpm add @vetro-protocol/gateway viem viem-erc20
+```
+
+## Overview
+
+- Two gateways ship by default — the VUSD gateway and the vetBTC gateway — exported as `gateways` (with `address` + `pegBaseSymbol`) and `gatewayAddresses` (just the addresses).
+- `deposit` mints the pegged token: checks `previewDeposit` for the expected output, runs an allowance + approval if needed, then calls `deposit(tokenIn, amountIn, minPeggedTokenOut, receiver)`.
+- Redemptions follow the gateway's two-step flow: `requestRedeem` opens a request, `redeem` finalises it once the optional withdrawal delay has elapsed (or immediately if the caller is on the instant-redeem whitelist), and `cancelRedeemRequest` aborts an open request.
+- Read actions cover everything a UI needs to drive these flows: previews, fee getters, request lookup, treasury / pegged-token addresses, and withdrawal-delay configuration.
+
+## Usage
+
+```ts
+import { deposit, gateways, previewDeposit } from "@vetro-protocol/gateway";
+import { createPublicClient, createWalletClient, custom, http } from "viem";
+import { hemi } from "viem/chains";
+
+const publicClient = createPublicClient({ chain: hemi, transport: http() });
+const walletClient = createWalletClient({
+  chain: hemi,
+  transport: custom(window.ethereum),
+});
+
+const vusdGateway = gateways[0]; // VUSD gateway
+
+// 1. Quote how much VUSD a USDT deposit would mint.
+const expectedOut = await previewDeposit(publicClient, {
+  address: vusdGateway.address,
+  amountIn: 1_000_000n, // 1 USDT (6 decimals)
+  tokenIn: "0x...", // USDT address
+});
+
+// 2. Deposit (approval handled automatically).
+const { emitter, promise } = deposit(walletClient, {
+  amountIn: 1_000_000n,
+  gatewayAddress: vusdGateway.address,
+  minPeggedTokenOut: expectedOut,
+  receiver: "0x...",
+  tokenIn: "0x...",
+});
+
+emitter.on("user-signed-deposit", (hash) => console.log("tx hash:", hash));
+emitter.on("deposit-transaction-succeeded", (receipt) =>
+  console.log("minted:", receipt),
+);
+
+await promise;
+```
+
+The same actions are also available via `.extend()` factories (`gatewayPublicActions()`, `gatewayWalletActions()`) for callers who prefer viem's extension pattern.
+
+## API
+
+- Public actions (reads):
+  - `previewDeposit(client, params)` — expected pegged-token output for a deposit.
+  - `previewRedeem(client, params)` — expected underlying output for a redeem.
+  - `getMintFee(client, params)` / `getRedeemFee(client, params)` — current fees.
+  - `getMaxWithdraw(client, params)` — maximum withdrawable amount.
+  - `getPeggedToken(client, params)` — pegged-token address minted by the gateway.
+  - `getTreasury(client, params)` — treasury address backing the gateway.
+  - `getRedeemRequest(client, params)` — details for a specific redeem request.
+  - `getWithdrawalDelay(client, params)` / `getWithdrawalDelayEnabled(client, params)` — delay configuration.
+  - `isInstantRedeemWhitelisted(client, params)` — whether an account can bypass the delay.
+- Wallet actions (writes): `deposit`, `requestRedeem`, `redeem`, `cancelRedeemRequest`. Each returns `{ emitter, promise }`.
+- `gatewayPublicActions()` / `gatewayWalletActions()` — viem extension factories that wire the same actions onto a client via `.extend()`.
+- `gatewayAbi` — the minimal ABI subset used by the package.
+- Constants: `gateways`, `gatewayAddresses`.
+- Types: `Gateway`, `CancelRedeemRequestEvents`, `DepositEvents`, `RedeemEvents`, `RequestRedeemEvents`.

--- a/packages/treasury/README.md
+++ b/packages/treasury/README.md
@@ -1,0 +1,49 @@
+# @vetro-protocol/treasury
+
+Vetro Protocol treasury read actions for viem clients. The treasury holds the underlying assets backing a gateway's pegged token (e.g. the USDT backing VUSD); this package exposes the read-only surface needed to inspect that backing.
+
+## Installation
+
+```sh
+pnpm add @vetro-protocol/treasury viem
+```
+
+## Overview
+
+- Read-only — no wallet actions, no events. The treasury is administered separately; consumers query it.
+- `getWhitelistedTokens` lists every underlying asset the treasury accepts.
+- `getTokenConfig` / `getPrice` return the per-token configuration and oracle price (denominated in the gateway's peg unit; convert to USD via the matching `Gateway.pegBaseSymbol`).
+- `getWithdrawable` returns how much of a given token can be withdrawn given the current state.
+
+## Usage
+
+```ts
+import { getPrice, getWhitelistedTokens } from "@vetro-protocol/treasury";
+import { createPublicClient, http } from "viem";
+import { hemi } from "viem/chains";
+
+const publicClient = createPublicClient({ chain: hemi, transport: http() });
+
+const treasuryAddress = "0x..."; // from getTreasury() on the matching gateway
+
+const tokens = await getWhitelistedTokens(publicClient, {
+  address: treasuryAddress,
+});
+
+const price = await getPrice(publicClient, {
+  address: treasuryAddress,
+  token: tokens[0],
+});
+```
+
+The same actions are also available via the `.extend()` factory (`treasuryPublicActions()`) for callers who prefer viem's extension pattern.
+
+## API
+
+- Public actions (reads):
+  - `getPrice(client, params)` — oracle price for a whitelisted token, in the treasury's peg unit.
+  - `getTokenConfig(client, params)` — per-token configuration struct.
+  - `getWhitelistedTokens(client, params)` — full list of accepted underlying tokens.
+  - `getWithdrawable(client, params)` — current withdrawable amount for a token.
+- `treasuryPublicActions()` — viem extension factory that wires the same actions onto a client via `.extend()`.
+- `treasuryAbi` — the minimal ABI subset used by the package.

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/publish-package.sh <package-name>
+# Reads packages/<pkg>/package.json for the version and publishes to npm.
+# Idempotent: skips if the version is already on npm.
+set -euo pipefail
+
+command -v jq >/dev/null || { echo "Missing required tool: jq"; exit 1; }
+
+PKG="${1:?Usage: $0 <package-name>}"
+PKG_DIR="packages/${PKG}"
+
+PKG_NAME=$(jq -r .name "${PKG_DIR}/package.json")
+LOCAL_VERSION=$(jq -r .version "${PKG_DIR}/package.json")
+
+existing=$(npm view "${PKG_NAME}@${LOCAL_VERSION}" version 2>/dev/null || echo "")
+if [ "$existing" = "$LOCAL_VERSION" ]; then
+  echo "Skipping ${PKG_NAME} (version ${LOCAL_VERSION} already on npm)"
+  exit 0
+fi
+
+dist_tag=""
+if [[ "$LOCAL_VERSION" == *-* ]]; then
+  rest="${LOCAL_VERSION#*-}"
+  dist_tag="${rest%%.*}"
+fi
+tag_args=()
+[ -n "$dist_tag" ] && tag_args=(--tag "$dist_tag")
+
+echo "Publishing ${PKG_NAME}@${LOCAL_VERSION}${dist_tag:+ (--tag ${dist_tag})}"
+pnpm -F "$PKG_NAME" publish --access public --no-git-checks "${tag_args[@]}"

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -1,16 +1,24 @@
 #!/usr/bin/env bash
-# Usage: ./scripts/publish-package.sh <package-name>
+# Usage: ./scripts/publish-package.sh <package-name> <expected-version>
 # Reads packages/<pkg>/package.json for the version and publishes to npm.
+# Fails if <expected-version> (the release tag's version) doesn't match
+# package.json — guards against a manually-created tag drifting from source.
 # Idempotent: skips if the version is already on npm.
 set -euo pipefail
 
 command -v jq >/dev/null || { echo "Missing required tool: jq"; exit 1; }
 
-PKG="${1:?Usage: $0 <package-name>}"
+PKG="${1:?Usage: $0 <package-name> <expected-version>}"
+EXPECTED_VERSION="${2:?Usage: $0 <package-name> <expected-version>}"
 PKG_DIR="packages/${PKG}"
 
 PKG_NAME=$(jq -r .name "${PKG_DIR}/package.json")
 LOCAL_VERSION=$(jq -r .version "${PKG_DIR}/package.json")
+
+if [ "$EXPECTED_VERSION" != "$LOCAL_VERSION" ]; then
+  echo "Tag version (${EXPECTED_VERSION}) does not match ${PKG_DIR}/package.json version (${LOCAL_VERSION})"
+  exit 1
+fi
 
 existing=$(npm view "${PKG_NAME}@${LOCAL_VERSION}" version 2>/dev/null || echo "")
 if [ "$existing" = "$LOCAL_VERSION" ]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/release.sh <package-name>
+# Example: ./scripts/release.sh bridge
+set -euo pipefail
+
+for cmd in jq gh; do
+  command -v "$cmd" >/dev/null || { echo "Missing required tool: $cmd"; exit 1; }
+done
+
+PKG="${1:-}"
+[ -n "$PKG" ] || { echo "Usage: $0 <package-name>"; exit 1; }
+
+PKG_DIR="packages/${PKG}"
+[ -f "${PKG_DIR}/package.json" ] || { echo "No package at ${PKG_DIR}"; exit 1; }
+
+publishable=$(jq -r '.private == false' "${PKG_DIR}/package.json")
+[ "$publishable" = "true" ] || { echo "${PKG} is not publishable (private !== false)"; exit 1; }
+
+VERSION=$(jq -r .version "${PKG_DIR}/package.json")
+TAG="${PKG}@${VERSION}"
+
+# Remote is the source of truth for tags; sync before any tag-state check so
+# this works on a fresh clone or after a prior run on a teammate's machine.
+git fetch --tags --quiet origin
+
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  echo "Tag ${TAG} already exists. Bump the version in package.json first."
+  exit 1
+fi
+
+# Previous tag for THIS package (most recent <pkg>@* tag, from origin after the fetch above).
+# --sort=-version:refname uses git's semver-aware version sort (descending), so
+# 1.0.1 > 1.0.0 > 1.0.0-beta — prereleases correctly rank below their stable.
+PREV_TAG=$(git tag --list "${PKG}@*" --sort=-version:refname | head -n1 || true)
+
+if [ -z "$PREV_TAG" ]; then
+  # First GitHub-driven release for this package — don't dump full history.
+  NOTES="_Initial GitHub release of @vetro-protocol/${PKG}._"
+else
+  # Per-PR notes scoped to this one package's path, bounded by the previous tag.
+  # Uses --first-parent so each PR is one line (the merge commit) and feature-branch
+  # commits don't show as separate entries. Direct-to-master commits (no PR) fall back
+  # to subject + SHA.
+  NOTES=$(
+    git log "${PREV_TAG}..HEAD" --first-parent --pretty='%H|%s' -- "${PKG_DIR}/" \
+    | while IFS='|' read -r sha subject; do
+        if [[ "$subject" =~ ^Merge\ pull\ request\ \#([0-9]+) ]]; then
+          pr=${BASH_REMATCH[1]}
+          gh pr view "$pr" --json number,title,author \
+            --jq '"- \(.title) by @\(.author.login) in #\(.number)"' \
+            2>/dev/null || echo "- PR #${pr} (info unavailable)"
+        elif [ -n "$subject" ]; then
+          echo "- ${subject} (${sha:0:7})"
+        fi
+      done
+  )
+
+  [ -n "$NOTES" ] || NOTES="_No commits touched ${PKG_DIR}/ since ${PREV_TAG}._"
+fi
+
+echo "Package:  ${PKG}"
+echo "Version:  ${VERSION}"
+echo "Tag:      ${TAG}"
+echo "Prev tag: ${PREV_TAG:-(none)}"
+echo
+echo "Notes:"
+echo "$NOTES"
+echo
+read -rp "Create draft release ${TAG}? [y/N] " ok
+[ "$ok" = "y" ] || exit 1
+
+git tag "${TAG}"
+git push origin "${TAG}"
+gh release create "${TAG}" --title "${TAG}" --notes "$NOTES" --draft
+
+echo
+echo "Draft release created. Review at:"
+gh release view "${TAG}" --json url --jq .url
+echo
+echo "When ready, click 'Publish release' on GitHub. That fires the workflow and publishes ${PKG} to npm."


### PR DESCRIPTION
### Description

Implements the per-package npm publish flow described in #423: a draft-GitHub-Release model that gates npm publishing behind a human review step, with idempotent CI that's a no-op on re-runs.

- `scripts/release.sh` — interactive script (run from `master`) that fetches tags from origin, refuses to continue if `<pkg>@<version>` already exists on the remote, composes release notes from PRs that touched `packages/<pkg>/` since the previous `<pkg>@*` tag, then creates the tag and opens a **draft** GitHub Release. First-time releases use a one-line "Initial release" placeholder instead of dumping full history.
- `scripts/publish-package.sh` — idempotent; reads the version from `packages/<pkg>/package.json`, skips if it's already on npm, and auto-derives the dist-tag from prerelease versions (`1.0.0-beta` → `--tag beta`, stable → `latest`).
- `.github/workflows/publish.yml` — fires on `release: published`. Allowlists `bridge@`, `earn@`, `gateway@`, `treasury@` at the job level so non-package releases (e.g. `web@<date>`, `vetro-app-subgraph@<version>`) are inert. `id-token: write` is set so npm provenance attestations are generated for packages that opt in via `publishConfig.provenance: true`.
- `packages/{earn,gateway,treasury}/README.md` — concise package landing pages modelled on `bridge/README.md`.
- `RELEASING.md` — human-readable walkthrough of the flow (versioning rule, cutting a release, what fires automatically, dist-tag/provenance behaviour, adding a new publishable package).

The four packages were already manually published at `1.0.0-beta` on npm during issue setup (Task H), so the first time this workflow fires it'll no-op the publish step — that's exactly Task I's safe verification path. End-to-end verification will happen after merge.

### Screenshots

N/A.

### Related issue(s)

Closes #423

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.