### PR TITLE
Show skeleton for Exit Queue while checks load

### DIFF
--- a/web/src/pages/earn/components/exitTickets/index.tsx
+++ b/web/src/pages/earn/components/exitTickets/index.tsx
@@ -33,7 +33,7 @@ const statusLabels = {
   withdrawn: "pages.earn.exit-tickets.withdrawn",
 } as const;
 
-const getColumns = ({
+export const getColumns = ({
   isWithdrawingAll,
   onDeleteSuccess,
   onWithdrawingChange,

--- a/web/src/pages/earn/components/exitTickets/skeleton.tsx
+++ b/web/src/pages/earn/components/exitTickets/skeleton.tsx
@@ -1,0 +1,31 @@
+import { Table } from "components/base/table";
+import { TopSection } from "components/base/table/topSection";
+import { useTranslation } from "react-i18next";
+
+import { getColumns } from ".";
+
+// Stable reference
+const emptyArray: never[] = [];
+
+export function ExitTicketsSkeleton() {
+  const { t } = useTranslation();
+  const columns = getColumns({
+    isWithdrawingAll: false,
+    onDeleteSuccess() {},
+    onWithdrawingChange() {},
+    t,
+  });
+
+  return (
+    <div>
+      <TopSection title={t("pages.earn.exit-tickets.title")} />
+      <Table
+        columns={columns}
+        data={emptyArray}
+        loading
+        maxBodyHeight="280px"
+        priorityColumnIdsOnSmall={["actions"]}
+      />
+    </div>
+  );
+}

--- a/web/src/pages/earn/hooks/useShowExitTickets.ts
+++ b/web/src/pages/earn/hooks/useShowExitTickets.ts
@@ -13,8 +13,10 @@ export function useShowExitTickets() {
 
   return useQueries({
     // Show the exit tickets section when at least one vault cannot
-    // instant-withdraw (including while still loading), since that vault
-    // requires the non-instant request flow that produces exit tickets.
+    // instant-withdraw, since that vault requires the non-instant
+    // request flow that produces exit tickets. The loading state is
+    // exposed separately via `isLoading` so the caller can show a
+    // skeleton while the checks resolve.
     combine: (results) => ({
       data: results.some((result) => result.data === false),
       isLoading: results.some((result) => result.isLoading),

--- a/web/src/pages/earn/hooks/useShowExitTickets.ts
+++ b/web/src/pages/earn/hooks/useShowExitTickets.ts
@@ -17,6 +17,7 @@ export function useShowExitTickets() {
     // requires the non-instant request flow that produces exit tickets.
     combine: (results) => ({
       data: results.some((result) => result.data === false),
+      isLoading: results.some((result) => result.isLoading),
     }),
     queries: stakingVaultAddresses.map((stakingVaultAddress) =>
       canInstantWithdrawOptions({

--- a/web/src/pages/earn/index.tsx
+++ b/web/src/pages/earn/index.tsx
@@ -30,7 +30,7 @@ export function Earn() {
           <div className="border-b border-gray-200 bg-gray-100">
             <StripedDivider />
           </div>
-          {isLoading ? <ExitTicketsSkeleton /> : <ExitTickets />}
+          {showExitTickets ? <ExitTickets /> : <ExitTicketsSkeleton />}
         </>
       )}
     </>

--- a/web/src/pages/earn/index.tsx
+++ b/web/src/pages/earn/index.tsx
@@ -5,11 +5,12 @@ import { useTranslation } from "react-i18next";
 
 import { EarnStats } from "./components/earnStats";
 import { ExitTickets } from "./components/exitTickets";
+import { ExitTicketsSkeleton } from "./components/exitTickets/skeleton";
 import { PoolInfoBar } from "./components/poolInfoBar";
 import { useShowExitTickets } from "./hooks/useShowExitTickets";
 
 export function Earn() {
-  const { data: showExitTickets } = useShowExitTickets();
+  const { data: showExitTickets, isLoading } = useShowExitTickets();
   const { t } = useTranslation();
 
   return (
@@ -24,14 +25,12 @@ export function Earn() {
           stakingVaultAddress={stakingVaultAddress}
         />
       ))}
-      {/* TODO add skeleton loading for this section
-      See https://github.com/vetro-protocol/vetro-monorepo/issues/341 */}
-      {showExitTickets && (
+      {(isLoading || showExitTickets) && (
         <>
           <div className="border-b border-gray-200 bg-gray-100">
             <StripedDivider />
           </div>
-          <ExitTickets />
+          {isLoading ? <ExitTicketsSkeleton /> : <ExitTickets />}
         </>
       )}
     </>


### PR DESCRIPTION
### Description

On the Earn page, the Exit Queue (Exit Tickets) section was conditionally rendered based on `useShowExitTickets`, which aggregates `canInstantWithdraw` across all staking vaults. While those checks were in flight the hook returned `false`, so the section was hidden on initial load and then popped in once the queries resolved.

This exposes an `isLoading` flag from `useShowExitTickets` and renders a new `ExitTicketsSkeleton` (the striped divider, section title, and a skeleton table that reuses the existing `Table` loading mode) while the instant-withdraw checks are in flight. The section's layout is now reserved up front, so it no longer flashes/pops when the page hydrates.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/b4d87d11-c7fe-4759-bd45-75c49e65b74d

### Related issue(s)

Closes #341

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
