### PR TITLE
Fix provenance for package's deployment

### DIFF
--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -10,6 +10,11 @@
     "_types",
     "src"
   ],
+  "repository": {
+    "directory": "packages/bridge",
+    "type": "git",
+    "url": "git+https://github.com/vetro-protocol/vetro-monorepo.git"
+  },
   "scripts": {
     "build": "tsc --noEmit",
     "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",

--- a/packages/earn/package.json
+++ b/packages/earn/package.json
@@ -10,6 +10,11 @@
     "_types",
     "src"
   ],
+  "repository": {
+    "directory": "packages/earn",
+    "type": "git",
+    "url": "git+https://github.com/vetro-protocol/vetro-monorepo.git"
+  },
   "scripts": {
     "build": "tsc --noEmit",
     "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -10,6 +10,11 @@
     "_types",
     "src"
   ],
+  "repository": {
+    "directory": "packages/gateway",
+    "type": "git",
+    "url": "git+https://github.com/vetro-protocol/vetro-monorepo.git"
+  },
   "scripts": {
     "build": "tsc --noEmit",
     "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vetro-protocol/gateway",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Vetro Protocol gateway actions for viem.",
   "license": "MIT",
   "files": [

--- a/packages/treasury/package.json
+++ b/packages/treasury/package.json
@@ -10,6 +10,11 @@
     "_types",
     "src"
   ],
+  "repository": {
+    "directory": "packages/treasury",
+    "type": "git",
+    "url": "git+https://github.com/vetro-protocol/vetro-monorepo.git"
+  },
   "scripts": {
     "build": "tsc --noEmit",
     "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

I tested the package deployment, and while the release was created and the publish action run, I got the following [error](https://github.com/vetro-protocol/vetro-monorepo/actions/runs/26581333063/job/78314874420):

> npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@vetro-protocol%2fgateway - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/vetro-protocol/vetro-monorepo" from provenance

This PR adds the config missing for the 4 packages.

It also bumps `@vetro-protocol/gateway` to version `beta.2` to continue testing

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #423 

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
