### PR TITLE
Rename Terms and Services page to Terms of Use

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -14,7 +14,7 @@ import { ErrorPage } from "pages/errorPage";
 import { Faq } from "pages/faq";
 import { NotFound } from "pages/notFound";
 import { Swap } from "pages/swap";
-import { TermsAndServices } from "pages/termsAndServices";
+import { TermsOfUse } from "pages/termsOfUse";
 import { Suspense, lazy } from "react";
 import {
   BrowserRouter,
@@ -77,7 +77,7 @@ function LanguageRoutes() {
             <Route element={<Bridge />} path="bridge" />
             <Route element={<Analytics />} path="analytics" />
             <Route element={<Faq />} path="faq" />
-            <Route element={<TermsAndServices />} path="terms-and-services" />
+            <Route element={<TermsOfUse />} path="terms-of-use" />
           </Route>
           <Route
             element={

--- a/web/src/components/headerMenu.tsx
+++ b/web/src/components/headerMenu.tsx
@@ -61,8 +61,8 @@ export function HeaderMenu() {
       items: [
         {
           icon: <DocumentIcon className={itemIconClassName} />,
-          label: t("nav.header-menu.terms-and-services"),
-          to: "/terms-and-services",
+          label: t("nav.header-menu.terms-of-use"),
+          to: "/terms-of-use",
         },
       ],
       label: t("nav.header-menu.company"),

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -42,7 +42,7 @@
       "linkedin": "LinkedIn",
       "open": "Open menu",
       "socials": "Socials",
-      "terms-and-services": "Terms and Services",
+      "terms-of-use": "Terms of Use",
       "x": "X"
     },
     "open-menu": "Open navigation menu",
@@ -444,7 +444,7 @@
         "title": "How to redeem VUSD to stables"
       }
     },
-    "terms-and-services": {
+    "terms-of-use": {
       "last-updated": "Last updated: May 18th, 2026",
       "published-by": "Published by Vetro Service & Support Ltd.",
       "title": "Vetro Terms Of Use"

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -42,7 +42,7 @@
       "linkedin": "LinkedIn",
       "open": "Abrir menú",
       "socials": "Redes sociales",
-      "terms-and-services": "Términos y condiciones",
+      "terms-of-use": "Términos de uso",
       "x": "X"
     },
     "open-menu": "Abrir menú de navegación",
@@ -453,7 +453,7 @@
         "title": "Cómo canjear VUSD a stables"
       }
     },
-    "terms-and-services": {
+    "terms-of-use": {
       "last-updated": "Última actualización: 18 de mayo de 2026",
       "published-by": "Publicado por Vetro Service & Support Ltd.",
       "title": "Términos de uso de Vetro"

--- a/web/src/pages/termsOfUse.tsx
+++ b/web/src/pages/termsOfUse.tsx
@@ -3,15 +3,15 @@ import { useTranslation } from "react-i18next";
 
 // The body of the Terms is a legal document so it can't be translated
 // and is presented in English only.
-export const TermsAndServices = function () {
+export const TermsOfUse = function () {
   const { t } = useTranslation();
   return (
     <div className="flex flex-col items-center">
-      <PageTitle value={t("pages.terms-and-services.title")} />
+      <PageTitle value={t("pages.terms-of-use.title")} />
       <div className="text-b-regular flex w-full items-center justify-center gap-x-3 border-y border-gray-200 bg-gray-100 py-4 text-gray-500">
-        <p>{t("pages.terms-and-services.published-by")}</p>
+        <p>{t("pages.terms-of-use.published-by")}</p>
         <span aria-hidden="true">·</span>
-        <p>{t("pages.terms-and-services.last-updated")}</p>
+        <p>{t("pages.terms-of-use.last-updated")}</p>
       </div>
       <div className="text-b-regular flex flex-col gap-y-4 bg-white p-4 text-gray-500 md:px-20 md:py-12 lg:px-30">
         <p>


### PR DESCRIPTION
### Description

Renames the `terms-and-services` route to `terms-of-use`, along with the header menu link label, the page component (`TermsAndServices` → `TermsOfUse`), and the i18n keys in both locales (en: "Terms of Use", es: "Términos de uso"). The old `/terms-and-services` URL is not redirected; it falls through to the NotFound page.

### Screenshots

N/A — text-only change (link label and URL).

### Related issue(s)

Closes #459

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.