### PR TITLE
Store total assets per day in vault history

### DIFF
--- a/subgraph/abis/StakingVault.json
+++ b/subgraph/abis/StakingVault.json
@@ -51,6 +51,19 @@
     "stateMutability": "view"
   },
   {
+    "type": "function",
+    "name": "totalAssets",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
     "type": "event",
     "name": "Deposit",
     "inputs": [

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vetro-app-subgraph",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "scripts": {
     "prebuild": "npm run codegen",

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -3,6 +3,7 @@ type VaultHistory @entity(immutable: false) {
   shareValue: BigInt!
   stakingVaultAddress: Bytes!
   timestamp: BigInt! # Timestamp fixed to YYYY-MM-DD 00:00:00 UTC
+  totalAssets: BigInt! # Total underlying assets held by the vault (ERC4626 totalAssets)
 }
 
 type ExitTicket @entity(immutable: false) {

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -54,6 +54,7 @@ export function handleBlock(block: ethereum.Block): void {
   const oneShare = BigInt.fromI32(10).pow(<u8>decimals);
   const shareValue = vault.convertToAssets(oneShare);
   entity.shareValue = shareValue;
+  entity.totalAssets = vault.totalAssets();
 
   entity.save();
 }

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -36,7 +36,11 @@ const receiverAddress = Address.fromString(receiverAddressString);
 
 const daySeconds = BigInt.fromI32(86400);
 
-function mockVaultCalls(decimals: i32, shareValue: BigInt): void {
+function mockVaultCalls(
+  decimals: i32,
+  shareValue: BigInt,
+  totalAssets: BigInt,
+): void {
   createMockedFunction(vaultAddress, "decimals", "decimals():(uint8)")
     .withArgs([])
     .returns([ethereum.Value.fromI32(decimals)]);
@@ -49,6 +53,10 @@ function mockVaultCalls(decimals: i32, shareValue: BigInt): void {
   )
     .withArgs([ethereum.Value.fromUnsignedBigInt(oneShare)])
     .returns([ethereum.Value.fromUnsignedBigInt(shareValue)]);
+
+  createMockedFunction(vaultAddress, "totalAssets", "totalAssets():(uint256)")
+    .withArgs([])
+    .returns([ethereum.Value.fromUnsignedBigInt(totalAssets)]);
 }
 
 describe("handleBlock", function () {
@@ -60,9 +68,10 @@ describe("handleBlock", function () {
   test("creates VaultHistory for day timestamp", function () {
     const decimals = 18;
     const currentShareValue = BigInt.fromString("1050000000000000000"); // 1.05 assets per share
+    const currentTotalAssets = BigInt.fromString("5000000000000000000000"); // 5000 assets
     const timestamp = BigInt.fromI32(1769731200); // 2026-01-30 00:00:00 UTC
 
-    mockVaultCalls(decimals, currentShareValue);
+    mockVaultCalls(decimals, currentShareValue, currentTotalAssets);
     const block = createMockBlock(BigInt.fromI32(100), timestamp);
     handleBlock(block);
 
@@ -84,6 +93,12 @@ describe("handleBlock", function () {
     assert.fieldEquals(
       "VaultHistory",
       id,
+      "totalAssets",
+      currentTotalAssets.toString(),
+    );
+    assert.fieldEquals(
+      "VaultHistory",
+      id,
       "stakingVaultAddress",
       vaultAddressString,
     );
@@ -93,10 +108,12 @@ describe("handleBlock", function () {
     const decimals = 18;
     const initialShareValue = BigInt.fromString("1050000000000000000");
     const updatedShareValue = BigInt.fromString("1060000000000000000");
+    const initialTotalAssets = BigInt.fromString("5000000000000000000000");
+    const updatedTotalAssets = BigInt.fromString("6000000000000000000000");
     const timestamp1 = BigInt.fromI32(1769734800); // 2026-01-30 01:00:00 UTC
     const timestamp2 = BigInt.fromI32(1769774400); // 2026-01-30 12:00:00 UTC
 
-    mockVaultCalls(decimals, initialShareValue);
+    mockVaultCalls(decimals, initialShareValue, initialTotalAssets);
     const block1 = createMockBlock(BigInt.fromI32(100), timestamp1);
     handleBlock(block1);
 
@@ -104,7 +121,7 @@ describe("handleBlock", function () {
     const id = `${vaultAddressString}-${dayTimestamp.toString()}`;
     assert.entityCount("VaultHistory", 1);
 
-    mockVaultCalls(decimals, updatedShareValue);
+    mockVaultCalls(decimals, updatedShareValue, updatedTotalAssets);
     const block2 = createMockBlock(BigInt.fromI32(200), timestamp2);
     handleBlock(block2);
 
@@ -114,6 +131,12 @@ describe("handleBlock", function () {
       id,
       "shareValue",
       updatedShareValue.toString(),
+    );
+    assert.fieldEquals(
+      "VaultHistory",
+      id,
+      "totalAssets",
+      updatedTotalAssets.toString(),
     );
     assert.fieldEquals(
       "VaultHistory",


### PR DESCRIPTION
### Description

This extends the subgraph to track historic TVL for each staking vault.

The block handler already snapshots `shareValue` once per UTC day on each `VaultHistory` row. This extends that same row with `totalAssets`, so a vault's total deposits — `totalAssets()`, denominated in the underlying pegged token — can be charted over time. No new entity or extra rows: blocks within a day keep overwriting the day's row, so only the last value per UTC day persists.

Because the block handler runs on every block during sync, redeploying backfills `totalAssets` for every past day automatically — no separate migration.

Changes:
- Add `totalAssets()` to the `StakingVault` ABI.
- Add a `totalAssets` field to the `VaultHistory` entity.
- Write `entity.totalAssets = vault.totalAssets()` in the block handler.
- Extend the `handleBlock` tests to cover it.
- Bump the subgraph version to 1.4.0.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to https://github.com/hemilabs/ui-monorepo/issues/1967

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.