### PR TITLE
Add getGateway action to gateway package

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vetro-protocol/gateway",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Vetro Protocol gateway actions for viem.",
   "license": "MIT",
   "files": [

--- a/packages/gateway/src/abi/peggedTokenAbi.ts
+++ b/packages/gateway/src/abi/peggedTokenAbi.ts
@@ -1,0 +1,9 @@
+export const peggedTokenAbi = [
+  {
+    inputs: [],
+    name: "gateway",
+    outputs: [{ type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;

--- a/packages/gateway/src/actions/index.ts
+++ b/packages/gateway/src/actions/index.ts
@@ -1,4 +1,5 @@
 // Export all public actions
+export * from "./public/getGateway.js";
 export * from "./public/getMaxWithdraw.js";
 export * from "./public/getPeggedToken.js";
 export * from "./public/getMintFee.js";

--- a/packages/gateway/src/actions/public/getGateway.ts
+++ b/packages/gateway/src/actions/public/getGateway.ts
@@ -1,0 +1,40 @@
+import { type Address, type Client } from "viem";
+import { readContract } from "viem/actions";
+
+import { peggedTokenAbi } from "../../abi/peggedTokenAbi.js";
+import { isAddressValid } from "../../utils/isAddressValid.js";
+
+/**
+ * Reads the gateway address for a given pegged token.
+ * @param client - The viem client used to read the contract.
+ * @param parameters - The parameters object.
+ * @param parameters.address - The pegged token address to read the gateway from.
+ * @returns The gateway address configured on the pegged token.
+ */
+export async function getGateway(
+  client: Client,
+  parameters: {
+    address: Address;
+  },
+) {
+  // Validate client
+  if (!client) {
+    throw new Error("Client is not defined");
+  }
+
+  // Validate parameters exist
+  if (!parameters) {
+    throw new Error("Parameters are required");
+  }
+
+  // Validate pegged token address
+  if (!isAddressValid(parameters.address)) {
+    throw new Error("Pegged token is invalid");
+  }
+
+  return readContract(client, {
+    abi: peggedTokenAbi,
+    address: parameters.address,
+    functionName: "gateway",
+  });
+}

--- a/packages/gateway/src/actions/public/index.ts
+++ b/packages/gateway/src/actions/public/index.ts
@@ -1,3 +1,4 @@
+export * from "./getGateway.js";
 export * from "./getMaxWithdraw.js";
 export * from "./getMintFee.js";
 export * from "./getPeggedToken.js";

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,6 +1,7 @@
 import type { Client, WalletClient } from "viem";
 
 import {
+  getGateway,
   getMaxWithdraw,
   getMintFee,
   getPeggedToken,
@@ -45,6 +46,8 @@ export {
 
 // Export factory functions for .extend() pattern
 export const gatewayPublicActions = () => (client: Client) => ({
+  getGateway: (params: Parameters<typeof getGateway>[1]) =>
+    getGateway(client, params),
   getMaxWithdraw: (params: Parameters<typeof getMaxWithdraw>[1]) =>
     getMaxWithdraw(client, params),
   getMintFee: (params: Parameters<typeof getMintFee>[1]) =>

--- a/packages/gateway/test/public/getGateway.test.ts
+++ b/packages/gateway/test/public/getGateway.test.ts
@@ -1,0 +1,77 @@
+import { Address, Client, zeroAddress } from "viem";
+import { readContract } from "viem/actions";
+import { describe, it, expect, vi } from "vitest";
+
+import { getGateway } from "../../src/actions/public/getGateway";
+
+vi.mock("viem/actions", () => ({
+  readContract: vi.fn(),
+}));
+
+const validParameters = {
+  address: "0x1234567890123456789012345678901234567890" as Address,
+};
+
+// @ts-expect-error - We only create an empty client for testing purposes
+const client: Client = {};
+
+describe("getGateway", function () {
+  it("should throw an error if client is not defined", async function () {
+    await expect(
+      // @ts-expect-error - Testing invalid input
+      getGateway(undefined, validParameters),
+    ).rejects.toThrow("Client is not defined");
+  });
+
+  it("should throw an error if parameters are not provided", async function () {
+    // @ts-expect-error - Testing invalid input
+    await expect(getGateway(client, undefined)).rejects.toThrow(
+      "Parameters are required",
+    );
+  });
+
+  it("should throw an error if the address is not valid", async function () {
+    const parameters = {
+      ...validParameters,
+      address: "invalid_address",
+    };
+    // @ts-expect-error - Testing invalid input
+    await expect(getGateway(client, parameters)).rejects.toThrow(
+      "Pegged token is invalid",
+    );
+  });
+
+  it("should throw an error if the address is not provided", async function () {
+    const parameters = {};
+    // @ts-expect-error - Testing invalid input
+    await expect(getGateway(client, parameters)).rejects.toThrow(
+      "Pegged token is invalid",
+    );
+  });
+
+  it("should throw an error if the address is zero address", async function () {
+    const parameters = {
+      address: zeroAddress,
+    };
+
+    await expect(getGateway(client, parameters)).rejects.toThrow(
+      "Pegged token is invalid",
+    );
+  });
+
+  it("should call readContract if all parameters are valid", async function () {
+    const gatewayAddress =
+      "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" as Address;
+
+    vi.mocked(readContract).mockResolvedValueOnce(gatewayAddress);
+
+    const result = await getGateway(client, validParameters);
+
+    expect(readContract).toHaveBeenCalledWith(client, {
+      abi: expect.anything(),
+      address: validParameters.address,
+      functionName: "gateway",
+    });
+    expect(result).toBe(gatewayAddress);
+  });
+});


### PR DESCRIPTION
### Description

Adds a public `getGateway` action to the `@vetro-protocol/gateway` package. Given a pegged token address, it reads the gateway address configured on that token via its `gateway()` view function — the inverse of the existing `getPeggedToken` action.

This step is needed for mapping a share into a gateway.

The change includes a minimal `peggedTokenAbi`, unit tests, exports through the public action indexes and the `gatewayPublicActions()` factory, and a minor version bump to `1.2.0`.

### Screenshots

N/A

### Related issue(s)

Related to https://github.com/hemilabs/ui-monorepo/issues/1973

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.