### PR TITLE
Append live TVL point to total-deposits-history

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -145,10 +145,10 @@ Valid periods are: `"1w"`, `"1m"`, `"3m"` and `"1y"`.
 
 ### `GET /variable-stake/total-deposits-history/:stakingVaultAddress/:period`
 
-Returns the historical total deposits for a staking vault over the given period — the vault's total underlying pegged token holdings (ERC4626 `totalAssets`), i.e. the same value shown as "Pool deposits" on the Earn page. One entry per UTC day. Results across multiple subgraph pages are concatenated, so long windows return their full history (e.g. `"1y"` may include up to ~366 entries).
+Returns the historical total deposits for a staking vault over the given period — the vault's total underlying pegged token holdings (ERC4626 `totalAssets`), i.e. the same value shown as "Pool deposits" on the Earn page. One entry per UTC day from the subgraph, plus a final point read live from the vault's on-chain `totalAssets()` at request time. The subgraph writes its history once per UTC day, so its latest point can lag actual TVL by up to ~24h; the appended live point keeps the last value in sync with current TVL. Results across multiple subgraph pages are concatenated, so long windows return their full history (e.g. `"1y"` may include up to ~366 entries plus the live point). If the live read fails the series is returned without the appended point.
 Valid periods are: `"1w"`, `"1m"`, `"3m"` and `"1y"`.
 `:stakingVaultAddress` must be a known staking vault. Returns `400` if malformed and `404` if the address is not a known staking vault.
-`totalDeposits` is the raw `uint256` amount in the pegged token's base units (not pre-scaled); format it with the token's decimals on the client. `timestamp` is the UTC day-start in milliseconds.
+`totalDeposits` is the raw `uint256` amount in the pegged token's base units (not pre-scaled); format it with the token's decimals on the client. `timestamp` is in milliseconds.
 
 #### Sample Response for "1w"
 

--- a/api/src/analytics.ts
+++ b/api/src/analytics.ts
@@ -6,16 +6,11 @@ import {
   getWhitelistedTokens,
   getWithdrawable,
 } from "@vetro-protocol/treasury/actions";
-import {
-  type Address,
-  createPublicClient,
-  http,
-  type PublicClient,
-} from "viem";
-import { mainnet } from "viem/chains";
+import { type Address, type PublicClient } from "viem";
 import { balanceOf, previewRedeem } from "viem-erc4626/actions";
 
 import { getPrice } from "./chainlink.ts";
+import { createMainnetClient } from "./mainnet-client.ts";
 import { findStakingVaultForPeggedToken } from "./staking-vault.ts";
 import {
   getStrategies,
@@ -42,10 +37,7 @@ export async function getTreasuryComposition({
   gatewayAddress: Address;
   url: string | undefined;
 }) {
-  const client = createPublicClient({
-    chain: mainnet,
-    transport: http(url),
-  });
+  const client = createMainnetClient(url);
   const treasuryAddress = await getTreasury(client, {
     address: gatewayAddress,
   });
@@ -169,10 +161,7 @@ export async function getPeggedTokenBacking({
   gatewayAddress: Address;
   url: string | undefined;
 }) {
-  const client = createPublicClient({
-    chain: mainnet,
-    transport: http(url),
-  });
+  const client = createMainnetClient(url);
   const [peggedTokenAddress, treasuryAddress] = await Promise.all([
     getPeggedToken(client, { address: gatewayAddress }),
     getTreasury(client, { address: gatewayAddress }),

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -260,7 +260,7 @@ app.get(
   validateStakingVaultAddress,
   validateParam("period", vaultHistoryValidPeriods),
   cache({
-    cacheControl: "max-age=3600",
+    cacheControl: "max-age=300",
     cacheName: "vetro-api",
   }),
   async function (c) {
@@ -270,6 +270,7 @@ app.get(
       const period = c.req.param("period");
       const data = await getTotalDepositsHistory({
         period,
+        rpcUrl: c.env.CUSTOM_RPC_URL_MAINNET,
         stakingVaultAddress,
         url,
       });

--- a/api/src/mainnet-client.ts
+++ b/api/src/mainnet-client.ts
@@ -1,0 +1,9 @@
+import { createPublicClient, http } from "viem";
+import { mainnet } from "viem/chains";
+
+/**
+ * Create a viem public client for Ethereum mainnet using the given RPC URL.
+ * When `rpcUrl` is undefined, viem falls back to the chain's default RPC.
+ */
+export const createMainnetClient = (rpcUrl: string | undefined) =>
+  createPublicClient({ chain: mainnet, transport: http(rpcUrl) });

--- a/api/src/total-deposits-history.ts
+++ b/api/src/total-deposits-history.ts
@@ -7,8 +7,6 @@ import { getPeriodStart } from "./vault-history-period.ts";
 
 type Row = { timestamp: string; totalAssets: string };
 
-type Point = { timestamp: number; totalDeposits: string };
-
 /**
  * Read the vault's current ERC4626 totalAssets live from the chain and return
  * it as a synthetic "now" point. The subgraph only writes a VaultHistory entry
@@ -23,7 +21,7 @@ async function getLiveTotalDepositsPoint({
 }: {
   rpcUrl: string | undefined;
   stakingVaultAddress: Address;
-}): Promise<Point | null> {
+}) {
   try {
     const client = createMainnetClient(rpcUrl);
     const liveTotalAssets = await totalAssets(client, {
@@ -56,7 +54,7 @@ export async function getTotalDepositsHistory({
   rpcUrl: string | undefined;
   stakingVaultAddress: Address;
   url: string;
-}): Promise<Point[]> {
+}) {
   const stakingVault = stakingVaultAddress.toLowerCase();
   const start = getPeriodStart(period);
   const query = `

--- a/api/src/total-deposits-history.ts
+++ b/api/src/total-deposits-history.ts
@@ -1,25 +1,62 @@
 import { type Address } from "viem";
+import { totalAssets } from "viem-erc4626/actions";
 
+import { createMainnetClient } from "./mainnet-client.ts";
 import { paginateSubgraphQuery } from "./paginate-subgraph-query.ts";
 import { getPeriodStart } from "./vault-history-period.ts";
 
 type Row = { timestamp: string; totalAssets: string };
 
+type Point = { timestamp: number; totalDeposits: string };
+
+/**
+ * Read the vault's current ERC4626 totalAssets live from the chain and return
+ * it as a synthetic "now" point. The subgraph only writes a VaultHistory entry
+ * once per UTC day, so its latest point can lag actual TVL by up to ~24h; this
+ * live point keeps the series' last value in sync with the on-chain balance.
+ * Returns null (so the caller falls back to the subgraph series alone) if the
+ * read fails, keeping the endpoint as available as a subgraph-only read.
+ */
+async function getLiveTotalDepositsPoint({
+  rpcUrl,
+  stakingVaultAddress,
+}: {
+  rpcUrl: string | undefined;
+  stakingVaultAddress: Address;
+}): Promise<Point | null> {
+  try {
+    const client = createMainnetClient(rpcUrl);
+    const liveTotalAssets = await totalAssets(client, {
+      address: stakingVaultAddress,
+    });
+    return { timestamp: Date.now(), totalDeposits: liveTotalAssets.toString() };
+  } catch (error) {
+    console.warn(
+      `Failed to read live totalAssets for ${stakingVaultAddress}: ${error.message}`,
+    );
+    return null;
+  }
+}
+
 /**
  * Query the subgraph for the total deposits (ERC4626 totalAssets, i.e. the
  * vault's underlying pegged token balance) history of a staking vault over the
  * given period. Paginates over the subgraph's 100-result page cap so that long
- * windows (e.g. "1y", up to ~366 daily entries) are returned in full.
+ * windows (e.g. "1y", up to ~366 daily entries) are returned in full. A live
+ * on-chain totalAssets read is appended as the final point so the latest value
+ * reflects current TVL rather than the last daily subgraph snapshot.
  */
 export async function getTotalDepositsHistory({
   period,
+  rpcUrl,
   stakingVaultAddress,
   url,
 }: {
   period: string;
+  rpcUrl: string | undefined;
   stakingVaultAddress: Address;
   url: string;
-}): Promise<{ timestamp: number; totalDeposits: string }[]> {
+}): Promise<Point[]> {
   const stakingVault = stakingVaultAddress.toLowerCase();
   const start = getPeriodStart(period);
   const query = `
@@ -39,19 +76,26 @@ export async function getTotalDepositsHistory({
       }
     }`;
 
-  const all = await paginateSubgraphQuery<Row>({
-    cursor: {
-      getValue: (row) => row.timestamp,
-      variable: "start",
-    },
-    field: "vaultHistories",
-    query,
-    url,
-    variables: { stakingVault, start },
-  });
+  // The subgraph pagination and the live read are independent, so run them
+  // concurrently rather than awaiting the history first.
+  const [all, livePoint] = await Promise.all([
+    paginateSubgraphQuery<Row>({
+      cursor: {
+        getValue: (row) => row.timestamp,
+        variable: "start",
+      },
+      field: "vaultHistories",
+      query,
+      url,
+      variables: { stakingVault, start },
+    }),
+    getLiveTotalDepositsPoint({ rpcUrl, stakingVaultAddress }),
+  ]);
 
-  return all.map((h) => ({
+  const history = all.map((h) => ({
     timestamp: Number.parseInt(h.timestamp, 10) * 1000,
     totalDeposits: h.totalAssets,
   }));
+
+  return livePoint ? [...history, livePoint] : history;
 }

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -1,17 +1,12 @@
 import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { getPeggedToken } from "@vetro-protocol/gateway/actions";
 import { linearRegression } from "@vetro-protocol/linear-least-squares-regression";
-import {
-  type Address,
-  createPublicClient,
-  checksumAddress,
-  type Hash,
-  http,
-} from "viem";
+import { type Address, checksumAddress, type Hash } from "viem";
 import { mainnet } from "viem/chains";
 import { convertToAssets } from "viem-erc4626/actions";
 
 import * as graphql from "./graphql.ts";
+import { createMainnetClient } from "./mainnet-client.ts";
 import * as merkl from "./merkl.ts";
 import parseBigIntStringToNumber from "./parse-bigint-string-to-number.ts";
 import { findStakingVaultForPeggedToken } from "./staking-vault.ts";
@@ -310,10 +305,7 @@ export async function getExitTicketQueueSize({
   rpcUrl: string | undefined;
   subgraphUrl: string;
 }) {
-  const client = createPublicClient({
-    chain: mainnet,
-    transport: http(rpcUrl),
-  });
+  const client = createMainnetClient(rpcUrl);
   const peggedTokenAddress = await getPeggedToken(client, {
     address: gatewayAddress,
   });

--- a/api/test/total-deposits-history.test.ts
+++ b/api/test/total-deposits-history.test.ts
@@ -1,5 +1,6 @@
 import { sVusdAddress } from "@vetro-protocol/earn";
-import { describe, expect, it, vi } from "vitest";
+import { totalAssets } from "viem-erc4626/actions";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as graphql from "../src/graphql.ts";
 import { getTotalDepositsHistory } from "../src/total-deposits-history.ts";
@@ -8,22 +9,47 @@ vi.mock("../src/graphql.ts", () => ({
   runQuery: vi.fn(),
 }));
 
+vi.mock("viem-erc4626/actions", () => ({
+  totalAssets: vi.fn(),
+}));
+
 const url = "https://subgraph.example/v1";
+const rpcUrl = "https://rpc.example";
+
+// Fixed "now" so the appended live point's timestamp is deterministic.
+const now = 1_708_000_000_000;
+const liveTotalAssets = 6_000_000_000_000_000_000_000n;
+const livePoint = { timestamp: now, totalDeposits: liveTotalAssets.toString() };
 
 const fetchHistory = (period = "1w") =>
-  getTotalDepositsHistory({ period, stakingVaultAddress: sVusdAddress, url });
+  getTotalDepositsHistory({
+    period,
+    rpcUrl,
+    stakingVaultAddress: sVusdAddress,
+    url,
+  });
 
 const lastCallVariables = <T>() =>
   vi.mocked(graphql.runQuery).mock.calls.at(-1)?.[2] as T | undefined;
 
 describe("total-deposits-history/getTotalDepositsHistory", function () {
-  it("returns [] when the subgraph returns no entries", async function () {
-    vi.mocked(graphql.runQuery).mockResolvedValue({ vaultHistories: [] });
-
-    expect(await fetchHistory()).toEqual([]);
+  beforeEach(function () {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    vi.mocked(totalAssets).mockResolvedValue(liveTotalAssets);
   });
 
-  it("returns totalAssets as a raw base-units string and converts timestamp to ms", async function () {
+  afterEach(function () {
+    vi.useRealTimers();
+  });
+
+  it("returns only the live point when the subgraph returns no entries", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({ vaultHistories: [] });
+
+    expect(await fetchHistory()).toEqual([livePoint]);
+  });
+
+  it("returns totalAssets as a raw base-units string and converts timestamp to ms, with a live point appended", async function () {
     vi.mocked(graphql.runQuery).mockResolvedValue({
       vaultHistories: [
         { timestamp: "1707782400", totalAssets: "5000000000000000000000" },
@@ -34,6 +60,20 @@ describe("total-deposits-history/getTotalDepositsHistory", function () {
     expect(await fetchHistory()).toEqual([
       { timestamp: 1_707_782_400_000, totalDeposits: "5000000000000000000000" },
       { timestamp: 1_707_868_800_000, totalDeposits: "5100000000000000000000" },
+      livePoint,
+    ]);
+  });
+
+  it("falls back to the subgraph series when the live totalAssets read fails", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultHistories: [
+        { timestamp: "1707782400", totalAssets: "5000000000000000000000" },
+      ],
+    });
+    vi.mocked(totalAssets).mockRejectedValue(new Error("rpc down"));
+
+    expect(await fetchHistory()).toEqual([
+      { timestamp: 1_707_782_400_000, totalDeposits: "5000000000000000000000" },
     ]);
   });
 


### PR DESCRIPTION
### Description

The "Pool Deposits" headline in the Earn Historical Metrics card could disagree with the pool's live TVL by up to ~24h. Both values are the same metric — the vault's ERC-4626 `totalAssets()` — but the headline reads the last point of `GET /variable-stake/total-deposits-history/:vault/:period`, which comes from the subgraph's `VaultHistory` entity, written only once per UTC day. So any deposit/withdrawal since the last daily snapshot wasn't reflected until the next day's record.

This implements the server-side fix (option b from the issue): `getTotalDepositsHistory` now reads the vault's current `totalAssets()` live on-chain (same source as the `usePoolDeposits` hook) concurrently with the subgraph pagination, and appends it as a synthetic "now" point. Every consumer's last value now reflects current TVL. If the live read fails, it falls back to the subgraph series alone, so the endpoint stays as available as before. The route cache is lowered from 1h to 5min to keep the appended point fresh.

Also extracts the duplicated mainnet public-client construction into a shared `createMainnetClient` helper, reused across `analytics`, `variable-stake`, and the new code.

### Screenshots

N/A — API-only change.

### Related issue(s)

Closes #473

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.