### PR TITLE
Make Earn pool contract address a link

### DIFF
--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -1,5 +1,4 @@
 import { ExternalLink } from "components/base/externalLink";
-import { ExternalLinkIcon } from "components/icons/externalLinkIcon";
 import { TokenLogo } from "components/tokenLogo";
 import { useApy } from "hooks/useApy";
 import { useMainnet } from "hooks/useMainnet";
@@ -76,11 +75,10 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
         <PoolInfoItem label="Token" value={peggedToken?.symbol} />
         <PoolInfoItem label={t("pages.earn.pool-info.pool-contract")}>
           <ExternalLink
-            className="text-xsm flex items-center gap-1 font-semibold text-gray-700 transition-colors hover:text-gray-900 [&:hover>svg]:text-gray-900 [&>svg]:text-gray-700 [&>svg]:transition-colors"
+            className="text-xsm font-semibold text-gray-600 transition-colors hover:text-gray-900"
             href={`${explorerBaseUrl}/address/${stakingVaultAddress}`}
           >
             {formatEvmAddress(stakingVaultAddress)}
-            <ExternalLinkIcon />
           </ExternalLink>
         </PoolInfoItem>
         <PoolInfoItem

--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -76,7 +76,7 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
         <PoolInfoItem label="Token" value={peggedToken?.symbol} />
         <PoolInfoItem label={t("pages.earn.pool-info.pool-contract")}>
           <ExternalLink
-            className="text-xsm flex items-center gap-1 font-semibold text-gray-700 transition-colors hover:text-gray-900 [&:hover>svg]:text-gray-900 [&>svg]:text-gray-900 [&>svg]:transition-colors"
+            className="text-xsm flex items-center gap-1 font-semibold text-gray-700 transition-colors hover:text-gray-900 [&:hover>svg]:text-gray-900 [&>svg]:text-gray-700 [&>svg]:transition-colors"
             href={`${explorerBaseUrl}/address/${stakingVaultAddress}`}
           >
             {formatEvmAddress(stakingVaultAddress)}

--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -1,5 +1,8 @@
+import { ExternalLink } from "components/base/externalLink";
+import { ExternalLinkIcon } from "components/icons/externalLinkIcon";
 import { TokenLogo } from "components/tokenLogo";
 import { useApy } from "hooks/useApy";
+import { useMainnet } from "hooks/useMainnet";
 import { usePoolDeposits } from "hooks/usePoolDeposits";
 import { usePrices } from "hooks/usePrices";
 import { useUserRewards } from "hooks/useUserRewards";
@@ -19,8 +22,11 @@ type Props = {
 };
 
 export function PoolInfoBar({ stakingVaultAddress }: Props) {
+  const chain = useMainnet();
   const { t } = useTranslation();
   const { data: peggedToken } = useVaultPeggedToken(stakingVaultAddress);
+
+  const explorerBaseUrl = chain.blockExplorers!.default.url;
 
   const { data: apy, isLoading: isLoadingApy } = useApy(stakingVaultAddress);
   const { data: poolDeposits, isLoading: isLoadingDeposits } =
@@ -68,10 +74,15 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
           <Skeleton borderRadius={8} height={40} width={40} />
         )}
         <PoolInfoItem label="Token" value={peggedToken?.symbol} />
-        <PoolInfoItem
-          label={t("pages.earn.pool-info.pool-contract")}
-          value={formatEvmAddress(stakingVaultAddress)}
-        />
+        <PoolInfoItem label={t("pages.earn.pool-info.pool-contract")}>
+          <ExternalLink
+            className="text-xsm flex items-center gap-1 font-semibold text-gray-700 transition-colors hover:text-gray-900 [&:hover>svg]:text-gray-900 [&>svg]:text-gray-900 [&>svg]:transition-colors"
+            href={`${explorerBaseUrl}/address/${stakingVaultAddress}`}
+          >
+            {formatEvmAddress(stakingVaultAddress)}
+            <ExternalLinkIcon />
+          </ExternalLink>
+        </PoolInfoItem>
         <PoolInfoItem
           isLoading={isLoadingDeposits || (!prices && !isPricesError)}
           label={t("pages.earn.pool-info.pool-deposits")}


### PR DESCRIPTION
### Description

On the Earn page, the "Pool contract" address in the pool info bar was rendered as plain text. This renders it as an external link to the chain's block explorer (`/address/<vault>`), using the existing `ExternalLink`/`ExternalLinkIcon` components and deriving the explorer base URL from `useMainnet()`. Added hover styling consistent with other links in the app.

### Screenshots

https://github.com/user-attachments/assets/43db35a3-94a3-4031-afa5-58547e7884d5

### Related issue(s)

Closes #471

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.