### PR TITLE
Fade whole withdraw-all row including background

### DIFF
--- a/web/src/pages/earn/components/exitTickets/withdrawAllProgressDrawer.tsx
+++ b/web/src/pages/earn/components/exitTickets/withdrawAllProgressDrawer.tsx
@@ -75,8 +75,8 @@ type RowProps = {
 
 const Row = ({ amount, peggedToken, status }: RowProps) => (
   <div
-    className={`flex items-start justify-between p-6 ${
-      status === "pending" ? "opacity-50" : ""
+    className={`flex items-start justify-between bg-gray-50 p-6 ${
+      status === "pending" ? "opacity-40" : ""
     }`}
   >
     <div className="flex flex-col gap-y-2">
@@ -89,13 +89,7 @@ const Row = ({ amount, peggedToken, status }: RowProps) => (
               isError: false,
             })}
           </span>
-          <span
-            className={
-              status === "completed" ? "text-gray-500" : "text-gray-900"
-            }
-          >
-            {peggedToken.symbol}
-          </span>
+          <span className="text-gray-500">{peggedToken.symbol}</span>
         </p>
         <TokenLogo {...peggedToken} size="large" />
       </div>
@@ -121,7 +115,7 @@ function VaultRow({ amount, stakingVaultAddress, status }: VaultRowProps) {
 
   if (isError) {
     return (
-      <div className="flex items-center justify-between p-6">
+      <div className="flex items-center justify-between bg-gray-50 p-6">
         <span className="text-4xl leading-10 font-semibold text-gray-300">
           -
         </span>
@@ -132,7 +126,7 @@ function VaultRow({ amount, stakingVaultAddress, status }: VaultRowProps) {
 
   if (!peggedToken) {
     return (
-      <div className="flex items-center justify-between p-6">
+      <div className="flex items-center justify-between bg-gray-50 p-6">
         <Skeleton className="h-10 w-40" />
       </div>
     );
@@ -207,7 +201,7 @@ export function WithdrawAllProgressDrawer({
         {t("pages.earn.exit-tickets.withdraw-all-progress.title")}
       </DrawerTitle>
 
-      <div className="divide-y divide-gray-200 border-y border-gray-200 bg-gray-50">
+      <div className="divide-y divide-gray-200 border-y border-gray-200">
         {vaults.map((vault) => (
           <VaultRow
             amount={vault.amount}


### PR DESCRIPTION
### Description

The "disabled"/pending opacity on the withdraw-all progress drawer rows was applied to the nested content while the gray-50 background lived on the container, so the background never faded. This moves the background down onto each row (normal, error, and loading states) so the pending row's opacity fades the whole row including its background. Also bumps that opacity to 40 and makes the token symbol always use the gray-500 color regardless of status.

### Screenshots

<img width="940" height="780" alt="image" src="https://github.com/user-attachments/assets/882401de-c9fa-4084-bad3-41cbb7438a69" />


### Related issue(s)

Closes #448

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.