### PR TITLE
Add localhost:3000 to allowed API origins

### DIFF
--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -14,7 +14,7 @@
   "vars": {
     "MERKL_OPPORTUNITY_SVETBTC": "",
     "MERKL_OPPORTUNITY_SVUSD": "",
-    "ORIGINS": "http://localhost:5173",
+    "ORIGINS": "http://localhost:3000,http://localhost:5173",
     "SUBGRAPH_URL_TEMPLATE": "http://localhost:8000/subgraphs/name/vetro-app-subgraph",
   },
   "env": {


### PR DESCRIPTION
### Description

Adds `http://localhost:3000` to the dev `ORIGINS` allowlist in `api/wrangler.jsonc`, so the API accepts requests from apps running on port 3000. This improves the local development experience for hemi-earn, which runs on that port and consumes this API.

### Screenshots

N/A — config-only change.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.