### PR TITLE
Update swap toasts and add redeem e2e coverage

### DIFF
--- a/web/e2e/fixtures/wallet.ts
+++ b/web/e2e/fixtures/wallet.ts
@@ -1,8 +1,9 @@
 import { TEST_PRIVATE_KEY } from "@hemilabs/anvil-fork-setup/utils";
 import { test as base } from "@playwright/test";
 import { installMockWallet } from "@vetro-protocol/mock-wallet";
-import { http } from "viem";
+import { createTestClient, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
+import { revert, snapshot } from "viem/actions";
 import { mainnet } from "viem/chains";
 
 import { ANVIL_URL } from "../anvil";
@@ -18,6 +19,22 @@ export const test = base.extend({
       page,
       transports: { [mainnet.id]: http(ANVIL_URL) },
     });
+
+    // The fork is started and funded once in globalSetup, then shared across
+    // every test (workers: 1). Without isolation, on-chain mutations from one
+    // test leak into the next — e.g. a redeem leaves the gateway allowance set,
+    // so a later run skips the approval tx and the stepper jumps to "completed"
+    // with no wallet interaction. Snapshot the funded baseline before the test
+    // and revert after, so each test starts from the same chain state.
+    // installMockWallet only injects scripts (no chain writes), so the snapshot
+    // here still captures the clean funded state.
+    const testClient = createTestClient({
+      chain: mainnet,
+      mode: "anvil",
+      transport: http(ANVIL_URL),
+    });
+    const snapshotId = await snapshot(testClient);
     await use(page);
+    await revert(testClient, { id: snapshotId });
   },
 });

--- a/web/e2e/swap.spec.ts
+++ b/web/e2e/swap.spec.ts
@@ -68,21 +68,27 @@ test("swap USDC → VUSD via the gateway", async function ({ page }) {
     page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
   ).toBeVisible({ timeout: 30_000 });
 
-  // Pick USDC as the input token. The trigger opens a modal dialog where
-  // tokens are listed as buttons (pinned grid + rows), not ARIA options.
-  await page
+  // Pick USDC as the input token. The default input is whitelistedTokens[0],
+  // whose ordering isn't guaranteed (anvil forks at the latest block, so the
+  // set/order can differ between local and CI), and clicking an already
+  // selected token won't close the modal. So only open the picker while USDC
+  // isn't selected, and retry if a click doesn't register.
+  const fromTokenSelector = page
     .getByRole("button", { name: "Select token to swap" })
-    .first()
-    .click();
-  const tokenDialog = page.getByRole("dialog");
-  // The modal fades in via an opacity transition. Playwright's visibility
-  // check ignores opacity, so it would otherwise click a token mid-animation
-  // and race the open/close state, leaving the modal stuck open and blocking
-  // the Swap click. Wait for the entrance to finish before selecting.
-  await expect(tokenDialog).toHaveCSS("opacity", "1");
-  await tokenDialog.getByRole("button", { name: /USDC/ }).first().click();
+    .first();
+  await expect(fromTokenSelector).toBeVisible();
+  await expect(async function () {
+    if ((await fromTokenSelector.textContent())?.includes("USDC")) return;
+    await fromTokenSelector.click();
+    const tokenDialog = page.getByRole("dialog");
+    // The modal fades in via an opacity transition. Playwright's visibility
+    // check ignores opacity, so wait for the entrance to finish before clicking.
+    await expect(tokenDialog).toHaveCSS("opacity", "1");
+    await tokenDialog.getByRole("button", { name: /USDC/ }).first().click();
+    await expect(fromTokenSelector).toContainText("USDC", { timeout: 5_000 });
+  }).toPass({ timeout: 20_000 });
   // Ensure the modal is gone before interacting with the form underneath.
-  await expect(tokenDialog).toBeHidden();
+  await expect(page.getByRole("dialog")).toBeHidden();
 
   await page
     .locator('input[type="text"]:not([disabled])')

--- a/web/e2e/swap.spec.ts
+++ b/web/e2e/swap.spec.ts
@@ -4,6 +4,8 @@ import { createPublicClient, http, parseUnits } from "viem";
 import { mainnet } from "viem/chains";
 import { balanceOf } from "viem-erc20/actions";
 
+import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts";
+import { whitelistInstantRedeem } from "../scripts/whitelistInstantRedeem.ts";
 import { knownTokens } from "../src/utils/tokenList.ts";
 
 import { ANVIL_URL } from "./anvil";
@@ -23,6 +25,11 @@ const usdc = getMainnetToken("USDC");
 const vusd = getMainnetToken("VUSD");
 const SWAP_AMOUNT_DISPLAY = "1";
 const SWAP_AMOUNT = parseUnits(SWAP_AMOUNT_DISPLAY, usdc.decimals);
+
+// The redeem burns VUSD (the pegged token), so the amount is measured in VUSD
+// decimals — not USDC's like the deposit above.
+const REDEEM_AMOUNT_DISPLAY = "2";
+const REDEEM_AMOUNT = parseUnits(REDEEM_AMOUNT_DISPLAY, vusd.decimals);
 
 test("swap USDC → VUSD via the gateway", async function ({ page }) {
   const publicClient = createPublicClient({
@@ -85,7 +92,7 @@ test("swap USDC → VUSD via the gateway", async function ({ page }) {
   await page.getByRole("button", { name: /^swap$/i }).click();
 
   // The success toast renders once the deposit tx is confirmed on the fork.
-  await expect(page.getByText("Deposit confirmed")).toBeVisible({
+  await expect(page.getByText("Swap successful")).toBeVisible({
     timeout: 40_000,
   });
 
@@ -107,4 +114,118 @@ test("swap USDC → VUSD via the gateway", async function ({ page }) {
     address: usdc.address,
   });
   expect(usdcAfter).toBe(usdcBefore - SWAP_AMOUNT);
+});
+
+test("redeem VUSD → USDC via the gateway (instant redeem)", async function ({
+  page,
+}) {
+  const publicClient = createPublicClient({
+    chain: mainnet,
+    transport: http(ANVIL_URL),
+  });
+
+  // Whitelist the test account for instant redeem so the redeem takes the
+  // one-step path (otherwise the gateway's withdrawal delay forces the
+  // two-step queue flow).
+  await whitelistInstantRedeem({
+    address: TEST_ADDRESS,
+    forkUrl: ANVIL_URL,
+    gateway: gatewayAddresses[0],
+  });
+
+  const [usdcBefore, vusdBefore] = await Promise.all([
+    balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: usdc.address,
+    }),
+    balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: vusd.address,
+    }),
+  ]);
+
+  await page.goto("/swap");
+
+  // Wait for the real form to render before toggling. While the whitelisted /
+  // pegged token queries are in flight, SwapForm shows SwapFormSkeleton, which
+  // renders a "Toggle swap direction" button with no onClick — clicking it is a
+  // no-op and the mode never lands in the URL. The "Select token to swap"
+  // button only exists in the loaded form (the skeleton uses a non-interactive
+  // token selector), so it's a reliable "form is interactive" signal.
+  await expect(
+    page.getByRole("button", { name: "Select token to swap" }).first(),
+  ).toBeVisible();
+
+  // Toggle to redeem BEFORE connecting. Connecting triggers a background
+  // refetch that can briefly remount the form (SwapFormSkeleton) and drop the
+  // toggle, since the mode lives in the URL (nuqs) and re-inits on remount.
+  // Doing it first — and waiting for the mode to land in the URL — means the
+  // remount re-initialises in redeem mode rather than reverting to deposit.
+  await page.getByRole("button", { name: "Toggle swap direction" }).click();
+  await expect(page).toHaveURL(/[?&]mode=redeem/);
+
+  // The mock wallet auto-connects silently via EIP-6963 (see fixtures/wallet),
+  // so no connect clicks are needed here — just wait for the header button to
+  // switch from "Connect wallet" to the 0x… short address.
+  await expect(
+    page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // Once connected and whitelisted, the redeem renders the instant one-step
+  // form with a selectable output token. Pick USDC unless it's already the
+  // default output (clicking the already-selected token won't close the
+  // modal). Scope to the "You will receive" section to avoid depending on the
+  // relative ordering of the two token selectors.
+  const toTokenSelector = page
+    .getByText("You will receive")
+    .locator("..")
+    .getByRole("button", { name: "Select token to swap" });
+  await expect(toTokenSelector).toBeVisible();
+  // Switch the output to USDC. Re-check inside toPass: a late form re-init can
+  // flip the default output, and clicking an already-selected token won't close
+  // the modal — so only open it while USDC isn't selected, and retry if a click
+  // doesn't register.
+  await expect(async function () {
+    if ((await toTokenSelector.textContent())?.includes("USDC")) return;
+    await toTokenSelector.click();
+    const tokenDialog = page.getByRole("dialog");
+    // The modal fades in via an opacity transition. Playwright's visibility
+    // check ignores opacity, so wait for the entrance to finish before clicking.
+    await expect(tokenDialog).toHaveCSS("opacity", "1");
+    await tokenDialog.getByRole("button", { name: /USDC/ }).first().click();
+    await expect(toTokenSelector).toContainText("USDC", { timeout: 5_000 });
+  }).toPass({ timeout: 20_000 });
+  // The modal closes via a CSS transition; ensure it's gone before interacting
+  // with the form underneath.
+  await expect(page.getByRole("dialog")).toBeHidden();
+
+  await page
+    .locator('input[type="text"]:not([disabled])')
+    .first()
+    .fill(REDEEM_AMOUNT_DISPLAY);
+
+  await page.getByRole("button", { name: /^redeem$/i }).click();
+  // The instant one-step redeem path shows the shared swap success toast.
+  await expect(page.getByText("Swap successful")).toBeVisible({
+    timeout: 40_000,
+  });
+
+  // No popups — the mock wallet signs and forwards to Anvil silently.
+  // Assert by polling balances directly against the fork.
+  await expect
+    .poll(
+      async () =>
+        balanceOf(publicClient, {
+          account: TEST_ADDRESS,
+          address: usdc.address,
+        }),
+      { timeout: 20_000 },
+    )
+    .toBeGreaterThan(usdcBefore);
+
+  const vusdAfter = await balanceOf(publicClient, {
+    account: TEST_ADDRESS,
+    address: vusd.address,
+  });
+  expect(vusdAfter).toBe(vusdBefore - REDEEM_AMOUNT);
 });

--- a/web/scripts/whitelistInstantRedeem.ts
+++ b/web/scripts/whitelistInstantRedeem.ts
@@ -1,0 +1,166 @@
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import {
+  type Address,
+  createPublicClient,
+  createTestClient,
+  http,
+  isAddress,
+  keccak256,
+  parseEther,
+  stringToBytes,
+} from "viem";
+import {
+  impersonateAccount,
+  readContract,
+  setBalance,
+  stopImpersonatingAccount,
+  waitForTransactionReceipt,
+  writeContract,
+} from "viem/actions";
+import { mainnet } from "viem/chains";
+
+import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
+import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts";
+
+// Whitelisting for instant redeem is `onlyRole(MAINTAINER_ROLE)`, and the
+// gateway delegates role checks to its Treasury (`Treasury.hasRole`). The
+// treasury owner holds DEFAULT_ADMIN_ROLE, which administers MAINTAINER_ROLE,
+// so we impersonate the owner, grant it MAINTAINER_ROLE on the treasury, then
+// whitelist the account on the gateway.
+const MAINTAINER_ROLE = keccak256(stringToBytes("MAINTAINER_ROLE"));
+
+const accessControlAbi = [
+  {
+    inputs: [
+      { name: "role", type: "bytes32" },
+      { name: "account", type: "address" },
+    ],
+    name: "grantRole",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { name: "role", type: "bytes32" },
+      { name: "account", type: "address" },
+    ],
+    name: "hasRole",
+    outputs: [{ type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export async function whitelistInstantRedeem({
+  address,
+  forkUrl = "http://127.0.0.1:8545",
+  gateway = gatewayAddresses[0],
+}: {
+  address: Address;
+  forkUrl?: string;
+  gateway?: Address;
+}) {
+  const transport = http(forkUrl);
+
+  const publicClient = createPublicClient({ chain: mainnet, transport });
+  const testClient = createTestClient({
+    chain: mainnet,
+    mode: "anvil",
+    transport,
+  });
+
+  const [owner, treasury, isWhitelisted] = await Promise.all([
+    readContract(publicClient, {
+      abi: gatewayAbi,
+      address: gateway,
+      functionName: "owner",
+    }),
+    readContract(publicClient, {
+      abi: gatewayAbi,
+      address: gateway,
+      functionName: "treasury",
+    }),
+    readContract(publicClient, {
+      abi: gatewayAbi,
+      address: gateway,
+      args: [address],
+      functionName: "isInstantRedeemWhitelisted",
+    }),
+  ]);
+
+  if (isWhitelisted) {
+    console.log(`${address} is already whitelisted for instant redeem.`);
+    return;
+  }
+
+  await impersonateAccount(testClient, { address: owner });
+  await setBalance(testClient, { address: owner, value: parseEther("1") });
+
+  try {
+    const ownerHasRole = await readContract(publicClient, {
+      abi: accessControlAbi,
+      address: treasury,
+      args: [MAINTAINER_ROLE, owner],
+      functionName: "hasRole",
+    });
+
+    if (!ownerHasRole) {
+      const grantHash = await writeContract(testClient, {
+        abi: accessControlAbi,
+        account: owner,
+        address: treasury,
+        args: [MAINTAINER_ROLE, owner],
+        functionName: "grantRole",
+      });
+      await waitForTransactionReceipt(publicClient, { hash: grantHash });
+    }
+
+    const whitelistHash = await writeContract(testClient, {
+      abi: gatewayAbi,
+      account: owner,
+      address: gateway,
+      args: [address],
+      functionName: "addToInstantRedeemWhitelist",
+    });
+    await waitForTransactionReceipt(publicClient, { hash: whitelistHash });
+  } finally {
+    await stopImpersonatingAccount(testClient, { address: owner });
+  }
+
+  console.log(
+    `${address} whitelisted for instant redeem on gateway ${gateway}.`,
+  );
+}
+
+// Allow running as a standalone script for consumers:
+//   node web/scripts/whitelistInstantRedeem.ts --address 0x… [--fork-url …] [--gateway …]
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { values } = parseArgs({
+    options: {
+      address: { short: "a", type: "string" },
+      "fork-url": { short: "f", type: "string" },
+      gateway: { short: "g", type: "string" },
+    },
+    strict: true,
+  });
+
+  if (values.gateway && !isAddress(values.gateway, { strict: false })) {
+    console.error("Invalid --gateway. Must be a valid address.");
+    process.exit(1);
+  }
+
+  if (!values.address || !isAddress(values.address, { strict: false })) {
+    console.error(
+      "Address is invalid. Usage: node web/scripts/whitelistInstantRedeem.ts --address 0xYourAddress",
+    );
+    process.exit(1);
+  }
+
+  await whitelistInstantRedeem({
+    address: values.address,
+    forkUrl: values["fork-url"],
+    gateway: (values.gateway as Address) ?? gatewayAddresses[0],
+  });
+}

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -317,9 +317,14 @@ export function Deposit({
       {showToast && (
         <Toast
           closable
-          description={t("pages.swap.toast.deposit-description")}
+          description={t("pages.swap.toast.swap-success-description", {
+            fromAmount: fromInputValue,
+            fromSymbol: fromToken.symbol,
+            toAmount: outputValue,
+            toSymbol: toToken.symbol,
+          })}
           onClose={() => setShowToast(false)}
-          title={t("pages.swap.toast.deposit-title")}
+          title={t("pages.swap.toast.swap-success-title")}
         />
       )}
     </>

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -328,9 +328,14 @@ export function OneStepRedeem({
       {showToast && (
         <Toast
           closable
-          description={t("pages.swap.toast.deposit-description")}
+          description={t("pages.swap.toast.swap-success-description", {
+            fromAmount: fromInputValue,
+            fromSymbol: fromToken.symbol,
+            toAmount: outputValue,
+            toSymbol: toToken.symbol,
+          })}
           onClose={() => setShowToast(false)}
-          title={t("pages.swap.toast.deposit-title")}
+          title={t("pages.swap.toast.swap-success-title")}
         />
       )}
     </>

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -312,12 +312,10 @@ export function TwoStepRedeem({
       {showToast && (
         <Toast
           closable
-          description={t("pages.swap.toast.your-cooldown-period-has-started", {
-            count: seconds,
-            seconds,
-          })}
+          description={t("pages.swap.toast.redeem-queued-description")}
           onClose={() => setShowToast(false)}
-          title={t("pages.swap.toast.deposited-to-queue", {
+          title={t("pages.swap.toast.redeem-queued-title", {
+            amount: fromInputValue,
             symbol: fromToken.symbol,
           })}
         />

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -423,10 +423,10 @@
       "select-option": "Select token to swap",
       "title": "Swap your tokens with Vetro assets",
       "toast": {
-        "deposit-description": "VUSD is now available in your wallet",
-        "deposit-title": "Deposit confirmed",
-        "deposited-to-queue": "{{symbol}} deposited to queue",
-        "your-cooldown-period-has-started": "Your {{seconds}}-second cooldown has started."
+        "redeem-queued-description": "You'll be able to redeem it once the cooldown ends.",
+        "redeem-queued-title": "{{amount}} {{symbol}} sent to queue",
+        "swap-success-description": "{{fromAmount}} {{fromSymbol}} converted to {{toAmount}} {{toSymbol}}.",
+        "swap-success-title": "Swap successful"
       },
       "treasury-reserves": "Treasury reserves",
       "tutorial": {

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -430,11 +430,10 @@
       "select-option": "Seleccione el token a intercambiar",
       "title": "Intercambie sus tokens por activos de Vetro",
       "toast": {
-        "deposit-description": "VUSD disponible en su billetera",
-        "deposit-title": "Depósito confirmado",
-        "deposited-to-queue": "{{symbol}} depositado en la cola",
-        "your-cooldown-period-has-started_one": "Su período de espera de {{seconds}} segundo ha comenzado.",
-        "your-cooldown-period-has-started_other": "Su período de espera de {{seconds}} segundos ha comenzado."
+        "redeem-queued-description": "Podrá canjearlo una vez que finalice el período de espera.",
+        "redeem-queued-title": "{{amount}} {{symbol}} enviado a la cola",
+        "swap-success-description": "{{fromAmount}} {{fromSymbol}} convertido a {{toAmount}} {{toSymbol}}.",
+        "swap-success-title": "Intercambio exitoso"
       },
       "treasury-reserves": "Reservas del tesoro",
       "tutorial": {


### PR DESCRIPTION
### Description

Replace the deposit-specific success toast with a generic "Swap successful" message that reports the converted amounts (`{{fromAmount}} {{fromSymbol}} converted to {{toAmount}} {{toSymbol}}`), shared across deposit and one-step redeem. Rework the two-step redeem toast into a "sent to queue" message. Translations updated for `en` and `es`.

Add an instant-redeem e2e test (`redeem VUSD → USDC via the gateway`) plus a `whitelistInstantRedeem` helper/script that puts the test account on the gateway's instant-redeem allowlist (impersonates the treasury owner, grants `MAINTAINER_ROLE`, then whitelists the account) so the redeem takes the one-step path.

Snapshot and revert the anvil fork around each e2e test so on-chain state (allowances, balances) no longer leaks between tests. Without this, a redeem left the gateway allowance set and later runs skipped the approval tx, making the progress stepper jump straight to "completed" with no wallet interaction.

### Screenshots

swap USDC > VUSD

<img width="1124" height="238" alt="image" src="https://github.com/user-attachments/assets/fa9e47ac-6a5a-47ac-aebc-52274d8f69d5" />

swap VUSD > USDC (instant)

<img width="1030" height="194" alt="image" src="https://github.com/user-attachments/assets/1c164c0d-d8b3-4605-a758-a6da91ee51c0" />

Sending  VUSD to exit queue

<img width="1032" height="278" alt="image" src="https://github.com/user-attachments/assets/1df915c6-77aa-430d-b9be-8762c0638336" />

### Related issue(s)

Closes #468

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.