### PR TITLE
Align pool info columns on Earn page

### DIFF
--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -72,15 +72,19 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
         ) : (
           <Skeleton borderRadius={8} height={40} width={40} />
         )}
-        <PoolInfoItem label="Token" value={peggedToken?.symbol} />
-        <PoolInfoItem label={t("pages.earn.pool-info.pool-contract")}>
-          <ExternalLink
-            className="text-xsm font-semibold text-gray-600 transition-colors hover:text-gray-900"
-            href={`${explorerBaseUrl}/address/${stakingVaultAddress}`}
-          >
-            {formatEvmAddress(stakingVaultAddress)}
-          </ExternalLink>
-        </PoolInfoItem>
+        <div className="contents md:*:w-16">
+          <PoolInfoItem label="Token" value={peggedToken?.symbol} />
+        </div>
+        <div className="contents md:*:w-32">
+          <PoolInfoItem label={t("pages.earn.pool-info.pool-contract")}>
+            <ExternalLink
+              className="text-xsm font-semibold text-gray-600 transition-colors hover:text-gray-900"
+              href={`${explorerBaseUrl}/address/${stakingVaultAddress}`}
+            >
+              {formatEvmAddress(stakingVaultAddress)}
+            </ExternalLink>
+          </PoolInfoItem>
+        </div>
         <PoolInfoItem
           isLoading={isLoadingDeposits || (!prices && !isPricesError)}
           label={t("pages.earn.pool-info.pool-deposits")}


### PR DESCRIPTION
### Description

The "Token" and "Pool contract" items in the Earn page's pool info bar rendered at variable widths — "VUSD" vs "vetBTC", and shortened addresses that differ in width under a proportional font — which shifted every downstream column out of alignment between pools.

Both items are now wrapped in `display:contents` divs that fix their width at the `md` breakpoint (`md:*:w-16` / `md:*:w-32`). Using `display:contents` keeps the items as direct flex/grid children so the row layout is unchanged, and the `md:` prefix leaves the mobile `grid-cols-2` layout untouched.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

<img width="1018" height="744" alt="image" src="https://github.com/user-attachments/assets/49947f61-6d3b-464f-83f8-0651e8de5760" />


### Related issue(s)

Closes #479

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.