### PR TITLE
Minor UI fixes across swap and analytics pages

### DIFF
--- a/web/src/components/bridgeForm/bridgeFees.tsx
+++ b/web/src/components/bridgeForm/bridgeFees.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { formatFiatNumber } from "utils/format";
 
-const DollarSign = () => <span className="mr-1">$</span>;
+const DollarSign = () => <span>$</span>;
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div className="flex items-center gap-x-1">{children}</div>
@@ -34,7 +34,7 @@ export function BridgeFees({
     value !== undefined ? (
       <Container>
         <DollarSign />
-        {formatFiatNumber(value)}
+        <span>{formatFiatNumber(value)}</span>
       </Container>
     ) : undefined;
 

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -294,6 +294,7 @@ export function Deposit({
       </FormSection>
       <RedeemQueueSection
         peggedToken={toToken}
+        showTopBorder={amountBigInt !== 0n}
         whitelistedTokens={whitelistedTokens}
       />
       {isDrawerOpen && flowStatus !== "idle" && (

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -305,6 +305,7 @@ export function OneStepRedeem({
       </FormSection>
       <RedeemQueueSection
         peggedToken={fromToken}
+        showTopBorder={amountBigInt !== 0n}
         whitelistedTokens={whitelistedTokens}
       />
       {isDrawerOpen && flowStatus !== "idle" && (

--- a/web/src/components/swapForm/redeemQueueSection.tsx
+++ b/web/src/components/swapForm/redeemQueueSection.tsx
@@ -6,14 +6,20 @@ import { RedeemQueue } from "./redeemQueue";
 
 type Props = {
   peggedToken: TokenWithGateway;
+  showTopBorder: boolean;
   whitelistedTokens: TokenWithGateway[];
 };
-export const RedeemQueueSection = function (props: Props) {
+export const RedeemQueueSection = function ({
+  showTopBorder,
+  ...props
+}: Props) {
   const ref = useScrollToHash("redeem-queue");
 
   return (
     <>
-      <div className="w-full border-y border-gray-200 bg-gray-100">
+      <div
+        className={`w-full ${showTopBorder ? "border-y" : "border-b"} border-gray-200 bg-gray-100`}
+      >
         <StripedDivider />
       </div>
       <div className="w-full" id="redeem-queue" ref={ref}>

--- a/web/src/components/swapForm/swapFees.tsx
+++ b/web/src/components/swapForm/swapFees.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from "react-i18next";
 import type { Token } from "types";
 import { formatFiatNumber } from "utils/format";
 
-const DollarSign = () => <span className="mr-1">$</span>;
+const DollarSign = () => <span>$</span>;
 
 type FeeData = {
   data: bigint | undefined;

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -286,6 +286,7 @@ export function TwoStepRedeem({
       </FormSection>
       <RedeemQueueSection
         peggedToken={fromToken}
+        showTopBorder={amountBigInt !== 0n}
         whitelistedTokens={whitelistedTokens}
       />
       {isTutorialOpen && (

--- a/web/src/pages/analytics/components/allocationCard/index.tsx
+++ b/web/src/pages/analytics/components/allocationCard/index.tsx
@@ -38,7 +38,7 @@ export const AllocationCard = function ({
   return (
     <div className="flex flex-1 flex-col only:border-x only:border-gray-200">
       <div className="px-6 md:px-14">
-        <div className="flex flex-col gap-3 border-t border-blue-500 py-6">
+        <div className="flex -translate-y-px flex-col gap-3 border-t border-blue-500 py-6">
           <div className="flex items-center justify-between">
             <span className="text-b-medium text-gray-900">{label}</span>
             <div className="size-4">{icon}</div>

--- a/web/src/pages/analytics/components/pegStabilityCard.tsx
+++ b/web/src/pages/analytics/components/pegStabilityCard.tsx
@@ -72,81 +72,87 @@ export function PegStabilityCard({ peggedToken, peggedTokenError }: Props) {
   const isError = peggedTokenError || isHistoryError;
 
   return (
-    <div className="flex-1 px-3 py-6 md:px-14">
-      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <span className="text-b-medium text-gray-900">
-          {t("pages.analytics.peg-stability-label")}
-        </span>
-        <SegmentedControl
-          onChange={setPeriod}
-          options={shareValueHistoryPeriods.map((p) => ({
-            label: t(periodLabelKeys[p]),
-            value: p,
-          }))}
-          size="xs"
-          value={period}
-          variant="pill"
-        />
-      </div>
-      <div
-        className="relative mt-6 md:mt-8"
-        ref={chartContainerRef}
-        style={{ height: chartHeight }}
-      >
-        {isError ? (
-          <div className="flex h-full items-center justify-center">
-            {isHistoryError ? (
-              <Button onClick={() => refetch()} size="xSmall" variant="primary">
-                {t("common.charts.reload-chart")}
-              </Button>
-            ) : (
-              <span className="text-gray-500">-</span>
-            )}
-          </div>
-        ) : chartData === undefined ? (
-          <Skeleton height={chartHeight} />
-        ) : (
-          <VictoryChart
-            containerComponent={
-              <VictoryVoronoiContainer
-                labelComponent={
-                  <VictoryTooltip
-                    constrainToVisibleArea
-                    cornerRadius={8}
-                    flyoutPadding={{ bottom: 8, left: 12, right: 12, top: 8 }}
-                    flyoutStyle={{ fill: "white", stroke: "#E5E7EB" }}
-                    pointerLength={0}
-                    style={{ fontSize: 11 }}
-                  />
-                }
-                labels={({ datum }: { datum: { x: number; y: number } }) =>
-                  `${formatDate(datum.x / 1000, i18n.language)}  ${formatShareValue(datum.y)}`
+    <div className="flex-1 px-3 md:px-14">
+      <div className="-translate-y-px border-t border-blue-500 py-6">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <span className="text-b-medium text-gray-900">
+            {t("pages.analytics.peg-stability-label")}
+          </span>
+          <SegmentedControl
+            onChange={setPeriod}
+            options={shareValueHistoryPeriods.map((p) => ({
+              label: t(periodLabelKeys[p]),
+              value: p,
+            }))}
+            size="xs"
+            value={period}
+            variant="pill"
+          />
+        </div>
+        <div
+          className="relative mt-6 md:mt-8"
+          ref={chartContainerRef}
+          style={{ height: chartHeight }}
+        >
+          {isError ? (
+            <div className="flex h-full items-center justify-center">
+              {isHistoryError ? (
+                <Button
+                  onClick={() => refetch()}
+                  size="xSmall"
+                  variant="primary"
+                >
+                  {t("common.charts.reload-chart")}
+                </Button>
+              ) : (
+                <span className="text-gray-500">-</span>
+              )}
+            </div>
+          ) : chartData === undefined ? (
+            <Skeleton height={chartHeight} />
+          ) : (
+            <VictoryChart
+              containerComponent={
+                <VictoryVoronoiContainer
+                  labelComponent={
+                    <VictoryTooltip
+                      constrainToVisibleArea
+                      cornerRadius={8}
+                      flyoutPadding={{ bottom: 8, left: 12, right: 12, top: 8 }}
+                      flyoutStyle={{ fill: "white", stroke: "#E5E7EB" }}
+                      pointerLength={0}
+                      style={{ fontSize: 11 }}
+                    />
+                  }
+                  labels={({ datum }: { datum: { x: number; y: number } }) =>
+                    `${formatDate(datum.x / 1000, i18n.language)}  ${formatShareValue(datum.y)}`
+                  }
+                />
+              }
+              height={chartHeight}
+              padding={chartPadding}
+              width={chartWidth || undefined}
+            >
+              <VictoryAxis
+                style={xAxisStyle}
+                tickCount={4}
+                tickFormat={(tick: number) =>
+                  formatShortDate(tick / 1000, i18n.language)
                 }
               />
-            }
-            height={chartHeight}
-            padding={chartPadding}
-            width={chartWidth || undefined}
-          >
-            <VictoryAxis
-              style={xAxisStyle}
-              tickCount={4}
-              tickFormat={(tick: number) =>
-                formatShortDate(tick / 1000, i18n.language)
-              }
-            />
-            <VictoryAxis
-              dependentAxis
-              style={yAxisStyle}
-              tickFormat={formatShareValue}
-            />
-            <VictoryLine
-              data={chartData}
-              interpolation="linear"
-              style={{ data: { stroke: "#416BFF", strokeWidth: 2 } }}
-            />
-          </VictoryChart>
-        )}
+              <VictoryAxis
+                dependentAxis
+                style={yAxisStyle}
+                tickFormat={formatShareValue}
+              />
+              <VictoryLine
+                data={chartData}
+                interpolation="linear"
+                style={{ data: { stroke: "#416BFF", strokeWidth: 2 } }}
+              />
+            </VictoryChart>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### Description

Tackles the four minor UI issues reported in #398:

1. Removed the space between the `$` sign and fee values in the bridge and swap fee displays.
2. Removed the doubled line on the swap page: the redeem queue section now only renders its top border when the fees section above it is expanded.
3. Aligned the allocation card's blue top border with the gray divider by shifting the content up 1px so both lines sit on the same plane.
4. Added the blue top border to the peg stability card, matching the allocation cards' header treatment.

**Commits:**

13d1fd3 Fix spacing between dollar sign and fee amounts
2097c40 Hide redeem queue top border when fees hidden
167e995 Overlap allocation card border with divider
bb287b6 Add blue top border to peg stability card

### Screenshots

1.

<img width="567" height="182" alt="image" src="https://github.com/user-attachments/assets/3c7ecf72-eaf0-4fa4-8357-1d3a67fad1e5" />

2.

<img width="1215" height="211" alt="image" src="https://github.com/user-attachments/assets/12a7c7f1-030b-4ce4-b445-e16f947c240f" />

3.

<img width="1156" height="381" alt="image" src="https://github.com/user-attachments/assets/126e2e04-2a4c-42e3-bed4-0f7e71d33362" />

4.

<img width="1074" height="104" alt="image" src="https://github.com/user-attachments/assets/d7fe67d5-4a03-4155-a581-902c6338c49e" />

### Related issue(s)

Closes #398

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.