### PR TITLE
Update 'Withdraw all' exit tickets toast text

### DIFF
--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -278,8 +278,8 @@
           "step-title": "Confirm {{symbol}} withdrawal",
           "title": "Withdrawing all exit tickets"
         },
-        "withdraw-all-toast-description": "All ready exit tickets have been withdrawn to your wallet.",
-        "withdraw-all-toast-title": "All withdrawals complete",
+        "withdraw-all-toast-description": "Your exit tickets have been withdrawn successfully.",
+        "withdraw-all-toast-title": "All exit tickets withdrawn",
         "withdraw-toast-description": "Your funds have been successfully withdrawn to your wallet.",
         "withdraw-toast-title": "Withdrawal complete",
         "withdrawal-amount": "{{amount}} {{symbol}}",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -281,8 +281,8 @@
           "step-title": "Confirmar retiro de {{symbol}}",
           "title": "Retirando todos los tickets de salida"
         },
-        "withdraw-all-toast-description": "Todos los tickets de salida listos han sido retirados a su billetera.",
-        "withdraw-all-toast-title": "Todos los retiros completados",
+        "withdraw-all-toast-description": "Sus tickets de salida han sido retirados exitosamente.",
+        "withdraw-all-toast-title": "Todos los tickets de salida retirados",
         "withdraw-toast-description": "Sus fondos han sido retirados exitosamente a su billetera.",
         "withdraw-toast-title": "Retiro completado",
         "withdrawal-amount": "{{amount}} {{symbol}}",


### PR DESCRIPTION
### Description

Updates the success toast shown after the 'Withdraw all' exit tickets flow to match the wording requested in #447. The title now reads "All exit tickets withdrawn" and the description "Your exit tickets have been withdrawn successfully." Both the `en` and `es` locales were updated.

### Screenshots

N/A — text-only change.

### Related issue(s)

Closes #447

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.