### PR TITLE
Add internal-dashboard workspace

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,17 +2,23 @@
   "extends": ["bloq", "prettier"],
   "ignorePatterns": [
     "api/.wrangler/**/*",
+    "internal-dashboard/dist/**/*",
     "landing/.wrangler/**/*",
     "web/dist/**/*",
     "web/storybook-static/**/*"
   ],
   "overrides": [
     {
-      "excludedFiles": ["subgraph/generated/**/*", "web/dist/**/*"],
+      "excludedFiles": [
+        "internal-dashboard/dist/**/*",
+        "subgraph/generated/**/*",
+        "web/dist/**/*"
+      ],
       "extends": ["bloq/esm", "bloq/typescript", "prettier"],
       "files": [
         "*.{js,mjs}",
         "api/**/*.ts",
+        "internal-dashboard/**/*.{js,ts,tsx}",
         "landing/**/*.ts",
         "packages/**/*.{js,ts,tsx}",
         "subgraph/**/*.ts",

--- a/README.md
+++ b/README.md
@@ -42,5 +42,9 @@ Then authenticate with your Figma account when prompted. The MCP configuration i
 
 The monorepo contains the following workspaces:
 
+- `api` - Service that provides data to the Vetro web application
+- `internal-dashboard` - Internal-facing dashboard for operational metrics
+- `landing` - Static waitlist landing page served via Cloudflare Workers
 - `packages/*` - Shared packages
+- `subgraph` - Subgraph indexing Ethereum mainnet events for the API
 - `web` - Web application

--- a/internal-dashboard/README.md
+++ b/internal-dashboard/README.md
@@ -1,0 +1,24 @@
+# Internal Dashboard
+
+Internal-facing dashboard for tracking various operational metrics. Each metric area
+lives on its own tab, mapped to a URL.
+
+- **Curve** (`/curve`) — liquidity on Curve pools _(placeholder for now)_.
+
+It's a Vite + React + TypeScript + Tailwind v4 SPA, deployed to Cloudflare via a Worker
+that serves the static assets and injects security headers (see `src/index.ts`).
+
+## Development
+
+```sh
+pnpm dev      # start the Vite dev server
+pnpm build    # typecheck + production build
+pnpm preview  # preview the production build
+pnpm tsc      # typecheck only
+```
+
+## Deployment
+
+Deployed to Cloudflare with `wrangler` (see `wrangler.jsonc`). The `staging` and
+`production` environments map to the `vetro-internal-dashboard-staging` and
+`vetro-internal-dashboard` Workers respectively.

--- a/internal-dashboard/index.html
+++ b/internal-dashboard/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Internal Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/internal-dashboard/package.json
+++ b/internal-dashboard/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@vetro-protocol/internal-dashboard",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "prepreview": "pnpm run build",
+    "preview": "vite preview",
+    "tsc": "tsc"
+  },
+  "dependencies": {
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
+    "react-router": "7.12.0"
+  },
+  "devDependencies": {
+    "@cloudflare/vite-plugin": "1.23.1",
+    "@cloudflare/workers-types": "4.20260504.1",
+    "@tailwindcss/vite": "4.3.0",
+    "@tsconfig/vite-react": "7.0.2",
+    "@types/node": "24.1.0",
+    "@types/react": "19.2.9",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.1",
+    "tailwindcss": "4.3.0",
+    "typescript": "5.9.3",
+    "vite": "8.0.13",
+    "wrangler": "4.63.0"
+  },
+  "private": true,
+  "type": "module"
+}

--- a/internal-dashboard/package.json
+++ b/internal-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "@vetro-protocol/internal-dashboard",
   "version": "1.0.0",
   "scripts": {
-    "build": "vite build",
+    "build": "tsc && vite build",
     "dev": "vite",
     "prepreview": "pnpm run build",
     "preview": "vite preview",

--- a/internal-dashboard/src/app.tsx
+++ b/internal-dashboard/src/app.tsx
@@ -1,0 +1,20 @@
+import { BrowserRouter, Navigate, Route, Routes } from "react-router";
+
+import { Header } from "./components/header";
+import { Layout } from "./components/layout";
+import { CurvePage } from "./pages/curve";
+
+export const App = () => (
+  <div className="lg:px-4 xl:px-8 2xl:px-28">
+    <Header />
+    <BrowserRouter>
+      <Layout>
+        <Routes>
+          <Route element={<Navigate replace to="/curve" />} path="/" />
+          <Route element={<CurvePage />} path="/curve" />
+          <Route element={<Navigate replace to="/curve" />} path="*" />
+        </Routes>
+      </Layout>
+    </BrowserRouter>
+  </div>
+);

--- a/internal-dashboard/src/components/header.tsx
+++ b/internal-dashboard/src/components/header.tsx
@@ -1,0 +1,7 @@
+export const Header = () => (
+  <header className="flex w-full items-center p-4">
+    <h1 className="mx-auto text-xl font-medium text-black">
+      Internal Dashboard
+    </h1>
+  </header>
+);

--- a/internal-dashboard/src/components/headerTabs.tsx
+++ b/internal-dashboard/src/components/headerTabs.tsx
@@ -1,0 +1,28 @@
+import { type ReactNode } from "react";
+import { NavLink } from "react-router";
+
+type Props = {
+  children: ReactNode;
+  to: string;
+};
+
+const Tab = ({ children, to }: Props) => (
+  <NavLink
+    className={({ isActive }) =>
+      `rounded-md px-2 py-1 text-sm font-medium ${
+        isActive
+          ? "border border-solid border-neutral-300/55 bg-white text-neutral-950 shadow-xs"
+          : "bg-neutral-100 text-neutral-600 hover:text-neutral-950"
+      }`
+    }
+    to={to}
+  >
+    {children}
+  </NavLink>
+);
+
+export const HeaderTabs = () => (
+  <nav className="mb-12 flex items-center gap-x-2 border-y border-solid border-y-neutral-300/55 p-4">
+    <Tab to="/curve">Curve</Tab>
+  </nav>
+);

--- a/internal-dashboard/src/components/layout.tsx
+++ b/internal-dashboard/src/components/layout.tsx
@@ -1,0 +1,14 @@
+import { type ReactNode } from "react";
+
+import { HeaderTabs } from "./headerTabs";
+
+type Props = {
+  children: ReactNode;
+};
+
+export const Layout = ({ children }: Props) => (
+  <>
+    <HeaderTabs />
+    <div className="mx-auto min-h-screen bg-white p-4">{children}</div>
+  </>
+);

--- a/internal-dashboard/src/index.css
+++ b/internal-dashboard/src/index.css
@@ -1,0 +1,10 @@
+@import "tailwindcss";
+
+@theme {
+  --shadow-primary:
+    0px 0px 2px 0px rgba(10, 10, 10, 0.1),
+    0px 8px 12px -4px rgba(10, 10, 10, 0.08),
+    0px 1px 2px 0px rgba(10, 10, 10, 0.1);
+  --text-sm: 0.8125rem; /* 13px */
+  --text-sm--line-height: 20px;
+}

--- a/internal-dashboard/src/index.ts
+++ b/internal-dashboard/src/index.ts
@@ -1,0 +1,114 @@
+// Worker entry point – proxies static assets and injects security headers.
+
+/// <reference types="@cloudflare/workers-types" />
+
+type Env = {
+  ASSETS: Fetcher;
+};
+
+// Deny all permissions – mirrors web/src/index.ts.
+const permissionsPolicy = [
+  "accelerometer",
+  "ambient-light-sensor",
+  "attribution-reporting",
+  "autoplay",
+  "battery",
+  "bluetooth",
+  "camera",
+  "ch-ua",
+  "ch-ua-arch",
+  "ch-ua-bitness",
+  "ch-ua-full-version",
+  "ch-ua-full-version-list",
+  "ch-ua-mobile",
+  "ch-ua-model",
+  "ch-ua-platform",
+  "ch-ua-platform-version",
+  "ch-ua-wow64",
+  "compute-pressure",
+  "cross-origin-isolated",
+  "direct-sockets",
+  "display-capture",
+  "encrypted-media",
+  "execution-while-not-rendered",
+  "execution-while-out-of-viewport",
+  "fullscreen",
+  "geolocation",
+  "gyroscope",
+  "hid",
+  "identity-credentials-get",
+  "idle-detection",
+  "keyboard-map",
+  "magnetometer",
+  "microphone",
+  "midi",
+  "navigation-override",
+  "payment",
+  "picture-in-picture",
+  "publickey-credentials-get",
+  "screen-wake-lock",
+  "serial",
+  "storage-access",
+  "sync-xhr",
+  "usb",
+  "web-share",
+  "window-management",
+  "xr-spatial-tracking",
+]
+  .map((feature) => `${feature}=()`)
+  .join(", ");
+
+const csp = [
+  "base-uri 'none'",
+  // Extend with external origins (e.g. the Curve API) as tabs start fetching data.
+  "connect-src 'self'",
+  "default-src 'none'",
+  "font-src 'self'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+  "img-src 'self' data:",
+  "script-src 'self'",
+  // Tailwind v4 injects styles via a <style> tag, so 'unsafe-inline' is needed.
+  "style-src 'self' 'unsafe-inline'",
+  "upgrade-insecure-requests",
+  "worker-src 'none'",
+].join("; ");
+
+// Applied to all responses – these have meaningful effect on sub-resources.
+const commonHeaders = {
+  "Content-Security-Policy": "default-src 'none'",
+  "Cross-Origin-Resource-Policy": "same-origin",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "X-Content-Type-Options": "nosniff",
+};
+
+// Applied only to HTML documents – these are navigation-level controls.
+// CSP is stricter for HTML responses so it overrides the commonHeaders CSP.
+const htmlHeaders = {
+  "Content-Security-Policy": csp,
+  "Cross-Origin-Opener-Policy": "same-origin",
+  "Origin-Agent-Cluster": "?1",
+  "Permissions-Policy": permissionsPolicy,
+  "X-DNS-Prefetch-Control": "off",
+  "X-Frame-Options": "DENY",
+};
+
+export default {
+  async fetch(request: Request, env: Env) {
+    const response = await env.ASSETS.fetch(request);
+    const newResponse = new Response(response.body, response);
+
+    for (const [key, value] of Object.entries(commonHeaders)) {
+      newResponse.headers.set(key, value);
+    }
+
+    const contentType = response.headers.get("Content-Type") ?? "";
+    if (contentType.includes("text/html")) {
+      for (const [key, value] of Object.entries(htmlHeaders)) {
+        newResponse.headers.set(key, value);
+      }
+    }
+
+    return newResponse;
+  },
+} satisfies ExportedHandler<Env>;

--- a/internal-dashboard/src/main.tsx
+++ b/internal-dashboard/src/main.tsx
@@ -1,0 +1,12 @@
+import "./index.css";
+
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./app";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/internal-dashboard/src/pages/curve.tsx
+++ b/internal-dashboard/src/pages/curve.tsx
@@ -1,0 +1,8 @@
+export const CurvePage = () => (
+  <section>
+    <h2 className="text-2xl font-semibold text-neutral-950">Curve</h2>
+    <p className="mt-2 text-sm font-medium text-neutral-600">
+      Liquidity tracking coming soon.
+    </p>
+  </section>
+);

--- a/internal-dashboard/src/vite-env.d.ts
+++ b/internal-dashboard/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/internal-dashboard/tsconfig.json
+++ b/internal-dashboard/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@tsconfig/vite-react/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/internal-dashboard/vite.config.ts
+++ b/internal-dashboard/vite.config.ts
@@ -1,0 +1,16 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig, type UserConfig } from "vite";
+
+const config = {
+  plugins: [react(), cloudflare(), tailwindcss()],
+  resolve: {
+    tsconfigPaths: true,
+  },
+  server: {
+    port: 5175,
+  },
+} satisfies UserConfig;
+
+export default defineConfig(config);

--- a/internal-dashboard/wrangler.jsonc
+++ b/internal-dashboard/wrangler.jsonc
@@ -1,0 +1,29 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "main": "src/index.ts",
+  "name": "vetro-internal-dashboard-staging",
+  "compatibility_date": "2026-02-05",
+  "workers_dev": false,
+  "preview_urls": true,
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 0.1,
+    "traces": {
+      "enabled": true,
+      "head_sampling_rate": 0.1,
+    },
+  },
+  "assets": {
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+  },
+  "env": {
+    "production": {
+      "name": "vetro-internal-dashboard",
+      "preview_urls": false,
+    },
+    "staging": {
+      "name": "vetro-internal-dashboard-staging",
+    },
+  },
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,55 @@ importers:
         specifier: 4.65.0
         version: 4.65.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
+  internal-dashboard:
+    dependencies:
+      react:
+        specifier: 19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
+      react-router:
+        specifier: 7.12.0
+        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: 1.23.1
+        version: 1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260205.0)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@cloudflare/workers-types':
+        specifier: 4.20260504.1
+        version: 4.20260504.1
+      '@tailwindcss/vite':
+        specifier: 4.3.0
+        version: 4.3.0(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+      '@tsconfig/vite-react':
+        specifier: 7.0.2
+        version: 7.0.2
+      '@types/node':
+        specifier: 24.1.0
+        version: 24.1.0
+      '@types/react':
+        specifier: 19.2.9
+        version: 19.2.9
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.9)
+      '@vitejs/plugin-react':
+        specifier: 6.0.1
+        version: 6.0.1(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+      tailwindcss:
+        specifier: 4.3.0
+        version: 4.3.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 8.0.13
+        version: 8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4)
+      wrangler:
+        specifier: 4.63.0
+        version: 4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+
   landing:
     devDependencies:
       '@tailwindcss/cli':
@@ -383,7 +432,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.23.1
-        version: 1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260205.0)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+        version: 1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260329.1)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@cloudflare/workers-types':
         specifier: 4.20260504.1
         version: 4.20260504.1
@@ -8106,6 +8155,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==, tarball: https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -9254,6 +9304,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260205.0
 
+  '@cloudflare/unenv-preset@2.12.0(unenv@2.0.0-rc.24)(workerd@1.20260329.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260329.1
+
   '@cloudflare/unenv-preset@2.12.1(unenv@2.0.0-rc.24)(workerd@1.20260212.0)':
     dependencies:
       unenv: 2.0.0-rc.24
@@ -9269,6 +9325,19 @@ snapshots:
   '@cloudflare/vite-plugin@1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260205.0)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@cloudflare/unenv-preset': 2.12.0(unenv@2.0.0-rc.24)(workerd@1.20260205.0)
+      miniflare: 4.20260205.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      unenv: 2.0.0-rc.24
+      vite: 8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4)
+      wrangler: 4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - workerd
+
+  '@cloudflare/vite-plugin@1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260329.1)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@cloudflare/unenv-preset': 2.12.0(unenv@2.0.0-rc.24)(workerd@1.20260329.1)
       miniflare: 4.20260205.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       unenv: 2.0.0-rc.24
       vite: 8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ overrides:
 
 packages:
   - "api"
+  - "internal-dashboard"
   - "landing"
   - "packages/*"
   - "subgraph"


### PR DESCRIPTION
### Description

Scaffolds a new internal-facing dashboard as a separate workspace (`internal-dashboard`). It's a Vite + React + TypeScript + Tailwind v4 SPA deployed to Cloudflare, modeled on the existing `web/` workspace and styled after the `network-monitor` dashboard (header + horizontal tab nav + white content area).

The app is built around "tabs" that each map to a URL. For now there's a single **Curve** tab (`/curve`) rendering a hello-world placeholder — pool-liquidity tracking will come in a follow-up. No data is fetched yet.

Also:
- Registers the workspace in `pnpm-workspace.yaml` and wires it into the root ESLint config.
- Completes the root README's workspace list (adds `internal-dashboard` plus the previously-missing `api`, `landing`, and `subgraph`).
- Dev server runs on port 5175 to avoid colliding with `web/`'s dev (5173) and Playwright (5174) ports.

Pinned all dependencies to the exact versions already used elsewhere in the monorepo.

### Screenshots

<!-- Adding a screenshot of the Curve tab. -->

<img width="3750" height="1652" alt="image" src="https://github.com/user-attachments/assets/d9ffe4b8-c3ce-4c30-a6e7-14df8a7a18a7" />

placeholder for what's to come

### Related issue(s)

Related to #474

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.