### PR TITLE
Optimize subgraph's block handling

### DIFF
--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vetro-app-subgraph",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "license": "MIT",
   "scripts": {
     "prebuild": "npm run codegen",

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,4 +1,4 @@
-type VaultHistory @entity(immutable: false) {
+type VaultHistory @entity(immutable: true) {
   id: ID!
   shareValue: BigInt!
   stakingVaultAddress: Bytes!

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -34,3 +34,8 @@ type UserStakingPosition @entity(immutable: false) {
   stakingVaultAddress: Bytes!
   totalCostBasis: BigInt! # WAD-scaled (36 decimals when asset has 18 decimals)
 }
+
+type VaultConfig @entity(immutable: true) {
+  id: Bytes! # vault address
+  decimals: Int!
+}

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -40,10 +40,11 @@ export function handleBlock(block: ethereum.Block): void {
   const vaultAddress = dataSource.address();
   const vault = StakingVault.bind(vaultAddress);
 
-  // To speed up the sync process, minimize the RPC calls and amount of entities
-  // saved, history records are only saved with the first block of each day. Use
-  // integer-divide then re-multiply to snap block.timestamp to the start of the
-  // UTC day (00:00:00).
+  // To speed up the sync process, minimize RPC calls and entity writes, only
+  // save one history record per day (the first time this handler runs for that
+  // day). Return early if the record for the current day already exists.
+  // Use integer-divide then re-multiply to snap block.timestamp to the start of
+  // the UTC day (00:00:00).
   const daySeconds = BigInt.fromI32(86400);
   const dayTimestamp = block.timestamp.div(daySeconds).times(daySeconds);
   // Then to keep the records aligned with the prior implementation which saved

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -37,12 +37,22 @@ function loadOrCreateQueueSummary(
 }
 
 export function handleBlock(block: ethereum.Block): void {
-  const daySeconds = BigInt.fromI32(86400);
-  // Integer-divide then re-multiply to snap block.timestamp to the start of the UTC day (00:00:00).
-  const dayTimestamp = block.timestamp.div(daySeconds).times(daySeconds);
-
   const vaultAddress = dataSource.address();
   const vault = StakingVault.bind(vaultAddress);
+
+  // To speed up the sync process, minimize the RPC calls and amount of entities
+  // saved, history records are only saved with the first block of each day. Use
+  // integer-divide then re-multiply to snap block.timestamp to the start of the
+  // UTC day (00:00:00).
+  const daySeconds = BigInt.fromI32(86400);
+  const dayTimestamp = block.timestamp.div(daySeconds).times(daySeconds);
+  // Then to keep the records aligned with the prior implementation which saved
+  // the entity at the end of each day, compute the previous day's timestamp.
+  const previousDayTimestamp = dayTimestamp.minus(daySeconds);
+  const id = buildId(vaultAddress, previousDayTimestamp.toString());
+  if (VaultHistory.load(id) != null) {
+    return;
+  }
 
   // Calling decimals() on the StakingVault contract will always result in the
   // same value. It is set on initialize() and cannot be changed afterwards.
@@ -65,14 +75,9 @@ export function handleBlock(block: ethereum.Block): void {
     return;
   }
 
-  const id = buildId(vaultAddress, dayTimestamp.toString());
-  let entity = VaultHistory.load(id);
-  if (entity == null) {
-    entity = new VaultHistory(id);
-    entity.timestamp = dayTimestamp;
-    entity.stakingVaultAddress = vaultAddress;
-  }
-
+  const entity = new VaultHistory(id);
+  entity.timestamp = previousDayTimestamp;
+  entity.stakingVaultAddress = vaultAddress;
   entity.shareValue = shareValueResult.value;
   entity.totalAssets = vault.totalAssets();
 

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -4,6 +4,7 @@ import {
   ExitTicket,
   ExitTicketQueueSummary,
   UserStakingPosition,
+  VaultConfig,
   VaultHistory,
 } from "../generated/schema";
 import {
@@ -41,10 +42,22 @@ export function handleBlock(block: ethereum.Block): void {
   const dayTimestamp = block.timestamp.div(daySeconds).times(daySeconds);
 
   const vaultAddress = dataSource.address();
-
   const vault = StakingVault.bind(vaultAddress);
-  const decimals = vault.decimals();
-  const oneShare = BigInt.fromI32(10).pow(<u8>decimals);
+
+  // Calling decimals() on the StakingVault contract will always result in the
+  // same value. It is set on initialize() and cannot be changed afterwards.
+  // Caching it in its own entity avoids calling decimals() on every block,
+  // speeding up the handler and reducing sync time. The contract is upgradeable
+  // but changing the decimals is highly unlikely as it would break many other
+  // things downstream.
+  let vaultConfig = VaultConfig.load(vaultAddress);
+  if (vaultConfig == null) {
+    vaultConfig = new VaultConfig(vaultAddress);
+    vaultConfig.decimals = vault.decimals();
+    vaultConfig.save();
+  }
+
+  const oneShare = BigInt.fromI32(10).pow(<u8>vaultConfig.decimals);
   const shareValueResult = vault.try_convertToAssets(oneShare);
   // Empty vault (zero total supply): convertToAssets reverts with a divide-by-zero
   // panic. Skip recording history for this block rather than aborting the handler.

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -19,6 +19,7 @@ dataSources:
         - ExitTicket
         - ExitTicketQueueSummary
         - UserStakingPosition
+        - VaultConfig
         - VaultHistory
       abis:
         - name: StakingVault
@@ -52,6 +53,7 @@ dataSources:
         - ExitTicket
         - ExitTicketQueueSummary
         - UserStakingPosition
+        - VaultConfig
         - VaultHistory
       abis:
         - name: StakingVault

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -37,6 +37,9 @@ dataSources:
           handler: handleWithdrawRequested
       blockHandlers:
         - handler: handleBlock
+          filter:
+            kind: polling
+            every: 300 # blocks in 1h
       file: ./src/earn.ts
   - kind: ethereum
     name: sVetBTCStakingVault
@@ -71,4 +74,7 @@ dataSources:
           handler: handleWithdrawRequested
       blockHandlers:
         - handler: handleBlock
+          filter:
+            kind: polling
+            every: 300 # blocks in 1h
       file: ./src/earn.ts

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -122,6 +122,29 @@ describe("handleBlock", function () {
     const id = `${vaultAddressString}-${previousDayTimestamp.toString()}`;
     assert.entityCount("VaultHistory", 1);
 
+    // Re-mock with different values so that if the handler skips the
+    // early-return and re-runs RPC calls, it would overwrite the entity and
+    // break the assertions below.
+    const oneShare = BigInt.fromI32(10).pow(<u8>decimals);
+    createMockedFunction(
+      vaultAddress,
+      "convertToAssets",
+      "convertToAssets(uint256):(uint256)",
+    )
+      .withArgs([ethereum.Value.fromUnsignedBigInt(oneShare)])
+      .returns([
+        ethereum.Value.fromUnsignedBigInt(
+          BigInt.fromString("1100000000000000000"),
+        ),
+      ]);
+    createMockedFunction(vaultAddress, "totalAssets", "totalAssets():(uint256)")
+      .withArgs([])
+      .returns([
+        ethereum.Value.fromUnsignedBigInt(
+          BigInt.fromString("6000000000000000000000"),
+        ),
+      ]);
+
     // Second block on the same day: early-returns without RPC calls
     const block2 = createMockBlock(BigInt.fromI32(200), timestamp2);
     handleBlock(block2);

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -211,10 +211,11 @@ describe("handleBlock", function () {
     );
 
     // Second block on a new day: VaultConfig is reused from the store.
-    // Intentionally omit decimals() mock — if the if (vaultConfig == null)
-    // guard were removed, the handler would call decimals() again and fail with
-    // a missing-mock error, making this test a true regression guard for the
-    // cache.
+    // Override the existing decimals() mock to revert; if handleBlock calls
+    // decimals() again instead of using the cached VaultConfig, the test fails.
+    createMockedFunction(vaultAddress, "decimals", "decimals():(uint8)")
+      .withArgs([])
+      .reverts();
     const updatedShareValue = BigInt.fromString("1060000000000000000");
     const updatedTotalAssets = BigInt.fromString("6000000000000000000000");
     const oneShare = BigInt.fromI32(10).pow(<u8>decimals);

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -188,9 +188,23 @@ describe("handleBlock", function () {
     );
 
     // Second block on a new day: VaultConfig is reused from the store.
+    // Intentionally omit decimals() mock — if the if (vaultConfig == null)
+    // guard were removed, the handler would call decimals() again and fail with
+    // a missing-mock error, making this test a true regression guard for the
+    // cache.
     const updatedShareValue = BigInt.fromString("1060000000000000000");
     const updatedTotalAssets = BigInt.fromString("6000000000000000000000");
-    mockVaultCalls(decimals, updatedShareValue, updatedTotalAssets);
+    const oneShare = BigInt.fromI32(10).pow(<u8>decimals);
+    createMockedFunction(
+      vaultAddress,
+      "convertToAssets",
+      "convertToAssets(uint256):(uint256)",
+    )
+      .withArgs([ethereum.Value.fromUnsignedBigInt(oneShare)])
+      .returns([ethereum.Value.fromUnsignedBigInt(updatedShareValue)]);
+    createMockedFunction(vaultAddress, "totalAssets", "totalAssets():(uint256)")
+      .withArgs([])
+      .returns([ethereum.Value.fromUnsignedBigInt(updatedTotalAssets)]);
     const block2 = createMockBlock(BigInt.fromI32(200), timestamp2);
     handleBlock(block2);
 

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -65,7 +65,7 @@ describe("handleBlock", function () {
     dataSourceMock.setAddress(vaultAddressString);
   });
 
-  test("creates VaultHistory for day timestamp", function () {
+  test("creates VaultHistory for previous day timestamp", function () {
     const decimals = 18;
     const currentShareValue = BigInt.fromString("1050000000000000000"); // 1.05 assets per share
     const currentTotalAssets = BigInt.fromString("5000000000000000000000"); // 5000 assets
@@ -75,14 +75,16 @@ describe("handleBlock", function () {
     const block = createMockBlock(BigInt.fromI32(100), timestamp);
     handleBlock(block);
 
+    // Entity is stored under the previous day's timestamp
     const dayTimestamp = timestamp.div(daySeconds).times(daySeconds);
-    const id = `${vaultAddressString}-${dayTimestamp.toString()}`;
+    const previousDayTimestamp = dayTimestamp.minus(daySeconds);
+    const id = `${vaultAddressString}-${previousDayTimestamp.toString()}`;
     assert.entityCount("VaultHistory", 1);
     assert.fieldEquals(
       "VaultHistory",
       id,
       "timestamp",
-      dayTimestamp.toString(),
+      previousDayTimestamp.toString(),
     );
     assert.fieldEquals(
       "VaultHistory",
@@ -104,12 +106,10 @@ describe("handleBlock", function () {
     );
   });
 
-  test("updates VaultHistory on same day", function () {
+  test("skips subsequent blocks on the same day", function () {
     const decimals = 18;
     const initialShareValue = BigInt.fromString("1050000000000000000");
-    const updatedShareValue = BigInt.fromString("1060000000000000000");
     const initialTotalAssets = BigInt.fromString("5000000000000000000000");
-    const updatedTotalAssets = BigInt.fromString("6000000000000000000000");
     const timestamp1 = BigInt.fromI32(1769734800); // 2026-01-30 01:00:00 UTC
     const timestamp2 = BigInt.fromI32(1769774400); // 2026-01-30 12:00:00 UTC
 
@@ -118,31 +118,27 @@ describe("handleBlock", function () {
     handleBlock(block1);
 
     const dayTimestamp = timestamp1.div(daySeconds).times(daySeconds);
-    const id = `${vaultAddressString}-${dayTimestamp.toString()}`;
+    const previousDayTimestamp = dayTimestamp.minus(daySeconds);
+    const id = `${vaultAddressString}-${previousDayTimestamp.toString()}`;
     assert.entityCount("VaultHistory", 1);
 
-    mockVaultCalls(decimals, updatedShareValue, updatedTotalAssets);
+    // Second block on the same day: early-returns without RPC calls
     const block2 = createMockBlock(BigInt.fromI32(200), timestamp2);
     handleBlock(block2);
 
+    // Still only one entity with the original values
     assert.entityCount("VaultHistory", 1);
     assert.fieldEquals(
       "VaultHistory",
       id,
       "shareValue",
-      updatedShareValue.toString(),
+      initialShareValue.toString(),
     );
     assert.fieldEquals(
       "VaultHistory",
       id,
       "totalAssets",
-      updatedTotalAssets.toString(),
-    );
-    assert.fieldEquals(
-      "VaultHistory",
-      id,
-      "timestamp",
-      dayTimestamp.toString(),
+      initialTotalAssets.toString(),
     );
   });
 
@@ -174,8 +170,9 @@ describe("handleBlock", function () {
     const decimals = 18;
     const shareValue = BigInt.fromString("1050000000000000000");
     const totalAssets = BigInt.fromString("5000000000000000000000");
-    const timestamp1 = BigInt.fromI32(1769731200); // day 1
-    const timestamp2 = BigInt.fromI32(1769817600); // day 2
+    // Two timestamps on different days so both produce a VaultHistory entity
+    const timestamp1 = BigInt.fromI32(1769731200); // 2026-01-30 00:00:00 UTC
+    const timestamp2 = BigInt.fromI32(1769817600); // 2026-01-31 00:00:00 UTC
 
     mockVaultCalls(decimals, shareValue, totalAssets);
     const block1 = createMockBlock(BigInt.fromI32(100), timestamp1);
@@ -190,15 +187,14 @@ describe("handleBlock", function () {
       decimals.toString(),
     );
 
-    // Second block: decimals() mock is not needed anymore since VaultConfig is cached.
-    // Re-mock only convertToAssets and totalAssets for the second block.
+    // Second block on a new day: VaultConfig is reused from the store.
     const updatedShareValue = BigInt.fromString("1060000000000000000");
     const updatedTotalAssets = BigInt.fromString("6000000000000000000000");
     mockVaultCalls(decimals, updatedShareValue, updatedTotalAssets);
     const block2 = createMockBlock(BigInt.fromI32(200), timestamp2);
     handleBlock(block2);
 
-    // Still only one VaultConfig entity
+    // Still only one VaultConfig entity, two VaultHistory entities (one per day)
     assert.entityCount("VaultConfig", 1);
     assert.entityCount("VaultHistory", 2);
   });

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -169,6 +169,39 @@ describe("handleBlock", function () {
 
     assert.entityCount("VaultHistory", 0);
   });
+
+  test("creates VaultConfig on first block and reuses it on subsequent blocks", function () {
+    const decimals = 18;
+    const shareValue = BigInt.fromString("1050000000000000000");
+    const totalAssets = BigInt.fromString("5000000000000000000000");
+    const timestamp1 = BigInt.fromI32(1769731200); // day 1
+    const timestamp2 = BigInt.fromI32(1769817600); // day 2
+
+    mockVaultCalls(decimals, shareValue, totalAssets);
+    const block1 = createMockBlock(BigInt.fromI32(100), timestamp1);
+    handleBlock(block1);
+
+    // VaultConfig entity should be created with the correct decimals
+    assert.entityCount("VaultConfig", 1);
+    assert.fieldEquals(
+      "VaultConfig",
+      vaultAddressString,
+      "decimals",
+      decimals.toString(),
+    );
+
+    // Second block: decimals() mock is not needed anymore since VaultConfig is cached.
+    // Re-mock only convertToAssets and totalAssets for the second block.
+    const updatedShareValue = BigInt.fromString("1060000000000000000");
+    const updatedTotalAssets = BigInt.fromString("6000000000000000000000");
+    mockVaultCalls(decimals, updatedShareValue, updatedTotalAssets);
+    const block2 = createMockBlock(BigInt.fromI32(200), timestamp2);
+    handleBlock(block2);
+
+    // Still only one VaultConfig entity
+    assert.entityCount("VaultConfig", 1);
+    assert.entityCount("VaultHistory", 2);
+  });
 });
 
 describe("handleDeposit", function () {


### PR DESCRIPTION
With these changes, each block handler is called 24 times instead of 7,200 per day and the RPC calls are 20k per day down to 2 (+1 for the very first block).

### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This pull request optimizes the subgraph’s block handler for vault history tracking by minimizing redundant RPC calls and entity writes, improving sync performance. It introduces a new `VaultConfig` entity to cache immutable vault configuration, updates history entity creation logic to align with previous behavior, and adds polling filters to block handlers. Tests are updated and expanded to cover these changes.

**Performance improvements and entity caching:**

* Added a new `VaultConfig` entity to cache the vault's `decimals` value, avoiding repeated contract calls on every block. The handler now creates this entity on the first block and reuses it thereafter. (`subgraph/schema.graphql` [[1]](diffhunk://#diff-926c12552c61d07ab911f5aba9c3fd53c3dfb9d9b241e1df16830218ac04988fR37-R41) `subgraph/src/earn.ts` [[2]](diffhunk://#diff-21fb7fcabbd216361917473329a8f2b8f8204e46e9cc18ff473fdca61ca48e9eR7) [[3]](diffhunk://#diff-21fb7fcabbd216361917473329a8f2b8f8204e46e9cc18ff473fdca61ca48e9eR40-L62) `subgraph/subgraph.yaml` [[4]](diffhunk://#diff-0cc4fa799cfb6dbc92f2d5c7aa278af22f8193196014b448d5ad734aff14e977R22) [[5]](diffhunk://#diff-0cc4fa799cfb6dbc92f2d5c7aa278af22f8193196014b448d5ad734aff14e977R59) [[6]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2R168-R200)
* Changed `VaultHistory` and `VaultConfig` entities to be immutable for consistency and potential performance benefits. (`subgraph/schema.graphql` [[1]](diffhunk://#diff-926c12552c61d07ab911f5aba9c3fd53c3dfb9d9b241e1df16830218ac04988fL1-R1) [[2]](diffhunk://#diff-926c12552c61d07ab911f5aba9c3fd53c3dfb9d9b241e1df16830218ac04988fR37-R41)

**Vault history logic updates:**

* Adjusted `VaultHistory` creation to use the previous day's timestamp, ensuring alignment with the prior implementation and preventing multiple history records per day. (`subgraph/src/earn.ts` [[1]](diffhunk://#diff-21fb7fcabbd216361917473329a8f2b8f8204e46e9cc18ff473fdca61ca48e9eR40-L62) `subgraph/tests/earn.test.ts` [[2]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L68-R68) [[3]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2R78-R87) [[4]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L107-L112) [[5]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L121-R141)

**Handler and sync optimizations:**

* Added a polling filter to the block handler to run every 300 blocks (about once per hour), reducing unnecessary handler invocations and further improving sync speed. (`subgraph/subgraph.yaml` [[1]](diffhunk://#diff-0cc4fa799cfb6dbc92f2d5c7aa278af22f8193196014b448d5ad734aff14e977R40-R42) [[2]](diffhunk://#diff-0cc4fa799cfb6dbc92f2d5c7aa278af22f8193196014b448d5ad734aff14e977R77-R79)

**Testing improvements:**

* Updated and expanded tests to verify new logic, including correct timestamp usage, entity creation, and `VaultConfig` caching and reuse. (`subgraph/tests/earn.test.ts` [[1]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L68-R68) [[2]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2R78-R87) [[3]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L107-L112) [[4]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L121-R141) [[5]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2R168-R200)

**Notes**

- The subgraph's version was bumped using the "pride versioning" scheme for the default pride/shame ratio.
- As the vault history is saved at the beginning of each day, a query will no longer return data from "today" until "tomorrow". The consumer (i.e. UI) could handle that by querying the current values from the contracts if needed.

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.