### PR TITLE
Add previewWithdraw action to gateway package

### DIFF
--- a/packages/gateway/README.md
+++ b/packages/gateway/README.md
@@ -61,6 +61,7 @@ The same actions are also available via `.extend()` factories (`gatewayPublicAct
 - Public actions (reads):
   - `previewDeposit(client, params)` — expected pegged-token output for a deposit.
   - `previewRedeem(client, params)` — expected underlying output for a redeem.
+  - `previewWithdraw(client, params)` — pegged-token input required to withdraw an exact `amountOut` of the underlying (inverse of `previewRedeem`, with `redeemFee` applied on-chain).
   - `getMintFee(client, params)` / `getRedeemFee(client, params)` — current fees.
   - `getMaxWithdraw(client, params)` — maximum withdrawable amount.
   - `getPeggedToken(client, params)` — pegged-token address minted by the gateway.

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vetro-protocol/gateway",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Vetro Protocol gateway actions for viem.",
   "license": "MIT",
   "files": [

--- a/packages/gateway/src/abi/gatewayAbi.ts
+++ b/packages/gateway/src/abi/gatewayAbi.ts
@@ -100,6 +100,16 @@ export const gatewayAbi = [
     type: "function",
   },
   {
+    inputs: [
+      { name: "tokenOut_", type: "address" },
+      { name: "amountOut_", type: "uint256" },
+    ],
+    name: "previewWithdraw",
+    outputs: [{ type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
     inputs: [],
     name: "cancelRedeemRequest",
     outputs: [],

--- a/packages/gateway/src/actions/index.ts
+++ b/packages/gateway/src/actions/index.ts
@@ -10,6 +10,7 @@ export * from "./public/getWithdrawalDelay.js";
 export * from "./public/isInstantRedeemWhitelisted.js";
 export * from "./public/previewDeposit.js";
 export * from "./public/previewRedeem.js";
+export * from "./public/previewWithdraw.js";
 
 // Export all wallet actions
 export * from "./wallet/cancelRedeemRequest.js";

--- a/packages/gateway/src/actions/public/index.ts
+++ b/packages/gateway/src/actions/public/index.ts
@@ -9,3 +9,4 @@ export * from "./getWithdrawalDelayEnabled.js";
 export * from "./isInstantRedeemWhitelisted.js";
 export * from "./previewDeposit.js";
 export * from "./previewRedeem.js";
+export * from "./previewWithdraw.js";

--- a/packages/gateway/src/actions/public/previewWithdraw.ts
+++ b/packages/gateway/src/actions/public/previewWithdraw.ts
@@ -1,0 +1,49 @@
+import { type Address, type Client } from "viem";
+import { readContract } from "viem/actions";
+
+import { gatewayAbi } from "../../abi/gatewayAbi.js";
+import { isAddressValid } from "../../utils/isAddressValid.js";
+
+export async function previewWithdraw(
+  client: Client,
+  parameters: {
+    address: Address;
+    tokenOut: Address;
+    amountOut: bigint;
+  },
+) {
+  // Validate client
+  if (!client) {
+    throw new Error("Client is not defined");
+  }
+
+  // Validate parameters exist
+  if (!parameters) {
+    throw new Error("Parameters are required");
+  }
+
+  // Validate gateway address
+  if (!isAddressValid(parameters.address)) {
+    throw new Error("Gateway is invalid");
+  }
+
+  // Validate tokenOut address
+  if (!isAddressValid(parameters.tokenOut)) {
+    throw new Error("Token is invalid");
+  }
+
+  // Validate amountOut
+  if (typeof parameters.amountOut !== "bigint") {
+    throw new Error("Amount must be a bigint");
+  }
+  if (parameters.amountOut <= 0n) {
+    throw new Error("Amount must be greater than 0");
+  }
+
+  return readContract(client, {
+    abi: gatewayAbi,
+    address: parameters.address,
+    args: [parameters.tokenOut, parameters.amountOut],
+    functionName: "previewWithdraw",
+  });
+}

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -12,6 +12,7 @@ import {
   isInstantRedeemWhitelisted,
   previewDeposit,
   previewRedeem,
+  previewWithdraw,
 } from "./actions/public/index.js";
 import {
   type CancelRedeemRequestParams,
@@ -68,6 +69,8 @@ export const gatewayPublicActions = () => (client: Client) => ({
     previewDeposit(client, params),
   previewRedeem: (params: Parameters<typeof previewRedeem>[1]) =>
     previewRedeem(client, params),
+  previewWithdraw: (params: Parameters<typeof previewWithdraw>[1]) =>
+    previewWithdraw(client, params),
 });
 
 export const gatewayWalletActions = () => (client: WalletClient) => ({

--- a/packages/gateway/test/public/previewWithdraw.test.ts
+++ b/packages/gateway/test/public/previewWithdraw.test.ts
@@ -1,0 +1,145 @@
+import { Address, Client, zeroAddress } from "viem";
+import { readContract } from "viem/actions";
+import { describe, it, expect, vi } from "vitest";
+
+import { previewWithdraw } from "../../src/actions/public/previewWithdraw";
+
+vi.mock("viem/actions", () => ({
+  readContract: vi.fn(),
+}));
+
+const validParameters = {
+  address: "0x1234567890123456789012345678901234567890" as Address,
+  amountOut: BigInt(1000),
+  tokenOut: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" as Address,
+};
+
+// @ts-expect-error - We only create an empty client for testing purposes
+const client: Client = {};
+
+describe("previewWithdraw", function () {
+  it("should throw an error if client is not defined", async function () {
+    await expect(
+      // @ts-expect-error - Testing invalid input
+      previewWithdraw(undefined, validParameters),
+    ).rejects.toThrow("Client is not defined");
+  });
+
+  it("should throw an error if parameters are not provided", async function () {
+    // @ts-expect-error - Testing invalid input
+    await expect(previewWithdraw(client, undefined)).rejects.toThrow(
+      "Parameters are required",
+    );
+  });
+
+  it("should throw an error if the gateway address is not valid", async function () {
+    const parameters = {
+      ...validParameters,
+      address: "invalid_address",
+    };
+
+    // @ts-expect-error - Testing invalid input
+    await expect(previewWithdraw(client, parameters)).rejects.toThrow(
+      "Gateway is invalid",
+    );
+  });
+
+  it("should throw an error if the gateway address is not provided", async function () {
+    const parameters = {
+      amountOut: validParameters.amountOut,
+      tokenOut: validParameters.tokenOut,
+    };
+
+    // @ts-expect-error - Testing invalid input
+    await expect(previewWithdraw(client, parameters)).rejects.toThrow(
+      "Gateway is invalid",
+    );
+  });
+
+  it("should throw an error if the gateway address is zero address", async function () {
+    const parameters = {
+      ...validParameters,
+      address: zeroAddress,
+    };
+
+    await expect(previewWithdraw(client, parameters)).rejects.toThrow(
+      "Gateway is invalid",
+    );
+  });
+
+  it("should throw an error if the token address is not valid", async function () {
+    const parameters = {
+      ...validParameters,
+      tokenOut: "invalid_token",
+    };
+
+    // @ts-expect-error - Testing invalid input
+    await expect(previewWithdraw(client, parameters)).rejects.toThrow(
+      "Token is invalid",
+    );
+  });
+
+  it("should throw an error if the token address is not provided", async function () {
+    const parameters = {
+      address: validParameters.address,
+      amountOut: validParameters.amountOut,
+    };
+
+    // @ts-expect-error - Testing invalid input
+    await expect(previewWithdraw(client, parameters)).rejects.toThrow(
+      "Token is invalid",
+    );
+  });
+
+  it("should throw an error if the token address is zero address", async function () {
+    const parameters = {
+      ...validParameters,
+      tokenOut: zeroAddress,
+    };
+
+    await expect(previewWithdraw(client, parameters)).rejects.toThrow(
+      "Token is invalid",
+    );
+  });
+
+  it("should throw an error if amountOut is not a bigint", async function () {
+    const parameters = { ...validParameters, amountOut: 1000 };
+
+    // @ts-expect-error - Testing invalid input
+    await expect(previewWithdraw(client, parameters)).rejects.toThrow(
+      "Amount must be a bigint",
+    );
+  });
+
+  it("should throw an error if amountOut is zero", async function () {
+    const parameters = { ...validParameters, amountOut: BigInt(0) };
+
+    await expect(previewWithdraw(client, parameters)).rejects.toThrow(
+      "Amount must be greater than 0",
+    );
+  });
+
+  it("should throw an error if amountOut is negative", async function () {
+    const parameters = { ...validParameters, amountOut: BigInt(-1) };
+
+    await expect(previewWithdraw(client, parameters)).rejects.toThrow(
+      "Amount must be greater than 0",
+    );
+  });
+
+  it("should call readContract if all parameters are valid", async function () {
+    const peggedTokenIn = BigInt(1050);
+
+    vi.mocked(readContract).mockResolvedValueOnce(peggedTokenIn);
+
+    const result = await previewWithdraw(client, validParameters);
+
+    expect(readContract).toHaveBeenCalledWith(client, {
+      abi: expect.anything(),
+      address: validParameters.address,
+      args: [validParameters.tokenOut, validParameters.amountOut],
+      functionName: "previewWithdraw",
+    });
+    expect(result).toBe(peggedTokenIn);
+  });
+});


### PR DESCRIPTION
### Description

This PR implements `previewWithdraw` as a public action on `@vetro-protocol/gateway`, mirroring `previewRedeem`. The Gateway contract already exposes it natively as the canonical inverse of `previewRedeem`: given a desired `amountOut` of the underlying token, it returns the pegged-token amount that must leave the vault, with `redeemFee` applied on-chain.

The new action follows the same shape as `previewRedeem` — `(client, { address, tokenOut, amountOut })`, same validation flow, same error messages. It's wired through `actions/public/index.ts`, the top-level actions barrel, and the `gatewayPublicActions()` factory, with a matching unit test and a README entry. Package version bumped from `1.0.0` to `1.1.0` (additive, non-breaking).

### Screenshots

N/A - No UI changes.

### Related issue(s)

Closes #452 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
