### PR TITLE
Add unit tests for pure API and web helpers

### DIFF
--- a/api/test/convert-bigints-to-string.test.ts
+++ b/api/test/convert-bigints-to-string.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { convertBigIntsToString } from "../src/convert-bigints-to-string.ts";
+
+describe("convertBigIntsToString", function () {
+  it("converts a top-level bigint", function () {
+    expect(convertBigIntsToString(5n)).toBe("5");
+  });
+
+  it("converts bigints nested in objects and arrays", function () {
+    expect(
+      convertBigIntsToString({ a: 1n, b: "x", c: [2n, 3n], d: { e: 4n } }),
+    ).toEqual({ a: "1", b: "x", c: ["2", "3"], d: { e: "4" } });
+  });
+
+  it("leaves non-bigint primitives untouched", function () {
+    expect(convertBigIntsToString({ n: 1, s: "x", z: null })).toEqual({
+      n: 1,
+      s: "x",
+      z: null,
+    });
+  });
+});

--- a/api/test/origin-glob-to-regexp.test.ts
+++ b/api/test/origin-glob-to-regexp.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { originGlobToRegExp } from "../src/origin-glob-to-regexp.ts";
+
+describe("originGlobToRegExp", function () {
+  it("matches subdomains for a wildcard glob", function () {
+    const regExp = originGlobToRegExp("https://*.example.com");
+    expect(regExp.test("https://app.example.com")).toBe(true);
+    expect(regExp.test("https://a.b.example.com")).toBe(true);
+  });
+
+  it("does not match the bare domain for a subdomain glob", function () {
+    const regExp = originGlobToRegExp("https://*.example.com");
+    expect(regExp.test("https://example.com")).toBe(false);
+  });
+
+  it("escapes dots so they are not treated as wildcards", function () {
+    const regExp = originGlobToRegExp("https://example.com");
+    expect(regExp.test("https://example.com")).toBe(true);
+    expect(regExp.test("https://exampleXcom")).toBe(false);
+  });
+});

--- a/api/test/parse-bigint-string-to-number.test.ts
+++ b/api/test/parse-bigint-string-to-number.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import parseBigIntStringToNumber from "../src/parse-bigint-string-to-number.ts";
+
+describe("parseBigIntStringToNumber", function () {
+  it("parses an integer string when no decimals are given", function () {
+    expect(parseBigIntStringToNumber("123")).toBe(123);
+  });
+
+  it("scales by the given number of decimals", function () {
+    expect(parseBigIntStringToNumber("1500", 3)).toBe(1.5);
+  });
+
+  it("zero-pads values shorter than the decimal count", function () {
+    expect(parseBigIntStringToNumber("5", 2)).toBe(0.05);
+  });
+});

--- a/api/test/querystring-object-to-string.test.ts
+++ b/api/test/querystring-object-to-string.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { queryStringObjectToString } from "../src/querystring-object-to-string.ts";
+
+describe("queryStringObjectToString", function () {
+  it("returns an empty string when no params are given", function () {
+    expect(queryStringObjectToString()).toBe("");
+  });
+
+  it("returns an empty string for an empty object", function () {
+    expect(queryStringObjectToString({})).toBe("");
+  });
+
+  it("prefixes a single param with a question mark", function () {
+    expect(queryStringObjectToString({ a: "1" })).toBe("?a=1");
+  });
+
+  it("joins multiple params with ampersands", function () {
+    expect(queryStringObjectToString({ a: "1", b: "2" })).toBe("?a=1&b=2");
+  });
+});

--- a/api/test/validate-origin.test.ts
+++ b/api/test/validate-origin.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { createOriginFn, parseOrigins } from "../src/validate-origin.ts";
+
+describe("parseOrigins", function () {
+  it("keeps literal origins as strings and converts globs to RegExp", function () {
+    const [literal, glob] = parseOrigins("https://a.com,https://*.b.com");
+    expect(literal).toBe("https://a.com");
+    expect(glob).toBeInstanceOf(RegExp);
+  });
+});
+
+describe("createOriginFn", function () {
+  const isAllowed = createOriginFn(
+    parseOrigins("https://a.com,https://*.b.com"),
+  );
+
+  it("returns the origin on a literal match", function () {
+    expect(isAllowed("https://a.com")).toBe("https://a.com");
+  });
+
+  it("returns the origin on a glob match", function () {
+    expect(isAllowed("https://app.b.com")).toBe("https://app.b.com");
+  });
+
+  it("returns null when no allowed origin matches", function () {
+    expect(isAllowed("https://evil.com")).toBeNull();
+  });
+});

--- a/web/test/pages/earn/components/exitTickets/getTicketStatus.test.ts
+++ b/web/test/pages/earn/components/exitTickets/getTicketStatus.test.ts
@@ -1,0 +1,66 @@
+import { getTicketStatus } from "pages/earn/components/exitTickets/getTicketStatus";
+import type { ExitTicket } from "pages/earn/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// 2025-01-01T00:00:00Z in unix seconds.
+const now = 1735689600;
+
+const buildTicket = (overrides: Partial<ExitTicket> = {}): ExitTicket => ({
+  assets: "1000",
+  claimableAt: String(now),
+  owner: "0x0000000000000000000000000000000000000001",
+  requestId: "1",
+  requestTxHash: "0xrequest",
+  shares: "1000",
+  stakingVaultAddress: "0x0000000000000000000000000000000000000002",
+  ...overrides,
+});
+
+describe("getTicketStatus", function () {
+  beforeEach(function () {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+  });
+
+  afterEach(function () {
+    vi.useRealTimers();
+  });
+
+  it("returns 'cancelled' when the ticket has a cancel tx", function () {
+    expect(getTicketStatus(buildTicket({ cancelTxHash: "0xcancel" }))).toBe(
+      "cancelled",
+    );
+  });
+
+  it("prefers 'cancelled' over 'withdrawn' when both txs are present", function () {
+    expect(
+      getTicketStatus(
+        buildTicket({ cancelTxHash: "0xcancel", claimTxHash: "0xclaim" }),
+      ),
+    ).toBe("cancelled");
+  });
+
+  it("returns 'withdrawn' when the ticket has a claim tx", function () {
+    expect(getTicketStatus(buildTicket({ claimTxHash: "0xclaim" }))).toBe(
+      "withdrawn",
+    );
+  });
+
+  it("returns 'ready' when the claimable time has passed", function () {
+    expect(
+      getTicketStatus(buildTicket({ claimableAt: String(now - 100) })),
+    ).toBe("ready");
+  });
+
+  it("returns 'ready' at the exact claimable time", function () {
+    expect(getTicketStatus(buildTicket({ claimableAt: String(now) }))).toBe(
+      "ready",
+    );
+  });
+
+  it("returns 'cooldown' when the claimable time is in the future", function () {
+    expect(
+      getTicketStatus(buildTicket({ claimableAt: String(now + 100) })),
+    ).toBe("cooldown");
+  });
+});


### PR DESCRIPTION
### Description

Adds unit tests for a handful of pure helper functions that previously had no coverage:

- **API** (`api/test/`): `convertBigIntsToString`, `originGlobToRegExp`, `parseBigIntStringToNumber`, `queryStringObjectToString`, and `validate-origin`'s `parseOrigins` / `createOriginFn`.
- **Web** (`web/test/`): `getTicketStatus`, covering the exit-ticket status precedence (cancelled → withdrawn → ready → cooldown) including the claimable-time boundary, using fake timers to pin `unixNowTimestamp`.

These are all pure, deterministic functions, so the tests are cheap to write and run — no mocks, no network, no setup beyond the existing vitest config. The value is modest but real: they pin down current behavior, document intent, and give us regression coverage on small bits of logic (decimal scaling, glob→regex escaping, origin allowlisting, status precedence) that are easy to break silently.

**Commits:**

- 98e9255 Add unit tests for API helper functions
- f5d9033 Add unit tests for getTicketStatus

### Screenshots

N/A

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A — N/A.
- [x] Environment variables set in CI, or N/A — N/A.