### PR TITLE
Bump publishable packages to 1.0.0

### DIFF
--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vetro-protocol/bridge",
-  "version": "1.0.0-beta",
+  "version": "1.0.0",
   "description": "Vetro Protocol bridge actions for viem (LayerZero V2 OFT).",
   "license": "MIT",
   "files": [

--- a/packages/earn/package.json
+++ b/packages/earn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vetro-protocol/earn",
-  "version": "1.0.0-beta",
+  "version": "1.0.0",
   "description": "Vetro Protocol staking-vault actions for viem.",
   "license": "MIT",
   "files": [

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vetro-protocol/gateway",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0",
   "description": "Vetro Protocol gateway actions for viem.",
   "license": "MIT",
   "files": [

--- a/packages/treasury/package.json
+++ b/packages/treasury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vetro-protocol/treasury",
-  "version": "1.0.0-beta",
+  "version": "1.0.0",
   "description": "Vetro Protocol treasury actions for viem.",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

I was able to get `@vetro-protocol/gateway` published with provenance through releases + automation 

<img width="993" height="264" alt="image" src="https://github.com/user-attachments/assets/ed6204b3-0a4d-4738-8223-cfa7de7d868f" />

See [@vetro-protocol/gateway/@1.0.0-beta.2](https://www.npmjs.com/package/@vetro-protocol/gateway/v/1.0.0-beta.2)

This means we can now bump all versions to stable, and publish each of them with releases 🎉 

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #423 and #428

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
