### PR TITLE
Add multi-vault withdraw-all flow with progress drawer

### DIFF
--- a/web/src/hooks/useClaimWithdrawBatch.ts
+++ b/web/src/hooks/useClaimWithdrawBatch.ts
@@ -162,9 +162,13 @@ export const useClaimWithdrawBatch = function ({
         queryKey: nativeBalanceKey,
       });
 
+      // Refetch (not just invalidate) each vault's shares balance: it feeds
+      // useStakedBalance via ensureQueryData and has no mounted observer, so
+      // invalidation alone would leave the staked balance recomputing from
+      // stale shares.
       await Promise.all(
         withdrawals.map(({ stakingVaultAddress }) =>
-          queryClient.invalidateQueries({
+          queryClient.refetchQueries({
             queryKey: tokenBalanceQueryKey(
               { address: stakingVaultAddress, chainId: chain.id },
               account,

--- a/web/src/hooks/useClaimWithdrawBatch.ts
+++ b/web/src/hooks/useClaimWithdrawBatch.ts
@@ -3,35 +3,49 @@ import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { claimWithdrawBatch } from "@vetro-protocol/earn/actions";
 import { exitTicketsQueryKey } from "pages/earn/hooks/useExitTickets";
 import type { ExitTicket } from "pages/earn/types";
+import type { TokenWithGateway } from "types";
+import type { Address } from "viem";
 import { useAccount } from "wagmi";
 
+import { useEthereumClient } from "./useEthereumClient";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { stakedBalanceQueryKey } from "./useStakedBalance";
+import { vaultPeggedTokenQueryOptions } from "./useVaultPeggedToken";
 
 type ClaimWithdrawBatchStatus = "claiming" | "completed" | "failed";
 
-type Params = {
-  onStatusChange: (status: ClaimWithdrawBatchStatus) => void;
-  onTransactionHash?: (hash: string) => void;
+type Withdrawal = {
   requestIds: bigint[];
+  stakingVaultAddress: Address;
 };
 
-// TODO using the only staking vault address to simplify this PR
-// we will handle multiple addresses in the next PR
-const stakingVaultAddress = stakingVaultAddresses[0];
+type Params = {
+  onStatusChange: (args: {
+    peggedToken: TokenWithGateway;
+    stakingVaultAddress: Address;
+    status: ClaimWithdrawBatchStatus;
+  }) => void;
+  // Fires once the whole batch claims without any vault failing: the mutationFn
+  // throws on the first failure, so a successful settle means every vault is done.
+  onSuccess?: VoidFunction;
+  onTransactionHash?: (args: {
+    hash: string;
+    stakingVaultAddress: Address;
+  }) => void;
+};
 
 export const useClaimWithdrawBatch = function ({
   onStatusChange,
+  onSuccess,
   onTransactionHash,
-  requestIds,
 }: Params) {
   const { address: account } = useAccount();
   const chain = useMainnet();
+  const client = useEthereumClient();
   const { data: walletClient } = useEthereumWalletClient();
   const ensureConnectedTo = useEnsureConnectedTo();
   const queryClient = useQueryClient();
@@ -41,83 +55,132 @@ export const useClaimWithdrawBatch = function ({
     chain.id,
   );
 
-  const sharesBalanceKey = tokenBalanceQueryKey(
-    { address: stakingVaultAddress, chainId: chain.id },
-    account,
-  );
-
-  const stakedKey = stakedBalanceQueryKey({
-    account: account!,
-    chainId: chain.id,
-    stakingVaultAddress,
-  });
-
-  const requestIdStrings = requestIds.map((id) => id.toString());
-
   return useMutation({
-    async mutationFn() {
+    async mutationFn(withdrawals: Withdrawal[]) {
       if (!account) {
         throw new Error("No account connected");
+      }
+      if (!walletClient) {
+        throw new Error("No wallet client");
       }
 
       await ensureConnectedTo(chain.id);
 
-      const { emitter, promise } = claimWithdrawBatch(walletClient!, {
-        receiver: account,
-        requestIds,
-        vaultAddress: stakingVaultAddress,
-      });
+      // One transaction per staking vault, run sequentially so the drawer can
+      // reflect progress step by step and so each transaction lands as its own
+      // activity entry.
+      for (const { requestIds, stakingVaultAddress } of withdrawals) {
+        // Resolve the vault's pegged token before claiming so every status
+        // change (and the activity entry it drives) has the token metadata.
+        const peggedToken = await queryClient.ensureQueryData(
+          vaultPeggedTokenQueryOptions({
+            client,
+            queryClient,
+            stakingVaultAddress,
+          }),
+        );
 
-      emitter.on("user-signed-claim-withdraw-batch", function (hash) {
-        onTransactionHash?.(hash);
-        onStatusChange("claiming");
-      });
+        const { emitter, promise } = claimWithdrawBatch(walletClient, {
+          receiver: account,
+          requestIds,
+          vaultAddress: stakingVaultAddress,
+        });
 
-      emitter.on("user-signing-claim-withdraw-batch-error", function () {
-        onStatusChange("failed");
-      });
+        let failed = false;
 
-      emitter.on(
-        "claim-withdraw-batch-transaction-reverted",
-        function (receipt) {
-          updateNativeBalanceAfterReceipt(receipt);
-          onStatusChange("failed");
-        },
-      );
+        emitter.on("user-signed-claim-withdraw-batch", function (hash) {
+          onTransactionHash?.({ hash, stakingVaultAddress });
+          onStatusChange({
+            peggedToken,
+            stakingVaultAddress,
+            status: "claiming",
+          });
+        });
 
-      emitter.on(
-        "claim-withdraw-batch-transaction-succeeded",
-        function (receipt) {
-          updateNativeBalanceAfterReceipt(receipt);
-          onStatusChange("completed");
+        emitter.on("user-signing-claim-withdraw-batch-error", function () {
+          failed = true;
+          onStatusChange({
+            peggedToken,
+            stakingVaultAddress,
+            status: "failed",
+          });
+        });
 
-          // Optimistically mark all claimed tickets as withdrawn
-          queryClient.setQueryData(
-            exitTicketsQueryKey(account),
-            (old: ExitTicket[] | undefined) =>
-              (old ?? []).map((t) =>
-                requestIdStrings.includes(t.requestId)
-                  ? { ...t, claimTxHash: receipt.transactionHash }
-                  : t,
-              ),
+        emitter.on(
+          "claim-withdraw-batch-transaction-reverted",
+          function (receipt) {
+            failed = true;
+            updateNativeBalanceAfterReceipt(receipt);
+            onStatusChange({
+              peggedToken,
+              stakingVaultAddress,
+              status: "failed",
+            });
+          },
+        );
+
+        emitter.on(
+          "claim-withdraw-batch-transaction-succeeded",
+          function (receipt) {
+            updateNativeBalanceAfterReceipt(receipt);
+            onStatusChange({
+              peggedToken,
+              stakingVaultAddress,
+              status: "completed",
+            });
+
+            const requestIdStrings = requestIds.map((id) => id.toString());
+
+            // Optimistically mark this vault's claimed tickets as withdrawn so
+            // they leave the ready list even if a later vault fails.
+            queryClient.setQueryData(
+              exitTicketsQueryKey(account),
+              (old: ExitTicket[] | undefined) =>
+                (old ?? []).map((t) =>
+                  requestIdStrings.includes(t.requestId)
+                    ? { ...t, claimTxHash: receipt.transactionHash }
+                    : t,
+                ),
+            );
+          },
+        );
+
+        await promise;
+
+        // Stop the flow on failure so the user can retry the remaining vaults.
+        if (failed) {
+          throw new Error(
+            `Claim withdraw batch failed for vault ${stakingVaultAddress}`,
           );
-        },
-      );
-
-      return promise;
+        }
+      }
     },
-    async onSettled() {
+    async onSettled(_data, _error, withdrawals) {
       queryClient.invalidateQueries({
         queryKey: nativeBalanceKey,
       });
 
-      await queryClient.invalidateQueries({
-        queryKey: sharesBalanceKey,
-      });
+      await Promise.all(
+        withdrawals.map(({ stakingVaultAddress }) =>
+          queryClient.invalidateQueries({
+            queryKey: tokenBalanceQueryKey(
+              { address: stakingVaultAddress, chainId: chain.id },
+              account,
+            ),
+          }),
+        ),
+      );
 
-      queryClient.invalidateQueries({
-        queryKey: stakedKey,
-      });
+      withdrawals.forEach(({ stakingVaultAddress }) =>
+        queryClient.invalidateQueries({
+          queryKey: stakedBalanceQueryKey({
+            account: account!,
+            chainId: chain.id,
+            stakingVaultAddress,
+          }),
+        }),
+      );
     },
+    onSuccess,
   });
 };

--- a/web/src/hooks/useClaimWithdrawBatch.ts
+++ b/web/src/hooks/useClaimWithdrawBatch.ts
@@ -88,6 +88,19 @@ export const useClaimWithdrawBatch = function ({
 
         let failed = false;
 
+        // The action never rejects: it funnels every failure through an event
+        // and resolves the promise regardless. So each terminal failure must be
+        // flagged here, otherwise the loop would treat the vault as successful,
+        // advance to the next one, and report the whole batch as complete.
+        const markFailed = function () {
+          failed = true;
+          onStatusChange({
+            peggedToken,
+            stakingVaultAddress,
+            status: "failed",
+          });
+        };
+
         emitter.on("user-signed-claim-withdraw-batch", function (hash) {
           onTransactionHash?.({ hash, stakingVaultAddress });
           onStatusChange({
@@ -97,25 +110,16 @@ export const useClaimWithdrawBatch = function ({
           });
         });
 
-        emitter.on("user-signing-claim-withdraw-batch-error", function () {
-          failed = true;
-          onStatusChange({
-            peggedToken,
-            stakingVaultAddress,
-            status: "failed",
-          });
-        });
+        emitter.on("user-signing-claim-withdraw-batch-error", markFailed);
+        emitter.on("claim-withdraw-batch-failed", markFailed);
+        emitter.on("claim-withdraw-batch-failed-validation", markFailed);
+        emitter.on("unexpected-error", markFailed);
 
         emitter.on(
           "claim-withdraw-batch-transaction-reverted",
           function (receipt) {
-            failed = true;
             updateNativeBalanceAfterReceipt(receipt);
-            onStatusChange({
-              peggedToken,
-              stakingVaultAddress,
-              status: "failed",
-            });
+            markFailed();
           },
         );
 

--- a/web/src/hooks/useClaimWithdrawBatch.ts
+++ b/web/src/hooks/useClaimWithdrawBatch.ts
@@ -10,7 +10,6 @@ import type { TokenWithGateway } from "types";
 import type { Address } from "viem";
 import { useAccount } from "wagmi";
 
-import { useEthereumClient } from "./useEthereumClient";
 import { useEthereumWalletClient } from "./useEthereumWalletClient";
 import { useMainnet } from "./useMainnet";
 import { stakedBalanceQueryKey } from "./useStakedBalance";
@@ -45,7 +44,6 @@ export const useClaimWithdrawBatch = function ({
 }: Params) {
   const { address: account } = useAccount();
   const chain = useMainnet();
-  const client = useEthereumClient();
   const { data: walletClient } = useEthereumWalletClient();
   const ensureConnectedTo = useEnsureConnectedTo();
   const queryClient = useQueryClient();
@@ -74,7 +72,7 @@ export const useClaimWithdrawBatch = function ({
         // change (and the activity entry it drives) has the token metadata.
         const peggedToken = await queryClient.ensureQueryData(
           vaultPeggedTokenQueryOptions({
-            client,
+            client: walletClient,
             queryClient,
             stakingVaultAddress,
           }),

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -227,7 +227,6 @@
     "earn": {
       "activity": {
         "cancel-withdraw-text": "{{amount}} {{symbol}} exit ticket deleted",
-        "claim-withdraw-batch-text": "All withdrawals claimed",
         "claim-withdraw-text": "{{amount}} {{symbol}} withdrawn",
         "deposit-text": "{{amount}} {{symbol}} staked",
         "instant-withdraw-text": "{{amount}} {{symbol}} withdrawn",
@@ -273,6 +272,12 @@
         "view-settings": "View settings",
         "withdraw": "Withdraw",
         "withdraw-all": "Withdraw all",
+        "withdraw-all-progress": {
+          "progress-label": "Withdraw progress",
+          "step-description": "Review the details and confirm the withdrawal in your wallet.",
+          "step-title": "Confirm {{symbol}} withdrawal",
+          "title": "Withdrawing all exit tickets"
+        },
         "withdraw-all-toast-description": "All ready exit tickets have been withdrawn to your wallet.",
         "withdraw-all-toast-title": "All withdrawals complete",
         "withdraw-toast-description": "Your funds have been successfully withdrawn to your wallet.",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -228,7 +228,6 @@
     "earn": {
       "activity": {
         "cancel-withdraw-text": "Exit ticket de {{amount}} {{symbol}} eliminado",
-        "claim-withdraw-batch-text": "Todos los retiros reclamados",
         "claim-withdraw-text": "{{amount}} {{symbol}} retirado",
         "deposit-text": "{{amount}} {{symbol}} depositado",
         "instant-withdraw-text": "{{amount}} {{symbol}} retirado",
@@ -276,6 +275,12 @@
         "view-settings": "Ver configuración",
         "withdraw": "Retirar",
         "withdraw-all": "Retirar todo",
+        "withdraw-all-progress": {
+          "progress-label": "Progreso del retiro",
+          "step-description": "Revise los detalles y confirme el retiro en su billetera.",
+          "step-title": "Confirmar retiro de {{symbol}}",
+          "title": "Retirando todos los tickets de salida"
+        },
         "withdraw-all-toast-description": "Todos los tickets de salida listos han sido retirados a su billetera.",
         "withdraw-all-toast-title": "Todos los retiros completados",
         "withdraw-toast-description": "Sus fondos han sido retirados exitosamente a su billetera.",

--- a/web/src/pages/earn/components/exitTickets/index.tsx
+++ b/web/src/pages/earn/components/exitTickets/index.tsx
@@ -9,11 +9,10 @@ import { Table } from "components/base/table";
 import { Header } from "components/base/table/header";
 import { TopSection } from "components/base/table/topSection";
 import { Toast } from "components/base/toast";
-import { useActivityTracking } from "hooks/useActivityTracking";
-import { useClaimWithdrawBatch } from "hooks/useClaimWithdrawBatch";
 import { TableCellsIcon } from "pages/earn/icons/tableCellsIcon";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import type { Address } from "viem";
 import { useAccount } from "wagmi";
 
 import { useExitTickets } from "../../hooks/useExitTickets";
@@ -26,6 +25,7 @@ import { EmptyState } from "./emptyState";
 import { getTicketStatus } from "./getTicketStatus";
 import { TxsCell } from "./txsCell";
 import { WithdrawalCell } from "./withdrawalCell";
+import { type VaultWithdrawal, WithdrawAllDrawer } from "./withdrawAllDrawer";
 
 const statusLabels = {
   cooldown: "pages.earn.exit-tickets.cooldown-in-progress",
@@ -102,20 +102,79 @@ const getColumns = ({
   },
 ];
 
-// TODO we'll update this in the next PR to add support to
-// exit tickets from multiple vaults - hardcoding to one for the time being
+// The empty-state CTA is not vault-specific; it just needs a vault to link to.
 const stakingVaultAddress = stakingVaultAddresses[0];
+
+type WithdrawAllButtonProps = {
+  count: number;
+  disabled: boolean;
+  isWithdrawing: boolean;
+  onWithdrawAll: VoidFunction;
+};
+
+function WithdrawAllButton({
+  count,
+  disabled,
+  isWithdrawing,
+  onWithdrawAll,
+}: WithdrawAllButtonProps) {
+  const { isConnected } = useAccount();
+  const { openConnectModal } = useConnectModal();
+  const { t } = useTranslation();
+
+  if (!isConnected) {
+    return (
+      <Button onClick={openConnectModal} size="xSmall" variant="primary">
+        {t("common.connect-wallet")}
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      disabled={disabled}
+      onClick={onWithdrawAll}
+      size="xSmall"
+      variant="primary"
+    >
+      <span className="invisible flex items-center gap-x-1">
+        {t("pages.earn.exit-tickets.withdraw-all")}
+        {count > 0 && <Badge variant="blue">{count}</Badge>}
+      </span>
+      <span className="absolute flex items-center gap-x-1">
+        {isWithdrawing
+          ? t("pages.earn.exit-tickets.withdrawing")
+          : t("pages.earn.exit-tickets.withdraw-all")}
+        {!isWithdrawing && count > 0 && <Badge variant="blue">{count}</Badge>}
+      </span>
+    </Button>
+  );
+}
+
+// Group ready tickets by staking vault: one claim transaction per vault.
+function groupByVault(readyTickets: ExitTicket[]) {
+  const map = new Map<Address, VaultWithdrawal>();
+  for (const ticket of readyTickets) {
+    const entry = map.get(ticket.stakingVaultAddress) ?? {
+      amount: 0n,
+      requestIds: [],
+      stakingVaultAddress: ticket.stakingVaultAddress,
+    };
+    entry.amount += BigInt(ticket.assets);
+    entry.requestIds.push(BigInt(ticket.requestId));
+    map.set(ticket.stakingVaultAddress, entry);
+  }
+  return [...map.values()];
+}
 
 export function ExitTickets() {
   const { data, isLoading } = useExitTickets();
   const { t } = useTranslation();
-  const { isConnected } = useAccount();
-  const { openConnectModal } = useConnectModal();
   const [selectedFilters, setSelectedFilters] = useState([
     "completed",
     "pending",
   ]);
-  const [isWithdrawingAll, setIsWithdrawingAll] = useState(false);
+  const [isWithdrawAllDrawerOpen, setIsWithdrawAllDrawerOpen] = useState(false);
   const [showDeleteToast, setShowDeleteToast] = useState(false);
   const [showWithdrawAllToast, setShowWithdrawAllToast] = useState(false);
   const [withdrawingSingleCount, setWithdrawingSingleCount] = useState(0);
@@ -124,38 +183,6 @@ export function ExitTickets() {
     () => (data ?? []).filter((ticket) => getTicketStatus(ticket) === "ready"),
     [data],
   );
-
-  const readyRequestIds = useMemo(
-    () => readyTickets.map((ticket) => BigInt(ticket.requestId)),
-    [readyTickets],
-  );
-
-  const { onCompleted, onFailed, onPending, onTransactionHash } =
-    useActivityTracking({
-      page: "earn",
-      text: t("pages.earn.activity.claim-withdraw-batch-text"),
-      title: `${t("nav.earn")} · ${t("pages.earn.exit-tickets.withdraw-all")}`,
-    });
-
-  const { mutate: claimWithdrawBatch } = useClaimWithdrawBatch({
-    onStatusChange(status) {
-      const handlers: Partial<Record<typeof status, () => void>> = {
-        claiming: onPending,
-        completed() {
-          onCompleted();
-          setIsWithdrawingAll(false);
-          setShowWithdrawAllToast(true);
-        },
-        failed() {
-          onFailed();
-          setIsWithdrawingAll(false);
-        },
-      };
-      handlers[status]?.();
-    },
-    onTransactionHash,
-    requestIds: readyRequestIds,
-  });
 
   const filterOptions = useMemo(
     () => [
@@ -174,7 +201,7 @@ export function ExitTickets() {
   const columns = useMemo(
     () =>
       getColumns({
-        isWithdrawingAll,
+        isWithdrawingAll: isWithdrawAllDrawerOpen,
         onDeleteSuccess() {
           setShowDeleteToast(true);
         },
@@ -183,7 +210,7 @@ export function ExitTickets() {
         },
         t,
       }),
-    [isWithdrawingAll, t],
+    [isWithdrawAllDrawerOpen, t],
   );
 
   // Filter and sort data based on selected filters and ticket status
@@ -219,11 +246,6 @@ export function ExitTickets() {
     [data, selectedFilters],
   );
 
-  function handleWithdrawAll() {
-    setIsWithdrawingAll(true);
-    claimWithdrawBatch();
-  }
-
   return (
     <div id="exit-tickets">
       {/* Title row */}
@@ -242,37 +264,16 @@ export function ExitTickets() {
             selectedValues={selectedFilters}
           />
           <div className="h-3 w-0.5 rounded-full bg-gray-200" />
-          {isConnected ? (
-            <Button
-              disabled={
-                readyTickets.length === 0 ||
-                isWithdrawingAll ||
-                withdrawingSingleCount > 0
-              }
-              onClick={handleWithdrawAll}
-              size="xSmall"
-              variant="primary"
-            >
-              <span className="invisible flex items-center gap-x-1">
-                {t("pages.earn.exit-tickets.withdraw-all")}
-                {readyTickets.length > 0 && (
-                  <Badge variant="blue">{readyTickets.length}</Badge>
-                )}
-              </span>
-              <span className="absolute flex items-center gap-x-1">
-                {isWithdrawingAll
-                  ? t("pages.earn.exit-tickets.withdrawing")
-                  : t("pages.earn.exit-tickets.withdraw-all")}
-                {!isWithdrawingAll && readyTickets.length > 0 && (
-                  <Badge variant="blue">{readyTickets.length}</Badge>
-                )}
-              </span>
-            </Button>
-          ) : (
-            <Button onClick={openConnectModal} size="xSmall" variant="primary">
-              {t("common.connect-wallet")}
-            </Button>
-          )}
+          <WithdrawAllButton
+            count={readyTickets.length}
+            disabled={
+              readyTickets.length === 0 ||
+              isWithdrawAllDrawerOpen ||
+              withdrawingSingleCount > 0
+            }
+            isWithdrawing={isWithdrawAllDrawerOpen}
+            onWithdrawAll={() => setIsWithdrawAllDrawerOpen(true)}
+          />
         </div>
       </TopSection>
       {/* Table */}
@@ -285,6 +286,13 @@ export function ExitTickets() {
         placeholder={<EmptyState stakingVaultAddress={stakingVaultAddress} />}
         priorityColumnIdsOnSmall={["actions"]}
       />
+      {isWithdrawAllDrawerOpen && (
+        <WithdrawAllDrawer
+          onClose={() => setIsWithdrawAllDrawerOpen(false)}
+          onSuccess={() => setShowWithdrawAllToast(true)}
+          withdrawals={groupByVault(readyTickets)}
+        />
+      )}
       {showDeleteToast && (
         <Toast
           closable

--- a/web/src/pages/earn/components/exitTickets/index.tsx
+++ b/web/src/pages/earn/components/exitTickets/index.tsx
@@ -137,11 +137,7 @@ function WithdrawAllButton({
       size="xSmall"
       variant="primary"
     >
-      <span className="invisible flex items-center gap-x-1">
-        {t("pages.earn.exit-tickets.withdraw-all")}
-        {count > 0 && <Badge variant="blue">{count}</Badge>}
-      </span>
-      <span className="absolute flex items-center gap-x-1">
+      <span className="flex items-center gap-x-1">
         {isWithdrawing
           ? t("pages.earn.exit-tickets.withdrawing")
           : t("pages.earn.exit-tickets.withdraw-all")}

--- a/web/src/pages/earn/components/exitTickets/withdrawAllDrawer.tsx
+++ b/web/src/pages/earn/components/exitTickets/withdrawAllDrawer.tsx
@@ -1,0 +1,144 @@
+import { Drawer } from "components/base/drawer";
+import { DrawerLoader } from "components/base/drawer/drawerLoader";
+import { useClaimWithdrawBatch } from "hooks/useClaimWithdrawBatch";
+import { useCloseOnSuccess } from "hooks/useCloseOnSuccess";
+import { Suspense, lazy, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { addActivity, updateActivity } from "stores/activityStore";
+import { unixNowTimestamp } from "utils/date";
+import { formatAmount } from "utils/token";
+import { type Address, isAddressEqual } from "viem";
+import { useAccount } from "wagmi";
+
+import type { VaultStatus } from "./withdrawAllProgressDrawer";
+
+const WithdrawAllProgressDrawer = lazy(() =>
+  import("./withdrawAllProgressDrawer").then((m) => ({
+    default: m.WithdrawAllProgressDrawer,
+  })),
+);
+
+export type VaultWithdrawal = {
+  amount: bigint;
+  requestIds: bigint[];
+  stakingVaultAddress: Address;
+};
+
+type Props = {
+  onClose: VoidFunction;
+  onSuccess: VoidFunction;
+  withdrawals: VaultWithdrawal[];
+};
+
+export function WithdrawAllDrawer({ onClose, onSuccess, withdrawals }: Props) {
+  const { address: account } = useAccount();
+  const { t } = useTranslation();
+
+  // Snapshot the vaults once: as each transaction succeeds it optimistically
+  // drops its tickets from the ready list (shrinking the parent's array), but
+  // the drawer must keep showing every vault until the flow ends.
+  const [vaults] = useState(withdrawals);
+
+  const [statuses, setStatuses] = useState<Record<Address, VaultStatus>>(() =>
+    Object.fromEntries(
+      vaults.map((vault) => [vault.stakingVaultAddress, "pending"]),
+    ),
+  );
+
+  // Maps each vault to the hash of its in-flight transaction so the matching
+  // activity entry can be updated when it settles. Mirrors the single tx hash
+  // ref in useActivityTracking, but keyed per vault: the entry is cleared once
+  // the vault reaches a terminal state, so a retry starts from a fresh hash.
+  const txHashes = useRef<Record<Address, string>>({});
+
+  const { mutate } = useClaimWithdrawBatch({
+    onStatusChange({ peggedToken, stakingVaultAddress, status }) {
+      setStatuses((prev) => ({ ...prev, [stakingVaultAddress]: status }));
+
+      const txHash = txHashes.current[stakingVaultAddress];
+      if (!account || !txHash) {
+        return;
+      }
+
+      if (status === "claiming") {
+        const amount = vaults.find((vault) =>
+          isAddressEqual(vault.stakingVaultAddress, stakingVaultAddress),
+        )!.amount;
+        addActivity(account, {
+          date: unixNowTimestamp(),
+          page: "earn",
+          status: "pending",
+          text: t("pages.earn.activity.claim-withdraw-text", {
+            amount: formatAmount({
+              amount,
+              decimals: peggedToken.decimals,
+              isError: false,
+            }),
+            symbol: peggedToken.symbol,
+          }),
+          title: `${t("nav.earn")} · ${t("pages.earn.exit-tickets.withdraw-all")}`,
+          txHash,
+        });
+      } else if (status === "completed") {
+        updateActivity(account, txHash, { status: "completed" });
+        delete txHashes.current[stakingVaultAddress];
+      } else if (status === "failed") {
+        updateActivity(account, txHash, { status: "failed" });
+        delete txHashes.current[stakingVaultAddress];
+      }
+    },
+    onSuccess,
+    onTransactionHash({ hash, stakingVaultAddress }) {
+      txHashes.current[stakingVaultAddress] = hash;
+    },
+  });
+
+  // Start the flow once on mount. mirrors how the swap form fires its mutation;
+  // the ref guards against React StrictMode's double effect invocation.
+  const started = useRef(false);
+  useEffect(
+    function start() {
+      if (started.current) {
+        return;
+      }
+      started.current = true;
+      mutate(vaults);
+    },
+    [mutate, vaults],
+  );
+
+  const allCompleted = vaults.every(
+    (vault) => statuses[vault.stakingVaultAddress] === "completed",
+  );
+  const hasFailure = vaults.some(
+    (vault) => statuses[vault.stakingVaultAddress] === "failed",
+  );
+
+  useCloseOnSuccess({ onClose, success: allCompleted });
+
+  function handleRetry() {
+    const remaining = vaults.filter(
+      (vault) => statuses[vault.stakingVaultAddress] !== "completed",
+    );
+    setStatuses(function (prev) {
+      const next = { ...prev };
+      remaining.forEach(function (vault) {
+        next[vault.stakingVaultAddress] = "pending";
+      });
+      return next;
+    });
+    mutate(remaining);
+  }
+
+  return (
+    <Drawer onClose={onClose}>
+      <Suspense fallback={<DrawerLoader />}>
+        <WithdrawAllProgressDrawer
+          onRetry={hasFailure ? handleRetry : undefined}
+          statuses={statuses}
+          vaults={vaults}
+        />
+      </Suspense>
+    </Drawer>
+  );
+}

--- a/web/src/pages/earn/components/exitTickets/withdrawAllProgressDrawer.tsx
+++ b/web/src/pages/earn/components/exitTickets/withdrawAllProgressDrawer.tsx
@@ -1,0 +1,249 @@
+import { useQueries, useQueryClient } from "@tanstack/react-query";
+import { Button } from "components/base/button";
+import { DrawerTitle } from "components/base/drawer/drawerTitle";
+import { RenderFiatValue } from "components/base/fiatValue";
+import { Spinner } from "components/base/spinner";
+import { CheckCircleIcon } from "components/base/toast/checkCircleIcon";
+import {
+  type Step,
+  stepStatus,
+  VerticalStepper,
+} from "components/base/verticalStepper";
+import { TokenLogo } from "components/tokenLogo";
+import { useAnimatedVisibility } from "hooks/useAnimatedVisibility";
+import { useEthereumClient } from "hooks/useEthereumClient";
+import {
+  useVaultPeggedToken,
+  vaultPeggedTokenQueryOptions,
+} from "hooks/useVaultPeggedToken";
+import { useTranslation } from "react-i18next";
+import Skeleton from "react-loading-skeleton";
+import type { TokenWithGateway } from "types";
+import { formatAmount } from "utils/token";
+import type { Address } from "viem";
+
+export type VaultStatus = "claiming" | "completed" | "failed" | "pending";
+
+type Vault = {
+  amount: bigint;
+  stakingVaultAddress: Address;
+};
+
+type Props = {
+  onRetry?: VoidFunction;
+  statuses: Record<Address, VaultStatus>;
+  vaults: Vault[];
+};
+
+const statusToStepStatus: Record<VaultStatus, Step["status"]> = {
+  claiming: stepStatus.progress,
+  completed: stepStatus.completed,
+  failed: stepStatus.failed,
+  pending: stepStatus.notReady,
+};
+
+const FailedIcon = () => (
+  <div className="flex size-4 items-center justify-center rounded-full bg-red-500">
+    <svg
+      aria-hidden="true"
+      className="size-2.5"
+      fill="none"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2.5}
+      viewBox="0 0 12 12"
+    >
+      <path d="M3 3l6 6M9 3l-6 6" />
+    </svg>
+  </div>
+);
+
+const StatusIcon = ({ status }: { status: VaultStatus }) => (
+  <div className="flex h-10 items-center">
+    {status === "claiming" && <Spinner />}
+    {status === "completed" && <CheckCircleIcon className="size-4" />}
+    {status === "failed" && <FailedIcon />}
+  </div>
+);
+
+type RowProps = {
+  amount: bigint;
+  peggedToken: TokenWithGateway;
+  status: VaultStatus;
+};
+
+const Row = ({ amount, peggedToken, status }: RowProps) => (
+  <div
+    className={`flex items-start justify-between p-6 ${
+      status === "pending" ? "opacity-50" : ""
+    }`}
+  >
+    <div className="flex flex-col gap-y-2">
+      <div className="flex items-center gap-3">
+        <p className="flex items-center gap-x-2 text-4xl leading-10 font-semibold tracking-tight text-gray-900">
+          <span>
+            {formatAmount({
+              amount,
+              decimals: peggedToken.decimals,
+              isError: false,
+            })}
+          </span>
+          <span
+            className={
+              status === "completed" ? "text-gray-500" : "text-gray-900"
+            }
+          >
+            {peggedToken.symbol}
+          </span>
+        </p>
+        <TokenLogo {...peggedToken} size="large" />
+      </div>
+      <p className="text-xsm text-gray-500">
+        $<RenderFiatValue token={peggedToken} value={amount} />
+      </p>
+    </div>
+    <StatusIcon status={status} />
+  </div>
+);
+
+type VaultRowProps = {
+  amount: bigint;
+  stakingVaultAddress: Address;
+  status: VaultStatus;
+};
+
+// Owns its vault's pegged-token query so the row can render its own loading and
+// error states without blocking the rest of the flow.
+function VaultRow({ amount, stakingVaultAddress, status }: VaultRowProps) {
+  const { data: peggedToken, isError } =
+    useVaultPeggedToken(stakingVaultAddress);
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-between p-6">
+        <span className="text-4xl leading-10 font-semibold text-gray-300">
+          -
+        </span>
+        <StatusIcon status={status} />
+      </div>
+    );
+  }
+
+  if (!peggedToken) {
+    return (
+      <div className="flex items-center justify-between p-6">
+        <Skeleton className="h-10 w-40" />
+      </div>
+    );
+  }
+
+  return <Row amount={amount} peggedToken={peggedToken} status={status} />;
+}
+
+const StepperSkeleton = ({ count }: { count: number }) => (
+  <div className="flex flex-col gap-5 py-4">
+    {Array.from({ length: count }).map((_, index) => (
+      <div className="flex gap-4" key={`step-skeleton-${index}`}>
+        <Skeleton circle className="size-4" />
+        <div className="flex flex-1 flex-col gap-1">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-48" />
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+// Resolves every vault's pegged token together (the stepper needs all symbols at
+// once) and shows a skeleton until they load, then renders the actual stepper.
+function VaultStepper({
+  statuses,
+  vaults,
+}: Pick<Props, "statuses" | "vaults">) {
+  const client = useEthereumClient();
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const peggedTokenQueries = useQueries({
+    queries: vaults.map((vault) =>
+      vaultPeggedTokenQueryOptions({
+        client,
+        queryClient,
+        stakingVaultAddress: vault.stakingVaultAddress,
+      }),
+    ),
+  });
+
+  if (peggedTokenQueries.some((query) => query.isLoading)) {
+    return <StepperSkeleton count={vaults.length} />;
+  }
+
+  const steps: Step[] = vaults.map((vault, index) => ({
+    description: t(
+      "pages.earn.exit-tickets.withdraw-all-progress.step-description",
+    ),
+    status: statusToStepStatus[statuses[vault.stakingVaultAddress]],
+    title: t("pages.earn.exit-tickets.withdraw-all-progress.step-title", {
+      symbol: peggedTokenQueries[index].data?.symbol ?? "",
+    }),
+  }));
+
+  return <VerticalStepper steps={steps} />;
+}
+
+export function WithdrawAllProgressDrawer({
+  onRetry,
+  statuses,
+  vaults,
+}: Props) {
+  const { t } = useTranslation();
+  const { render: renderRetry, show: showRetry } =
+    useAnimatedVisibility(!!onRetry);
+
+  return (
+    <div className="flex h-full flex-col">
+      <DrawerTitle>
+        {t("pages.earn.exit-tickets.withdraw-all-progress.title")}
+      </DrawerTitle>
+
+      <div className="divide-y divide-gray-200 border-y border-gray-200 bg-gray-50">
+        {vaults.map((vault) => (
+          <VaultRow
+            amount={vault.amount}
+            key={vault.stakingVaultAddress}
+            stakingVaultAddress={vault.stakingVaultAddress}
+            status={statuses[vault.stakingVaultAddress]}
+          />
+        ))}
+      </div>
+
+      <div className="flex-1" />
+
+      <div className="flex flex-col gap-2 px-6 pb-6">
+        <p className="text-[11px] leading-4 font-medium tracking-wide text-gray-500">
+          {t("pages.earn.exit-tickets.withdraw-all-progress.progress-label")}
+        </p>
+        <div className="border-t border-gray-200">
+          <VaultStepper statuses={statuses} vaults={vaults} />
+        </div>
+      </div>
+
+      {renderRetry && (
+        <div
+          className={`grid transition-[grid-template-rows] duration-300 ease-out ${
+            showRetry ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+          }`}
+        >
+          <div className="overflow-hidden">
+            <div className="border-t border-gray-200 bg-gray-50 px-6 py-3 *:w-full">
+              <Button onClick={onRetry} size="small" variant="primary">
+                {t("pages.swap.progress.retry")}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/earn/components/exitTickets/withdrawAllProgressDrawer.tsx
+++ b/web/src/pages/earn/components/exitTickets/withdrawAllProgressDrawer.tsx
@@ -221,7 +221,7 @@ export function WithdrawAllProgressDrawer({
       <div className="flex-1" />
 
       <div className="flex flex-col gap-2 px-6 pb-6">
-        <p className="text-[11px] leading-4 font-medium tracking-wide text-gray-500">
+        <p className="text-caption text-gray-500">
           {t("pages.earn.exit-tickets.withdraw-all-progress.progress-label")}
         </p>
         <div className="border-t border-gray-200">


### PR DESCRIPTION
### Description

Reworks "Withdraw all" to handle exit tickets spread across multiple staking vaults. Ready tickets are grouped by vault and claimed one transaction per vault, sequentially, so each transaction lands as its own activity entry and the drawer can show step-by-step progress.

`useClaimWithdrawBatch` now takes a list of withdrawals, resolves each vault's pegged token for status/activity metadata, and invalidates balances per vault on settle. The new `WithdrawAllDrawer` drives the flow (with per-vault retry on failure) and `WithdrawAllProgressDrawer` renders the per-vault stepper.

> **Note on testing:** I ran into issues with my local fork, so I locally mocked the `earn` library to simulate the transactions with promises. That's why in the video (uploaded below after the PR is created) there's no real signing prompt in the wallet — the mock emits the same event sequence as a real signed transaction (including a one-block delay, a forced failure on the second vault, and a successful retry). These mock changes are **not** committed.

### Screenshots

Success case

https://github.com/user-attachments/assets/26570700-10de-445a-96dd-cd9d03c074bd

Error case with retry

https://github.com/user-attachments/assets/8f81cbc7-9ef8-4189-abd4-64d86b6e65fc

### Related issue(s)

Closes #355

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.