### PR TITLE
Deploy subgraph after publishing a release

### DIFF
--- a/.github/workflows/subgraph-deployment.yml
+++ b/.github/workflows/subgraph-deployment.yml
@@ -1,9 +1,9 @@
 name: Subgraph Deployment
 
 on:
-  push:
-    tags:
-      - "vetro-app-subgraph@*"
+  release:
+    types:
+      - published
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -13,6 +13,7 @@ jobs:
   deploy-subgraph:
     permissions:
       contents: read
+    if: startsWith(github.event.release.tag_name, 'vetro-app-subgraph@')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/subgraph/README.md
+++ b/subgraph/README.md
@@ -61,7 +61,8 @@ Sample response:
 
 ## Deployment
 
-The first deployment has to be done manually by [@jcvernaleo](https://github.com/jcvernaleo).
+The first deployment was done manually by [@jcvernaleo](https://github.com/jcvernaleo).
 
 For subsequent deployments, apply a `vetro-app-subgraph@[version]` tag to the proper commit in the `master` branch by running `pnpm run tag` and push it.
-Once the subgraph is deployed and indexed, ask [@jcvernaleo](https://github.com/jcvernaleo) for publishing.
+Then create and publish a new release.
+Once the subgraph is deployed, ask [@jcvernaleo](https://github.com/jcvernaleo) to publish it.

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -14,7 +14,7 @@
     "remove-local": "graph remove --node http://localhost:8020/ $npm_package_name",
     "tag": "scripts/tag-subgraph.sh",
     "pretest": "npm run codegen",
-    "test": "graph test"
+    "test": "graph test --version=0.6.0"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.98.1",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The goal is to align all deployment workflows.

This pull request updates the subgraph deployment workflow and related documentation to streamline the deployment process and ensure compatibility with the latest tooling. The most important changes are grouped below:

**CI/CD Workflow Improvements:**

* Changed the GitHub Actions workflow trigger from pushing tags to publishing releases, ensuring deployments only occur when a new release is published (`.github/workflows/subgraph-deployment.yml`).
* Added a conditional to the deployment job so it only runs when the release tag starts with `vetro-app-subgraph@`, adding an extra safeguard to prevent unintended deployments (`.github/workflows/subgraph-deployment.yml`).

**Documentation Updates:**

* Updated deployment instructions in `subgraph/README.md` to reflect the new process: after tagging, a release must be created and published to trigger deployment, clarifying the steps and responsibilities.

**Tooling and Testing:**

* Updated the test script in `subgraph/package.json` to specify `graph test --version=0.6.0`, ensuring tests run with the intended version of the Graph CLI.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #432

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
