### PR TITLE
Fix release script tag handling and bump gateway to beta.1

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vetro-protocol/gateway",
-  "version": "1.0.0-beta",
+  "version": "1.0.0-beta.1",
   "description": "Vetro Protocol gateway actions for viem.",
   "license": "MIT",
   "files": [

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -69,9 +69,11 @@ echo
 read -rp "Create draft release ${TAG}? [y/N] " ok
 [ "$ok" = "y" ] || exit 1
 
-git tag "${TAG}"
-git push origin "${TAG}"
-gh release create "${TAG}" --title "${TAG}" --notes "$NOTES" --draft
+# Don't create the tag now: a draft release holds the tag NAME and only
+# materializes the git ref on publish. --target pins which commit the tag will
+# point at (the workflows trigger on 'release: published' and check out the tag).
+# This way, abandoning the draft leaves no orphan tag on origin.
+gh release create "${TAG}" --title "${TAG}" --notes "$NOTES" --draft --target "$(git rev-parse HEAD)"
 
 echo
 echo "Draft release created. Review at:"


### PR DESCRIPTION
### Description

Two changes building on the release-via-GitHub-Releases flow:

**1. Fix `scripts/release.sh` creating tags too early.** The script previously ran `git tag` + `git push origin <tag>` *before* creating the release, even though the release itself is only a draft. Since both publish workflows (`publish.yml`, `subgraph-deployment.yml`) trigger exclusively on `release: published`, pushing the tag up front was both unnecessary and harmful: abandoning a draft left an orphan `<pkg>@<version>` tag on origin, which then tripped the script's own "tag already exists — bump the version" guard on later runs. Now we let the draft release hold the tag *name* and let GitHub materialize the git ref only on publish. `--target "$(git rev-parse HEAD)"` pins which commit the tag will point at, since the workflows check out the tag.

**2. Bump `@vetro-protocol/gateway` to `1.0.0-beta.1`.** This is the correct semver successor to `1.0.0-beta` (dotted numeric prereleases compare numerically and all rank below the eventual `1.0.0`). The plan is to keep cutting beta iterations (`beta.2`, `beta.3`, …) to exercise the full release flow end to end. Once I've fully validated the whole flow, I'll bump all the libs to `1.0.0` and release them as stable.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #428

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.