### PR TITLE
Allow CORS calls from Hemi origins

### DIFF
--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -22,7 +22,7 @@
       "name": "vetro-api-staging",
       "vars": {
         "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
-        "ORIGINS": "https://vetro.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev",
+        "ORIGINS": "https://*.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
       },
@@ -40,7 +40,7 @@
       },
       "vars": {
         "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
-        "ORIGINS": "https://app.vetro.org,https://beta.vetro.org",
+        "ORIGINS": "https://app.vetro.org,https://beta.vetro.org,https://*.hemi.xyz",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
       },


### PR DESCRIPTION
### Description

Add the Hemi web apps to the API's allowed CORS origins so they can call the Vetro API.

- **Production**: accept any `*.hemi.xyz` subdomain, covering both the prod and beta apps.
- **Staging**: widen the allowed origin to the corresponding `*.letshamsterdance.xyz` wildcard so the Hemi staging app is accepted without committing its exact URL.

No code changes were required — the `ORIGINS` env var already supports comma-separated values and `*` globs (`api/src/validate-origin.ts`, `api/src/origin-glob-to-regexp.ts`). Only the values in `api/wrangler.jsonc` changed.

### Screenshots

N/A

### Related issue(s)

Related to hemilabs/ui-monorepo#1966

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.