### PR TITLE
Move ClaimRedeemFlowStatus type to shared module

### DIFF
--- a/web/src/components/swapForm/claimRedeemDrawer.tsx
+++ b/web/src/components/swapForm/claimRedeemDrawer.tsx
@@ -8,9 +8,9 @@ import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
 import type { Address } from "viem";
 
-import { type ClaimRedeemFlowStatus } from "./claimRedeemProgressDrawer";
 import type { UnitPreview } from "./outputLabel";
 import type { SwapFees } from "./swapFees";
+import { type ClaimRedeemFlowStatus } from "./types";
 
 const ClaimRedeemProgressDrawer = lazy(() =>
   import("./claimRedeemProgressDrawer").then((m) => ({

--- a/web/src/components/swapForm/claimRedeemProgressDrawer.tsx
+++ b/web/src/components/swapForm/claimRedeemProgressDrawer.tsx
@@ -19,13 +19,7 @@ import { OutputLabel, type UnitPreview } from "./outputLabel";
 import { SwapFees } from "./swapFees";
 import { ToTokenBalance } from "./toTokenBalance";
 import { TreasuryReserves } from "./treasuryReserves";
-
-export type ClaimRedeemFlowStatus =
-  | "idle"
-  | "redeem-error"
-  | "redeem-ready"
-  | "redeemed"
-  | "redeeming";
+import type { ClaimRedeemFlowStatus } from "./types";
 
 type Props = {
   amountBigInt: bigint;

--- a/web/src/components/swapForm/redeemQueue.tsx
+++ b/web/src/components/swapForm/redeemQueue.tsx
@@ -23,10 +23,10 @@ import { formatUnits, isAddressEqual, parseUnits } from "viem";
 
 import { CancelRedeemModal } from "./cancelRedeemModal";
 import { ClaimRedeemDrawer } from "./claimRedeemDrawer";
-import { type ClaimRedeemFlowStatus } from "./claimRedeemProgressDrawer";
 import { RedeemQueueEmptyState } from "./redeemQueueEmptyState";
 import { RedeemQueueTable } from "./redeemQueueTable";
 import { RedeemQueueToasts } from "./redeemQueueToasts";
+import { type ClaimRedeemFlowStatus } from "./types";
 
 type Props = {
   peggedToken: TokenWithGateway;

--- a/web/src/components/swapForm/types.ts
+++ b/web/src/components/swapForm/types.ts
@@ -1,5 +1,12 @@
 import type { TokenWithGateway } from "types";
 
+export type ClaimRedeemFlowStatus =
+  | "idle"
+  | "redeem-error"
+  | "redeem-ready"
+  | "redeemed"
+  | "redeeming";
+
 export type SwapFormState = {
   approve10x: boolean;
   fromInputValue: string;


### PR DESCRIPTION
### Description

Building the `web` package emitted an `INEFFECTIVE_DYNAMIC_IMPORT` warning: `claimRedeemProgressDrawer.tsx` was lazily imported by `claimRedeemDrawer.tsx` but also statically imported (for the `ClaimRedeemFlowStatus` type) by both `claimRedeemDrawer.tsx` and `redeemQueue.tsx`. The mixed static/dynamic import prevented the bundler from splitting the progress drawer into its own chunk, defeating the `lazy()` import.

This moves the `ClaimRedeemFlowStatus` type into `swapForm/types.ts` and repoints the importers there. The component file is now only ever reached via the dynamic import, so the bundler can split it out and the warning clears.

### Screenshots

N/A

### Related issue(s)

Closes #442

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.