### PR TITLE
Add Playwright e2e tests with non-blocking CI workflow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,12 @@
       }
     },
     {
+      "files": ["packages/mock-wallet/**/*.ts"],
+      "rules": {
+        "camelcase": ["warn", { "allow": ["^eth_", "^personal_", "^wallet_"] }]
+      }
+    },
+    {
       "files": ["landing/**/*.ts", "packages/**/*.{js,ts,tsx}"],
       "rules": {
         "complexity": ["warn", { "max": 20 }]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,12 @@
       }
     },
     {
+      "files": ["web/e2e/**/*.ts"],
+      "rules": {
+        "@vitest/require-hook": "off"
+      }
+    },
+    {
       "files": ["packages/mock-wallet/**/*.ts"],
       "rules": {
         "camelcase": ["warn", { "allow": ["^eth_", "^personal_", "^wallet_"] }]

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - run: pnpm --filter @vetro-protocol/web exec playwright install chromium
         env:
           DEBUG: pw:install
-      - run: pnpm --filter @vetro-protocol/web run test:e2e
+      - run: pnpm --filter @vetro-protocol/web exec playwright test
         env:
           DEBUG: pw:webserver
       - if: ${{ !cancelled() }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,41 @@
+# Kept as its own workflow, intentionally separate from js-checks, so it is NOT
+# part of the branch's required status checks while the e2e tests may still be
+# flaky. Once they prove stable, we may add "E2E Tests" to the required checks, or merge
+# with js-checks
+name: E2E Tests
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  run-e2e-tests:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: hemilabs/actions/setup-node-env@8f87619b7f0122c39e14a32514ab3e4e0d4c3966 # v2.3.0
+        with:
+          package-manager: pnpm
+      - run: pnpm --filter @vetro-protocol/web exec playwright install-deps chromium
+      - run: pnpm --filter @vetro-protocol/web exec playwright install chromium
+        env:
+          DEBUG: pw:install
+      - run: pnpm --filter @vetro-protocol/web run test:e2e
+        env:
+          DEBUG: pw:webserver
+      - if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 5
+    timeout-minutes: 10

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,13 +6,12 @@ name: E2E Tests
 
 on:
   pull_request:
-  push:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ Thumbs.db
 # Testing
 coverage/
 .nyc_output/
+playwright-report/
+test-results/
 
 # Cache
 .eslintcache

--- a/packages/gateway/src/abi/gatewayAbi.ts
+++ b/packages/gateway/src/abi/gatewayAbi.ts
@@ -74,6 +74,13 @@ export const gatewayAbi = [
   },
   {
     inputs: [{ name: "account_", type: "address" }],
+    name: "addToInstantRedeemWhitelist",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ name: "account_", type: "address" }],
     name: "removeFromInstantRedeemWhitelist",
     outputs: [],
     stateMutability: "nonpayable",

--- a/packages/mock-wallet/package.json
+++ b/packages/mock-wallet/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@vetro-protocol/mock-wallet",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.60.0",
+    "@tsconfig/node24": "24.0.4",
+    "typescript": "5.9.3",
+    "viem": "2.44.4"
+  },
+  "peerDependencies": {
+    "@playwright/test": "^1.x",
+    "viem": "^2.x"
+  },
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/packages/mock-wallet/src/index.ts
+++ b/packages/mock-wallet/src/index.ts
@@ -1,0 +1,126 @@
+import type { Page } from "@playwright/test";
+import {
+  type Chain,
+  type Hex,
+  type LocalAccount,
+  type Transport,
+  createWalletClient,
+} from "viem";
+
+const REQUEST_BINDING = "__mockWalletRequest";
+
+type RpcRequest = { method: string; params?: unknown[] };
+
+// Methods that return a fixed value, independent of params. Keeping them out
+// of the switch keeps request()'s complexity within the lint threshold.
+const staticResponses: Record<string, unknown> = {
+  wallet_getPermissions: [],
+  wallet_requestPermissions: [{ parentCapability: "eth_accounts" }],
+  wallet_revokePermissions: [{ parentCapability: "eth_accounts" }],
+  // The fork is a single mainnet chain; accept switch requests so RainbowKit's
+  // connect flow doesn't error, but do not actually move.
+  wallet_switchEthereumChain: null,
+};
+
+type CreateWalletParams = {
+  account: LocalAccount;
+  chain: Chain;
+  transports: Record<number, Transport>;
+};
+
+type MockWallet = {
+  request: (request: RpcRequest) => Promise<unknown>;
+};
+
+function createWallet({
+  account,
+  chain,
+  transports,
+}: CreateWalletParams): MockWallet {
+  const transport = transports[chain.id];
+  if (!transport) {
+    // Never fall back to viem's default public RPC — a missing entry would
+    // silently point the wallet at the real network instead of the fork.
+    throw new Error(`No transport configured for chain ${chain.id}`);
+  }
+  const client = createWalletClient({
+    account,
+    chain,
+    transport,
+  });
+  return {
+    async request({ method, params }) {
+      if (method in staticResponses) {
+        return staticResponses[method];
+      }
+      switch (method) {
+        case "eth_accounts":
+        case "eth_requestAccounts":
+          return client.getAddresses();
+        case "personal_sign":
+          return client.signMessage({
+            message: { raw: (params as [Hex])[0] },
+          });
+        case "eth_sendTransaction": {
+          const [tx] = params as [
+            { data?: Hex; from: Hex; to: Hex; value?: Hex },
+          ];
+          if (tx.from.toLowerCase() !== account.address.toLowerCase()) {
+            throw new Error("Invalid from address");
+          }
+          return client.sendTransaction({
+            data: tx.data,
+            to: tx.to,
+            value: tx.value ? BigInt(tx.value) : undefined,
+          });
+        }
+        default:
+          // @ts-expect-error EIP-1193 passthrough — viem's request() is typed
+          // as a discriminated union of known methods.
+          return client.request({ method, params });
+      }
+    },
+  };
+}
+
+type InstallMockWalletParams = CreateWalletParams & { page: Page };
+
+export async function installMockWallet({
+  page,
+  ...walletParams
+}: InstallMockWalletParams) {
+  const wallet = createWallet(walletParams);
+
+  await page.exposeFunction(REQUEST_BINDING, (request: RpcRequest) =>
+    wallet.request(request),
+  );
+
+  await page.addInitScript(
+    function ({ bindingName }: { bindingName: string }) {
+      const request = (window as unknown as Record<string, unknown>)[
+        bindingName
+      ] as (req: { method: string; params?: unknown[] }) => Promise<unknown>;
+      const provider = {
+        on() {},
+        removeListener() {},
+        request,
+      };
+      const info = {
+        icon: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24'/>",
+        name: "Mock Wallet",
+        rdns: "com.example.mock-wallet",
+        uuid: crypto.randomUUID(),
+      };
+      const detail = Object.freeze({ info, provider });
+      function announce() {
+        window.dispatchEvent(
+          new CustomEvent("eip6963:announceProvider", { detail }),
+        );
+      }
+      announce();
+      window.addEventListener("eip6963:requestProvider", announce);
+      window.addEventListener("DOMContentLoaded", announce);
+    },
+    { bindingName: REQUEST_BINDING },
+  );
+}

--- a/packages/mock-wallet/src/index.ts
+++ b/packages/mock-wallet/src/index.ts
@@ -50,7 +50,7 @@ function createWallet({
   });
   return {
     async request({ method, params }) {
-      if (method in staticResponses) {
+      if (Object.hasOwn(staticResponses, method)) {
         return staticResponses[method];
       }
       switch (method) {

--- a/packages/mock-wallet/tsconfig.json
+++ b/packages/mock-wallet/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "erasableSyntaxOnly": true,
+    "lib": ["es2024", "DOM", "DOM.Iterable"],
+    "noEmit": true
+  },
+  "exclude": ["node_modules"],
+  "extends": "@tsconfig/node24/tsconfig.json",
+  "include": ["**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,6 +387,12 @@ importers:
       '@cloudflare/workers-types':
         specifier: 4.20260504.1
         version: 4.20260504.1
+      '@hemilabs/anvil-fork-setup':
+        specifier: 2.0.0
+        version: 2.0.0(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.4))
+      '@playwright/test':
+        specifier: 1.60.0
+        version: 1.60.0
       '@sentry/vite-plugin':
         specifier: 5.3.0
         version: 5.3.0(encoding@0.1.13)(rollup@4.55.3)
@@ -414,6 +420,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.9)
+      '@vetro-protocol/mock-wallet':
+        specifier: workspace:*
+        version: link:../packages/mock-wallet
       '@vitejs/plugin-react':
         specifier: 6.0.1
         version: 6.0.1(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
@@ -1320,6 +1329,15 @@ packages:
 
   '@graphprotocol/graph-ts@0.38.2':
     resolution: {integrity: sha512-87KIFSFs2+Te+mnmb7Y+M57oqzlLy20cIyPIRbn9qJfpZFSZHTKtBLT6KQmcsK0YkoWis9Ur3c3M2c9mmaaEHQ==, tarball: https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.38.2.tgz}
+
+  '@hemilabs/anvil-fork-setup@2.0.0':
+    resolution: {integrity: sha512-zgYiJIsHEnuPw/soowX0nma7NhfX7SsxTFyxF0yl0shO8pI/YJXHeKtkVJX1S0f62P2HsXelQ/4Cz6bWfqS7+A==, tarball: https://registry.npmjs.org/@hemilabs/anvil-fork-setup/-/anvil-fork-setup-2.0.0.tgz}
+    engines: {node: '>=20'}
+    peerDependencies:
+      vitest: '>=4'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
 
   '@hemilabs/react-hooks@1.6.0':
     resolution: {integrity: sha512-1kHDMUO0QIa4ZfiUTs3P5N3C08wq+B8GESqQXQPn34pVKuoZ5vU1NGtUqFGttSP5CgnUYX0ny0BmwyPINrCiVw==, tarball: https://registry.npmjs.org/@hemilabs/react-hooks/-/react-hooks-1.6.0.tgz}
@@ -9849,6 +9867,10 @@ snapshots:
   '@graphprotocol/graph-ts@0.38.2':
     dependencies:
       assemblyscript: 0.27.31
+
+  '@hemilabs/anvil-fork-setup@2.0.0(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.4))':
+    optionalDependencies:
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.4)
 
   '@hemilabs/react-hooks@1.6.0(@hemilabs/wallet-watch-asset@1.0.2(patch_hash=933b0ee20c3f95b39d12cd9f25e1175fef9353a7ef2d91378cafd55f2efec0fc))(@tanstack/react-query@5.90.19(react@19.2.3))(react@19.2.3)(viem-erc20@2.1.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(@tanstack/query-core@5.90.19)(@tanstack/react-query@5.90.19(react@19.2.3))(@types/react@19.2.9)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,21 @@ importers:
         specifier: 4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.4)
 
+  packages/mock-wallet:
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.60.0
+        version: 1.60.0
+      '@tsconfig/node24':
+        specifier: 24.0.4
+        version: 24.0.4
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      viem:
+        specifier: 2.44.4
+        version: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+
   packages/morpho-blue-market:
     dependencies:
       to-promise-event:
@@ -2240,6 +2255,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==, tarball: https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==, tarball: https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==, tarball: https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz}
@@ -5535,6 +5555,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==, tarball: https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -7107,6 +7132,16 @@ packages:
   pkg-dir@5.0.0:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==, tarball: https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz}
     engines: {node: '>=10'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==, tarball: https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==, tarball: https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==, tarball: https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz}
@@ -10126,7 +10161,7 @@ snapshots:
     dependencies:
       '@libp2p/interface': 3.1.0
       '@noble/curves': 2.0.1
-      '@noble/hashes': 2.0.1
+      '@noble/hashes': 2.2.0
       multiformats: 13.4.2
       protons-runtime: 5.6.0
       uint8arraylist: 2.4.8
@@ -10747,6 +10782,10 @@ snapshots:
   '@pinax/graph-networks-registry@0.7.1': {}
 
   '@pkgr/core@0.2.9': {}
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -15095,6 +15134,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -15126,7 +15168,7 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       function-bind: 1.1.2
       get-proto: 1.0.1
       gopd: 1.2.0
@@ -15565,7 +15607,7 @@ snapshots:
 
   is-nan@1.3.2:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
 
   is-natural-number@4.0.1: {}
@@ -16419,14 +16461,14 @@ snapshots:
 
   object-is@1.1.6:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
   object.assign@4.1.7:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
@@ -16814,6 +16856,14 @@ snapshots:
   pkg-dir@5.0.0:
     dependencies:
       find-up: 5.0.0
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 
@@ -18706,7 +18756,7 @@ snapshots:
   which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       for-each: 0.3.5
       get-proto: 1.0.1

--- a/web/e2e/anvil.ts
+++ b/web/e2e/anvil.ts
@@ -1,0 +1,2 @@
+export const ANVIL_PORT = 8545;
+export const ANVIL_URL = `http://127.0.0.1:${ANVIL_PORT}`;

--- a/web/e2e/fixtures/wallet.ts
+++ b/web/e2e/fixtures/wallet.ts
@@ -1,0 +1,23 @@
+import { TEST_PRIVATE_KEY } from "@hemilabs/anvil-fork-setup/utils";
+import { test as base } from "@playwright/test";
+import { installMockWallet } from "@vetro-protocol/mock-wallet";
+import { http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { mainnet } from "viem/chains";
+
+import { ANVIL_URL } from "../anvil";
+
+// `installMockWallet` injects an EIP-6963-announcing EIP-1193 provider into
+// the page before the dApp scripts run. RainbowKit then sees the wallet via
+// EIP-6963 and connects silently — no extension popup, no confirm clicks.
+export const test = base.extend({
+  async page({ page }, use) {
+    await installMockWallet({
+      account: privateKeyToAccount(TEST_PRIVATE_KEY),
+      chain: mainnet,
+      page,
+      transports: { [mainnet.id]: http(ANVIL_URL) },
+    });
+    await use(page);
+  },
+});

--- a/web/e2e/global-setup.ts
+++ b/web/e2e/global-setup.ts
@@ -1,0 +1,29 @@
+import { startAnvilFork } from "@hemilabs/anvil-fork-setup";
+import { TEST_ADDRESS } from "@hemilabs/anvil-fork-setup/utils";
+import { mainnet } from "viem/chains";
+
+import { fundAccount } from "../scripts/fundAccount.ts";
+
+import { ANVIL_PORT } from "./anvil.ts";
+
+// Reuse the app's committed RPC config as the fork upstream — anvil cannot
+// fork from viem's default public RPC (rate-limited). Vite only loads .env
+// for the app itself; globalSetup runs in plain Node, so load it explicitly.
+// loadEnvFile never overrides existing vars, so real env vars still win.
+process.loadEnvFile(new URL("../.env", import.meta.url));
+
+export default async function globalSetup() {
+  const { stop, url } = await startAnvilFork({
+    chainId: mainnet.id,
+    forkUrl:
+      process.env.VITE_RPC_URL_MAINNET ?? mainnet.rpcUrls.default.http[0],
+    port: ANVIL_PORT,
+  });
+  try {
+    await fundAccount({ address: TEST_ADDRESS, forkUrl: url });
+  } catch (error) {
+    await stop();
+    throw error;
+  }
+  return stop;
+}

--- a/web/e2e/swap.spec.ts
+++ b/web/e2e/swap.spec.ts
@@ -1,0 +1,110 @@
+import { TEST_ADDRESS } from "@hemilabs/anvil-fork-setup/utils";
+import { expect } from "@playwright/test";
+import { createPublicClient, http, parseUnits } from "viem";
+import { mainnet } from "viem/chains";
+import { balanceOf } from "viem-erc20/actions";
+
+import { knownTokens } from "../src/utils/tokenList.ts";
+
+import { ANVIL_URL } from "./anvil";
+import { test } from "./fixtures/wallet";
+
+function getMainnetToken(symbol: string) {
+  const token = knownTokens.find(
+    (t) => t.chainId === mainnet.id && t.symbol === symbol,
+  );
+  if (!token) {
+    throw new Error(`Token ${symbol} not found in tokenList for mainnet`);
+  }
+  return token;
+}
+
+const usdc = getMainnetToken("USDC");
+const vusd = getMainnetToken("VUSD");
+const SWAP_AMOUNT_DISPLAY = "1";
+const SWAP_AMOUNT = parseUnits(SWAP_AMOUNT_DISPLAY, usdc.decimals);
+
+test("swap USDC → VUSD via the gateway", async function ({ page }) {
+  const publicClient = createPublicClient({
+    chain: mainnet,
+    transport: http(ANVIL_URL),
+  });
+
+  const [usdcBefore, vusdBefore] = await Promise.all([
+    balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: usdc.address,
+    }),
+    balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: vusd.address,
+    }),
+  ]);
+
+  await page.goto("/swap");
+
+  // Two "Connect wallet" buttons: header trigger + form submit (disabled).
+  await page
+    .getByRole("button", { name: /connect wallet/i })
+    .first()
+    .click();
+
+  // The mock wallet announces EIP-6963 with rdns "com.example.mock-wallet".
+  // The modal occasionally re-renders as new providers announce, so click
+  // with force to bypass the stability check.
+  await page
+    .getByTestId("rk-wallet-option-com.example.mock-wallet")
+    .click({ force: true });
+
+  // Header button switches from "Connect wallet" to a 0x… short address.
+  await expect(
+    page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // Pick USDC as the input token. The trigger opens a modal dialog where
+  // tokens are listed as buttons (pinned grid + rows), not ARIA options.
+  await page
+    .getByRole("button", { name: "Select token to swap" })
+    .first()
+    .click();
+  const tokenDialog = page.getByRole("dialog");
+  // The modal fades in via an opacity transition. Playwright's visibility
+  // check ignores opacity, so it would otherwise click a token mid-animation
+  // and race the open/close state, leaving the modal stuck open and blocking
+  // the Swap click. Wait for the entrance to finish before selecting.
+  await expect(tokenDialog).toHaveCSS("opacity", "1");
+  await tokenDialog.getByRole("button", { name: /USDC/ }).first().click();
+  // Ensure the modal is gone before interacting with the form underneath.
+  await expect(tokenDialog).toBeHidden();
+
+  await page
+    .locator('input[type="text"]:not([disabled])')
+    .first()
+    .fill(SWAP_AMOUNT_DISPLAY);
+
+  await page.getByRole("button", { name: /^swap$/i }).click();
+
+  // The success toast renders once the deposit tx is confirmed on the fork.
+  await expect(page.getByText("Deposit confirmed")).toBeVisible({
+    timeout: 40_000,
+  });
+
+  // No popups — the mock wallet signs and forwards to Anvil silently.
+  // Assert by polling balances directly against the fork.
+  await expect
+    .poll(
+      async () =>
+        balanceOf(publicClient, {
+          account: TEST_ADDRESS,
+          address: vusd.address,
+        }),
+      { timeout: 20_000 },
+    )
+    .toBeGreaterThan(vusdBefore);
+
+  const usdcAfter = await balanceOf(publicClient, {
+    account: TEST_ADDRESS,
+    address: usdc.address,
+  });
+  expect(usdcAfter).toBe(usdcBefore - SWAP_AMOUNT);
+});

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run",
     "pretest:e2e": "playwright install chromium",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --headed",
+    "test:e2e:ui": "pnpm run test:e2e --headed",
     "tsc": "tsc"
   },
   "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,9 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
     "test": "vitest run",
+    "pretest:e2e": "playwright install chromium",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --headed",
     "tsc": "tsc"
   },
   "dependencies": {
@@ -45,6 +48,8 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.23.1",
     "@cloudflare/workers-types": "4.20260504.1",
+    "@hemilabs/anvil-fork-setup": "2.0.0",
+    "@playwright/test": "1.60.0",
     "@sentry/vite-plugin": "5.3.0",
     "@storybook/react": "10.2.1",
     "@storybook/react-vite": "10.2.1",
@@ -54,6 +59,7 @@
     "@types/node": "24.1.0",
     "@types/react": "19.2.9",
     "@types/react-dom": "19.2.3",
+    "@vetro-protocol/mock-wallet": "workspace:*",
     "@vitejs/plugin-react": "6.0.1",
     "storybook": "10.2.1",
     "tailwindcss": "4.3.0",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   // (failures are already printed to the console by the list reporter).
   reporter: [
     ["list"],
+    ["github"],
     ["html", { open: process.env.CI ? "never" : "on-failure" }],
   ],
   testDir: "./e2e",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from "@playwright/test";
+
+import { ANVIL_URL } from "./e2e/anvil";
+
+// Distinct from the default 5173 so a developer's running `pnpm dev` doesn't
+// get reused with the wrong env (we need VITE_RPC_URL_MAINNET pointing at the
+// fork, which only takes effect when Playwright spawns Vite itself).
+const PORT = 5174;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  fullyParallel: false,
+  globalSetup: "./e2e/global-setup.ts",
+  // Locally the HTML report auto-opens on failure; on CI it never opens
+  // (failures are already printed to the console by the list reporter).
+  reporter: [
+    ["list"],
+    ["html", { open: process.env.CI ? "never" : "on-failure" }],
+  ],
+  testDir: "./e2e",
+  testMatch: /.*\.spec\.ts$/,
+  timeout: 120_000,
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: `pnpm dev --port ${PORT} --strictPort`,
+    env: {
+      // Swap/redeem is fully on-chain; the backend APIs only supply USD display
+      // values. Disable them so e2e stays hermetic (prices render as $0, which
+      // these tests don't assert on). isValidUrl("") is false → query disabled.
+      VITE_PORTAL_API_URL: "",
+      VITE_RPC_URL_MAINNET: ANVIL_URL,
+      VITE_VETRO_API_URL: "",
+    },
+    reuseExistingServer: false,
+    timeout: 120_000,
+    url: BASE_URL,
+  },
+  workers: 1,
+});

--- a/web/scripts/fundAccount.ts
+++ b/web/scripts/fundAccount.ts
@@ -1,0 +1,106 @@
+import {
+  type Address,
+  createPublicClient,
+  createTestClient,
+  encodePacked,
+  formatEther,
+  http,
+  keccak256,
+  pad,
+  parseEther,
+  toHex,
+} from "viem";
+import { getBalance, setBalance, setStorageAt } from "viem/actions";
+import { mainnet } from "viem/chains";
+import { balanceOf } from "viem-erc20/actions";
+
+import { knownTokens } from "../src/utils/tokenList.ts";
+
+export const defaultSetupSymbols = [
+  "cbBTC",
+  "hemiBTC",
+  "USDC",
+  "USDT",
+  "vetBTC",
+  "VUSD",
+  "WBTC",
+  "WETH",
+];
+
+type FundableToken = {
+  address: Address;
+  balanceSlot: number;
+  decimals: number;
+  symbol: string;
+};
+
+const getDefaultTokens = (): FundableToken[] =>
+  knownTokens
+    .filter(
+      (t) => t.chainId === mainnet.id && defaultSetupSymbols.includes(t.symbol),
+    )
+    .map((t) => ({
+      address: t.address,
+      balanceSlot: t.extensions!.balanceSlot!,
+      decimals: t.decimals,
+      symbol: t.symbol,
+    }));
+
+export async function fundAccount({
+  address,
+  amount = 100n,
+  forkUrl = "http://127.0.0.1:8545",
+  tokens = getDefaultTokens(),
+}: {
+  address: Address;
+  amount?: bigint;
+  forkUrl?: string;
+  tokens?: FundableToken[];
+}) {
+  const transport = http(forkUrl);
+
+  const publicClient = createPublicClient({ chain: mainnet, transport });
+  const testClient = createTestClient({
+    chain: mainnet,
+    mode: "anvil",
+    transport,
+  });
+
+  const ethBalanceBefore = await getBalance(publicClient, { address });
+  await setBalance(testClient, { address, value: parseEther("1") });
+  const ethBalanceAfter = await getBalance(publicClient, { address });
+  console.log(
+    `ETH: ${formatEther(ethBalanceBefore)} -> ${formatEther(ethBalanceAfter)}`,
+  );
+
+  for (const token of tokens) {
+    const balanceBefore = await balanceOf(publicClient, {
+      account: address,
+      address: token.address,
+    });
+
+    const value = amount * 10n ** BigInt(token.decimals);
+
+    const storageKey = keccak256(
+      encodePacked(
+        ["bytes32", "bytes32"],
+        [pad(address), pad(toHex(token.balanceSlot))],
+      ),
+    );
+
+    await setStorageAt(testClient, {
+      address: token.address,
+      index: storageKey,
+      value: pad(toHex(value)),
+    });
+
+    const balanceAfter = await balanceOf(publicClient, {
+      account: address,
+      address: token.address,
+    });
+
+    console.log(
+      `${token.symbol}: ${balanceBefore} -> ${balanceAfter} (${amount} tokens)`,
+    );
+  }
+}

--- a/web/scripts/setup.ts
+++ b/web/scripts/setup.ts
@@ -1,43 +1,7 @@
 import { parseArgs } from "node:util";
-import {
-  createPublicClient,
-  createTestClient,
-  encodePacked,
-  formatEther,
-  http,
-  isAddress,
-  keccak256,
-  pad,
-  parseEther,
-  toHex,
-} from "viem";
-import { getBalance, setBalance, setStorageAt } from "viem/actions";
-import { mainnet } from "viem/chains";
-import { balanceOf } from "viem-erc20/actions";
+import { isAddress } from "viem";
 
-import { knownTokens } from "../src/utils/tokenList.ts";
-
-const setupSymbols = [
-  "cbBTC",
-  "hemiBTC",
-  "USDC",
-  "USDT",
-  "vetBTC",
-  "VUSD",
-  "WBTC",
-  "WETH",
-];
-
-const tokens = knownTokens
-  .filter((t) => t.chainId === mainnet.id && setupSymbols.includes(t.symbol))
-  .map((t) => ({
-    address: t.address,
-    balanceSlot: t.extensions!.balanceSlot!,
-    decimals: t.decimals,
-    symbol: t.symbol,
-  }));
-
-const amount = 100n;
+import { fundAccount } from "./fundAccount.ts";
 
 const { values } = parseArgs({
   options: {
@@ -47,8 +11,6 @@ const { values } = parseArgs({
   strict: true,
 });
 
-const forkUrl = values["fork-url"] ?? "http://127.0.0.1:8545";
-
 if (!values.address || !isAddress(values.address, { strict: false })) {
   console.error(
     "Address is invalid. Usage: node web/scripts/setup.ts --address 0xYourAddress",
@@ -56,57 +18,7 @@ if (!values.address || !isAddress(values.address, { strict: false })) {
   process.exit(1);
 }
 
-const { address } = values;
-
-const transport = http(forkUrl);
-
-const publicClient = createPublicClient({
-  chain: mainnet,
-  transport,
+await fundAccount({
+  address: values.address,
+  forkUrl: values["fork-url"],
 });
-
-const testClient = createTestClient({
-  chain: mainnet,
-  mode: "anvil",
-  transport,
-});
-
-// Fund 1 ETH for gas
-const ethBalanceBefore = await getBalance(publicClient, { address });
-await setBalance(testClient, { address, value: parseEther("1") });
-const ethBalanceAfter = await getBalance(publicClient, { address });
-console.log(
-  `ETH: ${formatEther(ethBalanceBefore)} -> ${formatEther(ethBalanceAfter)}`,
-);
-
-for (const token of tokens) {
-  const balanceBefore = await balanceOf(publicClient, {
-    account: address,
-    address: token.address,
-  });
-
-  const value = amount * 10n ** BigInt(token.decimals);
-
-  // keccak256(abi.encode(address, slot)) - standard Solidity mapping layout
-  const storageKey = keccak256(
-    encodePacked(
-      ["bytes32", "bytes32"],
-      [pad(address), pad(toHex(token.balanceSlot))],
-    ),
-  );
-
-  await setStorageAt(testClient, {
-    address: token.address,
-    index: storageKey,
-    value: pad(toHex(value)),
-  });
-
-  const balanceAfter = await balanceOf(publicClient, {
-    account: address,
-    address: token.address,
-  });
-
-  console.log(
-    `${token.symbol}: ${balanceBefore} -> ${balanceAfter} (${amount} tokens)`,
-  );
-}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -5,6 +5,13 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["reset.d.ts", "scripts", "src", "test"],
+  "include": [
+    "e2e",
+    "playwright.config.ts",
+    "reset.d.ts",
+    "scripts",
+    "src",
+    "test"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,9 +1,10 @@
 import tsconfigPaths from "vite-tsconfig-paths";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     clearMocks: true,
+    exclude: ["e2e/**", ...configDefaults.exclude],
   },
 });


### PR DESCRIPTION
### Description

Adds end-to-end testing with Playwright that drives the app against an Anvil mainnet fork, plus a dedicated CI workflow to run it.

- e2e suite under `web/e2e` covering swap/redeem flows. `global-setup` boots an Anvil fork via `@hemilabs/anvil-fork-setup`, `fundAccount` seeds balances, and `playwright.config` spins up Vite on an isolated port (5174) pointed at the fork.
- New `@vetro-protocol/mock-wallet` package providing a headless wallet for the tests.
- A separate **"E2E Tests"** GitHub Actions workflow, kept independent from `js-checks`.

**⚠️ These e2e tests are new and may be flaky for now.** They run in their own workflow and are intentionally **not** added to the branch's required status checks — a failing e2e run will **not** block merging. More tests will be added in follow-ups; once they prove stable we can promote the workflow to a required check (or fold it into `js-checks`).

**Commits:**

420ad95 Add Playwright e2e tests with CI workflow
d9b9b49 Add @vetro-protocol/mock-wallet package

### Screenshots

https://github.com/user-attachments/assets/79c55b41-aafd-434a-a265-785aa15427fc

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A. _(N/A)_
- [x] Environment variables set in CI, or N/A. _(N/A — fork RPC comes from committed `web/.env`)_
