### PR TITLE
Proxy price calls to Hemi Portal API

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -6,7 +6,7 @@ Service that provides data to the Vetro web application.
 
 ### `GET /prices`
 
-Proxies the portal API token prices endpoint. Returns the upstream response as-is.
+Proxies the portal API token prices endpoint. Returns the upstream response as-is on success.
 
 #### Sample response
 

--- a/api/README.md
+++ b/api/README.md
@@ -4,6 +4,23 @@ Service that provides data to the Vetro web application.
 
 ## Data endpoints
 
+### `GET /prices`
+
+Proxies the portal API token prices endpoint. Returns the upstream response as-is.
+
+#### Sample response
+
+```json
+{
+  "prices": {
+    "ETH": "2450.12",
+    "BTC": "65000.00",
+    "USDT": "0.999881",
+    "USDC": "1.00009"
+  }
+}
+```
+
 ### `GET /analytics/pegged-token-backing/:gatewayAddress`
 
 Get the total strategic reserves and the total surplus for a given gateway's pegged token.
@@ -240,6 +257,7 @@ Secrets are set separately using the Wrangler CLI.
 | MERKL_OPPORTUNITY_SVETBTC | Merkl opportunity id for the sVetBTC staking vault. Optional; if unset, that vault yields no rewards. |                         |
 | MERKL_OPPORTUNITY_SVUSD   | Merkl opportunity id for the sVUSD staking vault. Optional; if unset, that vault yields no rewards.   |                         |
 | ORIGINS                   | Comma-separated list of allowed origins. (1)                                                          | `http://localhost:5173` |
+| PORTAL_API_URL            | Upstream portal API base URL for token prices.                                                        | (see wrangler.jsonc)    |
 | SUBGRAPH_API_KEY          | The subgraph API key.                                                                                 |                         |
 | SUBGRAPH_ID               | The subgraph id.                                                                                      |                         |
 | SUBGRAPH_URL_TEMPLATE     | The subgraph URL template. (2)                                                                        | (localhost)             |

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -39,7 +39,7 @@ app.get(
   }),
   async function (c) {
     try {
-      const response = await fetch(`${c.env.PORTAL_API_URL}/prices`);
+      const response = await fetch(new URL("/prices", c.env.PORTAL_API_URL));
       if (!response.ok) {
         throw new Error(`upstream returned ${response.status}`);
       }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -38,7 +38,7 @@ app.get(
     cacheName: "vetro-api",
   }),
   async function (c) {
-    let response;
+    let response: Response;
     try {
       response = await fetch(new URL("/prices", c.env.PORTAL_API_URL));
     } catch (error) {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -38,15 +38,25 @@ app.get(
     cacheName: "vetro-api",
   }),
   async function (c) {
+    let response;
     try {
-      const response = await fetch(new URL("/prices", c.env.PORTAL_API_URL));
-      if (!response.ok) {
-        throw new Error(`upstream returned ${response.status}`);
-      }
+      response = await fetch(new URL("/prices", c.env.PORTAL_API_URL));
+    } catch (error) {
+      console.error("Hemi Portal API unreachable:", error.message);
+      return c.json({ error: "Service Unavailable" }, 503);
+    }
+
+    if (!response.ok) {
+      console.warn(`Hemi Portal API returned ${response.status}`);
+      return c.json({ error: "Bad Gateway" }, 502);
+    }
+
+    try {
       const data = await response.json();
       return c.json(data);
     } catch (error) {
-      throw new Error(`Failed to get token prices: ${error.message}`);
+      console.warn("Hemi Portal API returned invalid JSON:", error.message);
+      return c.json({ error: "Bad Gateway" }, 502);
     }
   },
 );

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -32,6 +32,26 @@ app.use("*", async function (c, next) {
 app.use("*", securityHeaders);
 
 app.get(
+  "/prices",
+  cache({
+    cacheControl: "max-age=60",
+    cacheName: "vetro-api",
+  }),
+  async function (c) {
+    try {
+      const response = await fetch(`${c.env.PORTAL_API_URL}/prices`);
+      if (!response.ok) {
+        throw new Error(`upstream returned ${response.status}`);
+      }
+      const data = await response.json();
+      return c.json(data);
+    } catch (error) {
+      throw new Error(`Failed to get token prices: ${error.message}`);
+    }
+  },
+);
+
+app.get(
   "/analytics/pegged-token-backing/:gatewayAddress",
   validateGatewayAddress,
   cache({

--- a/api/src/worker-env.d.ts
+++ b/api/src/worker-env.d.ts
@@ -6,6 +6,7 @@ interface Env {
   MERKL_OPPORTUNITY_SVETBTC?: string;
   MERKL_OPPORTUNITY_SVUSD?: string;
   ORIGINS: string;
+  PORTAL_API_URL: string;
   SUBGRAPH_API_KEY?: string;
   SUBGRAPH_ID?: string;
   SUBGRAPH_URL_TEMPLATE: string;

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -15,6 +15,7 @@
     "MERKL_OPPORTUNITY_SVETBTC": "",
     "MERKL_OPPORTUNITY_SVUSD": "",
     "ORIGINS": "http://localhost:3000,http://localhost:5173",
+    "PORTAL_API_URL": "https://portal-api.hemi.xyz",
     "SUBGRAPH_URL_TEMPLATE": "http://localhost:8000/subgraphs/name/vetro-app-subgraph",
   },
   "env": {
@@ -23,6 +24,7 @@
       "vars": {
         "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
         "ORIGINS": "https://*.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev",
+        "PORTAL_API_URL": "https://portal-api.hemi.xyz",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
       },
@@ -41,6 +43,7 @@
       "vars": {
         "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
         "ORIGINS": "https://app.vetro.org,https://beta.vetro.org,https://*.hemi.xyz",
+        "PORTAL_API_URL": "https://portal-api.hemi.xyz",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
       },

--- a/web/.env
+++ b/web/.env
@@ -1,3 +1,2 @@
-VITE_PORTAL_API_URL="https://portal-api.hemi.xyz"
 VITE_RPC_URL_MAINNET="https://eth.drpc.org"
 VITE_VETRO_API_URL="https://vetro-api.letshamsterdance.xyz"

--- a/web/README.md
+++ b/web/README.md
@@ -11,7 +11,6 @@ Vite only exposes variables prefixed with `VITE_` to the client bundle. Set thes
 | Variable               | Required | Description                                                                                    |
 | ---------------------- | -------- | ---------------------------------------------------------------------------------------------- |
 | `VITE_DEPLOY_ENV`      | No       | Set to `"production"` to hide source maps from browsers. Any other value serves them publicly. |
-| `VITE_PORTAL_API_URL`  | Yes      | Hemi Portal API base URL (used for token prices).                                              |
 | `VITE_RPC_URL_MAINNET` | No       | RPC URL for Ethereum mainnet. Falls back to viem's default when unset.                         |
 | `VITE_SENTRY_DSN`      | No       | Sentry DSN. When unset, Sentry is disabled.                                                    |
 | `VITE_VETRO_API_URL`   | Yes      | Vetro backend API base URL (analytics, APR history, exit tickets, rewards, etc.).              |

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -31,7 +31,6 @@ export default defineConfig({
       // Swap/redeem is fully on-chain; the backend APIs only supply USD display
       // values. Disable them so e2e stays hermetic (prices render as $0, which
       // these tests don't assert on). isValidUrl("") is false → query disabled.
-      VITE_PORTAL_API_URL: "",
       VITE_RPC_URL_MAINNET: ANVIL_URL,
       VITE_VETRO_API_URL: "",
     },

--- a/web/src/hooks/useTokenPrices.ts
+++ b/web/src/hooks/useTokenPrices.ts
@@ -4,6 +4,7 @@ import {
   useQuery,
 } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
+import { isValidUrl } from "utils/url";
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
 
@@ -20,6 +21,7 @@ export const tokenPricesOptions = <TSelect = Prices>(
   options: QueryOptions<TSelect> = {} as QueryOptions<TSelect>,
 ) =>
   queryOptions({
+    enabled: apiUrl !== undefined && isValidUrl(apiUrl),
     queryFn: () =>
       fetch(`${apiUrl}/prices`).then(({ prices }) => prices as Prices),
     queryKey: tokenPricesQueryKey(),

--- a/web/src/hooks/useTokenPrices.ts
+++ b/web/src/hooks/useTokenPrices.ts
@@ -4,9 +4,8 @@ import {
   useQuery,
 } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
-import { isValidUrl } from "utils/url";
 
-const apiUrl = import.meta.env.VITE_PORTAL_API_URL;
+const apiUrl = import.meta.env.VITE_VETRO_API_URL;
 
 type Prices = Record<string, string>;
 
@@ -21,7 +20,6 @@ export const tokenPricesOptions = <TSelect = Prices>(
   options: QueryOptions<TSelect> = {} as QueryOptions<TSelect>,
 ) =>
   queryOptions({
-    enabled: apiUrl !== undefined && isValidUrl(apiUrl),
     queryFn: () =>
       fetch(`${apiUrl}/prices`).then(({ prices }) => prices as Prices),
     queryKey: tokenPricesQueryKey(),

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -13,7 +13,6 @@ type Env = {
 const rpcUrls = allChains.flatMap((chain) => chain.rpcUrls.default.http);
 
 const allUrls: (string | undefined)[] = [
-  import.meta.env.VITE_PORTAL_API_URL,
   import.meta.env.VITE_VETRO_API_URL,
   ...rpcUrls,
   import.meta.env.VITE_SENTRY_DSN,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This pull request updates how token prices are fetched and served in the Vetro web application. The backend API now proxies token price data from the upstream Portal API, and the frontend is updated to consume this new endpoint. This removes the need for the frontend to directly configure or access the Portal API, simplifying environment setup and improving encapsulation.

**Backend changes:**

* Added a new `/prices` endpoint to the backend (`api/src/index.ts`) that proxies token prices from the upstream Portal API, including caching for 60 seconds.
* Added the `PORTAL_API_URL` environment variable to backend configuration files (`api/wrangler.jsonc`) for all environments. [[1]](diffhunk://#diff-70b6e0bdc7835364f2aed61e9da9392f1d8ed23d7e35467116eccb9b9d429600R18) [[2]](diffhunk://#diff-70b6e0bdc7835364f2aed61e9da9392f1d8ed23d7e35467116eccb9b9d429600R27) [[3]](diffhunk://#diff-70b6e0bdc7835364f2aed61e9da9392f1d8ed23d7e35467116eccb9b9d429600R46)
* Updated backend documentation to describe the new `/prices` endpoint and document the new environment variable. [[1]](diffhunk://#diff-c7b1c23e00a1fd0378f6ea41a7dfe1c9e043d766f738dba26860c783b82e8c6aR7-R23) [[2]](diffhunk://#diff-c7b1c23e00a1fd0378f6ea41a7dfe1c9e043d766f738dba26860c783b82e8c6aR260)

**Frontend changes:**

* Updated the frontend to fetch token prices from the backend’s `/prices` endpoint (`useTokenPrices.ts`), removing direct use of the Portal API URL and related validation logic. [[1]](diffhunk://#diff-df2050d9013a44a9190148118eb61e093bd5bed04fd86e49ea9d7edec5127dc3L7-R8) [[2]](diffhunk://#diff-df2050d9013a44a9190148118eb61e093bd5bed04fd86e49ea9d7edec5127dc3L24)
* Removed the `VITE_PORTAL_API_URL` environment variable from frontend configuration and documentation, as it is no longer needed. [[1]](diffhunk://#diff-6fe6c15ea311601124e92e2af9336a637c7701cc3e0971361c07922a82d2536bL1) [[2]](diffhunk://#diff-4a534cf0dab53faad7a19d1926cb05f63ebf793e827bdf11a4a19e0e654ef639L14) [[3]](diffhunk://#diff-3541c99a8c5af3845be2fe8aea134bb0b92773cbc8e0b1348fca8887f3542181L34) [[4]](diffhunk://#diff-209d53bbda33adc7e939f4ea5f85d9aad16af863d419ed40c1f2f151196c820eL16)

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
