### PR TITLE
Fix divide-by-zero in Earn subgraph

### DIFF
--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vetro-app-subgraph",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "scripts": {
     "prebuild": "npm run codegen",

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -41,6 +41,17 @@ export function handleBlock(block: ethereum.Block): void {
   const dayTimestamp = block.timestamp.div(daySeconds).times(daySeconds);
 
   const vaultAddress = dataSource.address();
+
+  const vault = StakingVault.bind(vaultAddress);
+  const decimals = vault.decimals();
+  const oneShare = BigInt.fromI32(10).pow(<u8>decimals);
+  const shareValueResult = vault.try_convertToAssets(oneShare);
+  // Empty vault (zero total supply): convertToAssets reverts with a divide-by-zero
+  // panic. Skip recording history for this block rather than aborting the handler.
+  if (shareValueResult.reverted) {
+    return;
+  }
+
   const id = buildId(vaultAddress, dayTimestamp.toString());
   let entity = VaultHistory.load(id);
   if (entity == null) {
@@ -49,11 +60,7 @@ export function handleBlock(block: ethereum.Block): void {
     entity.stakingVaultAddress = vaultAddress;
   }
 
-  const vault = StakingVault.bind(vaultAddress);
-  const decimals = vault.decimals();
-  const oneShare = BigInt.fromI32(10).pow(<u8>decimals);
-  const shareValue = vault.convertToAssets(oneShare);
-  entity.shareValue = shareValue;
+  entity.shareValue = shareValueResult.value;
   entity.totalAssets = vault.totalAssets();
 
   entity.save();
@@ -102,8 +109,10 @@ export function handleTransfer(event: Transfer): void {
   const fromId = buildId(vaultAddress, event.params.from.toHexString());
   const fromEntity = UserStakingPosition.load(fromId)!;
 
-  if (fromEntity.shares.equals(value)) {
-    // All shares transferred out: reset to zero.
+  if (fromEntity.shares.le(value)) {
+    // All shares transferred out (or tracked shares already at/below the
+    // transferred amount): reset to zero. Guarding with `<=` also keeps the
+    // proportional branch below from dividing by a zero `fromEntity.shares`.
     fromEntity.shares = BigInt.fromI32(0);
     fromEntity.totalCostBasis = BigInt.fromI32(0);
   } else {

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -145,6 +145,30 @@ describe("handleBlock", function () {
       dayTimestamp.toString(),
     );
   });
+
+  test("skips the block when convertToAssets reverts (empty vault)", function () {
+    // An empty vault (zero total supply) makes convertToAssets revert with a
+    // divide-by-zero panic. The handler must skip the block, not abort.
+    const decimals = 18;
+    const oneShare = BigInt.fromI32(10).pow(<u8>decimals);
+    const timestamp = BigInt.fromI32(1769731200); // 2026-01-30 00:00:00 UTC
+
+    createMockedFunction(vaultAddress, "decimals", "decimals():(uint8)")
+      .withArgs([])
+      .returns([ethereum.Value.fromI32(decimals)]);
+    createMockedFunction(
+      vaultAddress,
+      "convertToAssets",
+      "convertToAssets(uint256):(uint256)",
+    )
+      .withArgs([ethereum.Value.fromUnsignedBigInt(oneShare)])
+      .reverts();
+
+    const block = createMockBlock(BigInt.fromI32(100), timestamp);
+    handleBlock(block);
+
+    assert.entityCount("VaultHistory", 0);
+  });
 });
 
 describe("handleDeposit", function () {
@@ -764,6 +788,42 @@ describe("handleTransfer", function () {
     );
 
     const id = `${vaultAddressString}-${ownerAddressString}`;
+    assert.fieldEquals("UserStakingPosition", id, "shares", "0");
+    assert.fieldEquals("UserStakingPosition", id, "totalCostBasis", "0");
+  });
+
+  test("keeps shares at 0 on transfer-out from a zero-share position (no divide-by-zero)", function () {
+    // Setup: owner deposits then transfers everything out, leaving a position
+    // with shares=0. A further non-zero transfer-out (tracked shares diverged
+    // from on-chain balance) must reset to zero instead of dividing by zero.
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("120000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+    handleTransfer(
+      createTransferEvent(
+        ownerAddress,
+        receiverAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    assert.fieldEquals("UserStakingPosition", id, "shares", "0");
+
+    // Transfer-out of 30 while tracked shares are 0.
+    handleTransfer(
+      createTransferEvent(
+        ownerAddress,
+        receiverAddress,
+        BigInt.fromString("30000000000000000000"),
+      ),
+    );
+
     assert.fieldEquals("UserStakingPosition", id, "shares", "0");
     assert.fieldEquals("UserStakingPosition", id, "totalCostBasis", "0");
   });


### PR DESCRIPTION
### Description

Two integer-division sites in `subgraph/src/earn.ts` could divide by zero and abort indexing.

- **`handleBlock` → `convertToAssets` (empty vault):** the block handler runs on every block from each vault's `startBlock`. While a vault has zero total supply (before the first deposit, or after a full exit), the ERC4626 `convertToAssets` call reverts with a divide-by-zero panic, and the non-`try_` call aborted the handler. Fixed by switching to `try_convertToAssets` and skipping the block (no `VaultHistory` row) when it reverts. The `StakingVault` ABI exposes no `totalSupply`, so the `try_` guard is the right approach.
- **`handleTransfer` → proportional cost basis:** the sender's cost basis is recomputed as `totalCostBasis * newShares / fromEntity.shares`, but the reset guard only fired on `shares == value`. A transfer-out from a position whose tracked shares were `0` (or below `value`) fell into the proportional branch and divided by zero. Widened the guard from `.equals(value)` to `.le(value)` so the division only runs when `shares > value` (and `value` is already proven `> 0`), making the denominator provably non-zero.

Added matchstick tests for both cases (empty-vault block, zero-share transfer-out) and bumped the subgraph version to `1.4.1`.

### Screenshots

N/A — subgraph mapping change, no UI.

### Related issue(s)

Closes #454

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
