### PR TITLE
Deploy 2025-06-18

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,17 +2,23 @@
   "extends": ["bloq", "prettier"],
   "ignorePatterns": [
     "api/.wrangler/**/*",
+    "internal-dashboard/dist/**/*",
     "landing/.wrangler/**/*",
     "web/dist/**/*",
     "web/storybook-static/**/*"
   ],
   "overrides": [
     {
-      "excludedFiles": ["subgraph/generated/**/*", "web/dist/**/*"],
+      "excludedFiles": [
+        "internal-dashboard/dist/**/*",
+        "subgraph/generated/**/*",
+        "web/dist/**/*"
+      ],
       "extends": ["bloq/esm", "bloq/typescript", "prettier"],
       "files": [
         "*.{js,mjs}",
         "api/**/*.ts",
+        "internal-dashboard/**/*.{js,ts,tsx}",
         "landing/**/*.ts",
         "packages/**/*.{js,ts,tsx}",
         "subgraph/**/*.ts",

--- a/README.md
+++ b/README.md
@@ -42,5 +42,9 @@ Then authenticate with your Figma account when prompted. The MCP configuration i
 
 The monorepo contains the following workspaces:
 
+- `api` - Service that provides data to the Vetro web application
+- `internal-dashboard` - Internal-facing dashboard for operational metrics
+- `landing` - Static waitlist landing page served via Cloudflare Workers
 - `packages/*` - Shared packages
+- `subgraph` - Subgraph indexing Ethereum mainnet events for the API
 - `web` - Web application

--- a/api/README.md
+++ b/api/README.md
@@ -6,7 +6,7 @@ Service that provides data to the Vetro web application.
 
 ### `GET /prices`
 
-Proxies the portal API token prices endpoint. Returns the upstream response as-is.
+Proxies the portal API token prices endpoint. Returns the upstream response as-is on success.
 
 #### Sample response
 

--- a/api/README.md
+++ b/api/README.md
@@ -4,6 +4,23 @@ Service that provides data to the Vetro web application.
 
 ## Data endpoints
 
+### `GET /prices`
+
+Proxies the portal API token prices endpoint. Returns the upstream response as-is.
+
+#### Sample response
+
+```json
+{
+  "prices": {
+    "ETH": "2450.12",
+    "BTC": "65000.00",
+    "USDT": "0.999881",
+    "USDC": "1.00009"
+  }
+}
+```
+
 ### `GET /analytics/pegged-token-backing/:gatewayAddress`
 
 Get the total strategic reserves and the total surplus for a given gateway's pegged token.
@@ -240,6 +257,7 @@ Secrets are set separately using the Wrangler CLI.
 | MERKL_OPPORTUNITY_SVETBTC | Merkl opportunity id for the sVetBTC staking vault. Optional; if unset, that vault yields no rewards. |                         |
 | MERKL_OPPORTUNITY_SVUSD   | Merkl opportunity id for the sVUSD staking vault. Optional; if unset, that vault yields no rewards.   |                         |
 | ORIGINS                   | Comma-separated list of allowed origins. (1)                                                          | `http://localhost:5173` |
+| PORTAL_API_URL            | Upstream portal API base URL for token prices.                                                        | (see wrangler.jsonc)    |
 | SUBGRAPH_API_KEY          | The subgraph API key.                                                                                 |                         |
 | SUBGRAPH_ID               | The subgraph id.                                                                                      |                         |
 | SUBGRAPH_URL_TEMPLATE     | The subgraph URL template. (2)                                                                        | (localhost)             |

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -39,7 +39,7 @@ app.get(
   }),
   async function (c) {
     try {
-      const response = await fetch(`${c.env.PORTAL_API_URL}/prices`);
+      const response = await fetch(new URL("/prices", c.env.PORTAL_API_URL));
       if (!response.ok) {
         throw new Error(`upstream returned ${response.status}`);
       }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -38,7 +38,7 @@ app.get(
     cacheName: "vetro-api",
   }),
   async function (c) {
-    let response;
+    let response: Response;
     try {
       response = await fetch(new URL("/prices", c.env.PORTAL_API_URL));
     } catch (error) {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -38,15 +38,25 @@ app.get(
     cacheName: "vetro-api",
   }),
   async function (c) {
+    let response;
     try {
-      const response = await fetch(new URL("/prices", c.env.PORTAL_API_URL));
-      if (!response.ok) {
-        throw new Error(`upstream returned ${response.status}`);
-      }
+      response = await fetch(new URL("/prices", c.env.PORTAL_API_URL));
+    } catch (error) {
+      console.error("Hemi Portal API unreachable:", error.message);
+      return c.json({ error: "Service Unavailable" }, 503);
+    }
+
+    if (!response.ok) {
+      console.warn(`Hemi Portal API returned ${response.status}`);
+      return c.json({ error: "Bad Gateway" }, 502);
+    }
+
+    try {
       const data = await response.json();
       return c.json(data);
     } catch (error) {
-      throw new Error(`Failed to get token prices: ${error.message}`);
+      console.warn("Hemi Portal API returned invalid JSON:", error.message);
+      return c.json({ error: "Bad Gateway" }, 502);
     }
   },
 );

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -32,6 +32,26 @@ app.use("*", async function (c, next) {
 app.use("*", securityHeaders);
 
 app.get(
+  "/prices",
+  cache({
+    cacheControl: "max-age=60",
+    cacheName: "vetro-api",
+  }),
+  async function (c) {
+    try {
+      const response = await fetch(`${c.env.PORTAL_API_URL}/prices`);
+      if (!response.ok) {
+        throw new Error(`upstream returned ${response.status}`);
+      }
+      const data = await response.json();
+      return c.json(data);
+    } catch (error) {
+      throw new Error(`Failed to get token prices: ${error.message}`);
+    }
+  },
+);
+
+app.get(
   "/analytics/pegged-token-backing/:gatewayAddress",
   validateGatewayAddress,
   cache({

--- a/api/src/worker-env.d.ts
+++ b/api/src/worker-env.d.ts
@@ -6,6 +6,7 @@ interface Env {
   MERKL_OPPORTUNITY_SVETBTC?: string;
   MERKL_OPPORTUNITY_SVUSD?: string;
   ORIGINS: string;
+  PORTAL_API_URL: string;
   SUBGRAPH_API_KEY?: string;
   SUBGRAPH_ID?: string;
   SUBGRAPH_URL_TEMPLATE: string;

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -15,6 +15,7 @@
     "MERKL_OPPORTUNITY_SVETBTC": "",
     "MERKL_OPPORTUNITY_SVUSD": "",
     "ORIGINS": "http://localhost:3000,http://localhost:5173",
+    "PORTAL_API_URL": "https://portal-api.hemi.xyz",
     "SUBGRAPH_URL_TEMPLATE": "http://localhost:8000/subgraphs/name/vetro-app-subgraph",
   },
   "env": {
@@ -23,6 +24,7 @@
       "vars": {
         "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
         "ORIGINS": "https://*.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev",
+        "PORTAL_API_URL": "https://portal-api.hemi.xyz",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
       },
@@ -41,6 +43,7 @@
       "vars": {
         "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
         "ORIGINS": "https://app.vetro.org,https://beta.vetro.org,https://*.hemi.xyz",
+        "PORTAL_API_URL": "https://portal-api.hemi.xyz",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
       },

--- a/internal-dashboard/README.md
+++ b/internal-dashboard/README.md
@@ -1,0 +1,24 @@
+# Internal Dashboard
+
+Internal-facing dashboard for tracking various operational metrics. Each metric area
+lives on its own tab, mapped to a URL.
+
+- **Curve** (`/curve`) — liquidity on Curve pools _(placeholder for now)_.
+
+It's a Vite + React + TypeScript + Tailwind v4 SPA, deployed to Cloudflare via a Worker
+that serves the static assets and injects security headers (see `src/index.ts`).
+
+## Development
+
+```sh
+pnpm dev      # start the Vite dev server
+pnpm build    # typecheck + production build
+pnpm preview  # preview the production build
+pnpm tsc      # typecheck only
+```
+
+## Deployment
+
+Deployed to Cloudflare with `wrangler` (see `wrangler.jsonc`). The `staging` and
+`production` environments map to the `vetro-internal-dashboard-staging` and
+`vetro-internal-dashboard` Workers respectively.

--- a/internal-dashboard/index.html
+++ b/internal-dashboard/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Internal Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/internal-dashboard/package.json
+++ b/internal-dashboard/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@vetro-protocol/internal-dashboard",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "prepreview": "pnpm run build",
+    "preview": "vite preview",
+    "tsc": "tsc"
+  },
+  "dependencies": {
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
+    "react-router": "7.12.0"
+  },
+  "devDependencies": {
+    "@cloudflare/vite-plugin": "1.23.1",
+    "@cloudflare/workers-types": "4.20260504.1",
+    "@tailwindcss/vite": "4.3.0",
+    "@tsconfig/vite-react": "7.0.2",
+    "@types/node": "24.1.0",
+    "@types/react": "19.2.9",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.1",
+    "tailwindcss": "4.3.0",
+    "typescript": "5.9.3",
+    "vite": "8.0.13",
+    "wrangler": "4.63.0"
+  },
+  "private": true,
+  "type": "module"
+}

--- a/internal-dashboard/package.json
+++ b/internal-dashboard/package.json
@@ -2,7 +2,7 @@
   "name": "@vetro-protocol/internal-dashboard",
   "version": "1.0.0",
   "scripts": {
-    "build": "vite build",
+    "build": "tsc && vite build",
     "dev": "vite",
     "prepreview": "pnpm run build",
     "preview": "vite preview",

--- a/internal-dashboard/src/app.tsx
+++ b/internal-dashboard/src/app.tsx
@@ -1,0 +1,20 @@
+import { BrowserRouter, Navigate, Route, Routes } from "react-router";
+
+import { Header } from "./components/header";
+import { Layout } from "./components/layout";
+import { CurvePage } from "./pages/curve";
+
+export const App = () => (
+  <div className="lg:px-4 xl:px-8 2xl:px-28">
+    <Header />
+    <BrowserRouter>
+      <Layout>
+        <Routes>
+          <Route element={<Navigate replace to="/curve" />} path="/" />
+          <Route element={<CurvePage />} path="/curve" />
+          <Route element={<Navigate replace to="/curve" />} path="*" />
+        </Routes>
+      </Layout>
+    </BrowserRouter>
+  </div>
+);

--- a/internal-dashboard/src/components/header.tsx
+++ b/internal-dashboard/src/components/header.tsx
@@ -1,0 +1,7 @@
+export const Header = () => (
+  <header className="flex w-full items-center p-4">
+    <h1 className="mx-auto text-xl font-medium text-black">
+      Internal Dashboard
+    </h1>
+  </header>
+);

--- a/internal-dashboard/src/components/headerTabs.tsx
+++ b/internal-dashboard/src/components/headerTabs.tsx
@@ -1,0 +1,28 @@
+import { type ReactNode } from "react";
+import { NavLink } from "react-router";
+
+type Props = {
+  children: ReactNode;
+  to: string;
+};
+
+const Tab = ({ children, to }: Props) => (
+  <NavLink
+    className={({ isActive }) =>
+      `rounded-md px-2 py-1 text-sm font-medium ${
+        isActive
+          ? "border border-solid border-neutral-300/55 bg-white text-neutral-950 shadow-xs"
+          : "bg-neutral-100 text-neutral-600 hover:text-neutral-950"
+      }`
+    }
+    to={to}
+  >
+    {children}
+  </NavLink>
+);
+
+export const HeaderTabs = () => (
+  <nav className="mb-12 flex items-center gap-x-2 border-y border-solid border-y-neutral-300/55 p-4">
+    <Tab to="/curve">Curve</Tab>
+  </nav>
+);

--- a/internal-dashboard/src/components/layout.tsx
+++ b/internal-dashboard/src/components/layout.tsx
@@ -1,0 +1,14 @@
+import { type ReactNode } from "react";
+
+import { HeaderTabs } from "./headerTabs";
+
+type Props = {
+  children: ReactNode;
+};
+
+export const Layout = ({ children }: Props) => (
+  <>
+    <HeaderTabs />
+    <div className="mx-auto min-h-screen bg-white p-4">{children}</div>
+  </>
+);

--- a/internal-dashboard/src/index.css
+++ b/internal-dashboard/src/index.css
@@ -1,0 +1,10 @@
+@import "tailwindcss";
+
+@theme {
+  --shadow-primary:
+    0px 0px 2px 0px rgba(10, 10, 10, 0.1),
+    0px 8px 12px -4px rgba(10, 10, 10, 0.08),
+    0px 1px 2px 0px rgba(10, 10, 10, 0.1);
+  --text-sm: 0.8125rem; /* 13px */
+  --text-sm--line-height: 20px;
+}

--- a/internal-dashboard/src/index.ts
+++ b/internal-dashboard/src/index.ts
@@ -1,0 +1,114 @@
+// Worker entry point – proxies static assets and injects security headers.
+
+/// <reference types="@cloudflare/workers-types" />
+
+type Env = {
+  ASSETS: Fetcher;
+};
+
+// Deny all permissions – mirrors web/src/index.ts.
+const permissionsPolicy = [
+  "accelerometer",
+  "ambient-light-sensor",
+  "attribution-reporting",
+  "autoplay",
+  "battery",
+  "bluetooth",
+  "camera",
+  "ch-ua",
+  "ch-ua-arch",
+  "ch-ua-bitness",
+  "ch-ua-full-version",
+  "ch-ua-full-version-list",
+  "ch-ua-mobile",
+  "ch-ua-model",
+  "ch-ua-platform",
+  "ch-ua-platform-version",
+  "ch-ua-wow64",
+  "compute-pressure",
+  "cross-origin-isolated",
+  "direct-sockets",
+  "display-capture",
+  "encrypted-media",
+  "execution-while-not-rendered",
+  "execution-while-out-of-viewport",
+  "fullscreen",
+  "geolocation",
+  "gyroscope",
+  "hid",
+  "identity-credentials-get",
+  "idle-detection",
+  "keyboard-map",
+  "magnetometer",
+  "microphone",
+  "midi",
+  "navigation-override",
+  "payment",
+  "picture-in-picture",
+  "publickey-credentials-get",
+  "screen-wake-lock",
+  "serial",
+  "storage-access",
+  "sync-xhr",
+  "usb",
+  "web-share",
+  "window-management",
+  "xr-spatial-tracking",
+]
+  .map((feature) => `${feature}=()`)
+  .join(", ");
+
+const csp = [
+  "base-uri 'none'",
+  // Extend with external origins (e.g. the Curve API) as tabs start fetching data.
+  "connect-src 'self'",
+  "default-src 'none'",
+  "font-src 'self'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+  "img-src 'self' data:",
+  "script-src 'self'",
+  // Tailwind v4 injects styles via a <style> tag, so 'unsafe-inline' is needed.
+  "style-src 'self' 'unsafe-inline'",
+  "upgrade-insecure-requests",
+  "worker-src 'none'",
+].join("; ");
+
+// Applied to all responses – these have meaningful effect on sub-resources.
+const commonHeaders = {
+  "Content-Security-Policy": "default-src 'none'",
+  "Cross-Origin-Resource-Policy": "same-origin",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "X-Content-Type-Options": "nosniff",
+};
+
+// Applied only to HTML documents – these are navigation-level controls.
+// CSP is stricter for HTML responses so it overrides the commonHeaders CSP.
+const htmlHeaders = {
+  "Content-Security-Policy": csp,
+  "Cross-Origin-Opener-Policy": "same-origin",
+  "Origin-Agent-Cluster": "?1",
+  "Permissions-Policy": permissionsPolicy,
+  "X-DNS-Prefetch-Control": "off",
+  "X-Frame-Options": "DENY",
+};
+
+export default {
+  async fetch(request: Request, env: Env) {
+    const response = await env.ASSETS.fetch(request);
+    const newResponse = new Response(response.body, response);
+
+    for (const [key, value] of Object.entries(commonHeaders)) {
+      newResponse.headers.set(key, value);
+    }
+
+    const contentType = response.headers.get("Content-Type") ?? "";
+    if (contentType.includes("text/html")) {
+      for (const [key, value] of Object.entries(htmlHeaders)) {
+        newResponse.headers.set(key, value);
+      }
+    }
+
+    return newResponse;
+  },
+} satisfies ExportedHandler<Env>;

--- a/internal-dashboard/src/main.tsx
+++ b/internal-dashboard/src/main.tsx
@@ -1,0 +1,12 @@
+import "./index.css";
+
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./app";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/internal-dashboard/src/pages/curve.tsx
+++ b/internal-dashboard/src/pages/curve.tsx
@@ -1,0 +1,8 @@
+export const CurvePage = () => (
+  <section>
+    <h2 className="text-2xl font-semibold text-neutral-950">Curve</h2>
+    <p className="mt-2 text-sm font-medium text-neutral-600">
+      Liquidity tracking coming soon.
+    </p>
+  </section>
+);

--- a/internal-dashboard/src/vite-env.d.ts
+++ b/internal-dashboard/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/internal-dashboard/tsconfig.json
+++ b/internal-dashboard/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@tsconfig/vite-react/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/internal-dashboard/vite.config.ts
+++ b/internal-dashboard/vite.config.ts
@@ -1,0 +1,16 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig, type UserConfig } from "vite";
+
+const config = {
+  plugins: [react(), cloudflare(), tailwindcss()],
+  resolve: {
+    tsconfigPaths: true,
+  },
+  server: {
+    port: 5175,
+  },
+} satisfies UserConfig;
+
+export default defineConfig(config);

--- a/internal-dashboard/wrangler.jsonc
+++ b/internal-dashboard/wrangler.jsonc
@@ -1,0 +1,29 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "main": "src/index.ts",
+  "name": "vetro-internal-dashboard-staging",
+  "compatibility_date": "2026-02-05",
+  "workers_dev": false,
+  "preview_urls": true,
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 0.1,
+    "traces": {
+      "enabled": true,
+      "head_sampling_rate": 0.1,
+    },
+  },
+  "assets": {
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+  },
+  "env": {
+    "production": {
+      "name": "vetro-internal-dashboard",
+      "preview_urls": false,
+    },
+    "staging": {
+      "name": "vetro-internal-dashboard-staging",
+    },
+  },
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,55 @@ importers:
         specifier: 4.65.0
         version: 4.65.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
+  internal-dashboard:
+    dependencies:
+      react:
+        specifier: 19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
+      react-router:
+        specifier: 7.12.0
+        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: 1.23.1
+        version: 1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260205.0)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@cloudflare/workers-types':
+        specifier: 4.20260504.1
+        version: 4.20260504.1
+      '@tailwindcss/vite':
+        specifier: 4.3.0
+        version: 4.3.0(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+      '@tsconfig/vite-react':
+        specifier: 7.0.2
+        version: 7.0.2
+      '@types/node':
+        specifier: 24.1.0
+        version: 24.1.0
+      '@types/react':
+        specifier: 19.2.9
+        version: 19.2.9
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.9)
+      '@vitejs/plugin-react':
+        specifier: 6.0.1
+        version: 6.0.1(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+      tailwindcss:
+        specifier: 4.3.0
+        version: 4.3.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 8.0.13
+        version: 8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4)
+      wrangler:
+        specifier: 4.63.0
+        version: 4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+
   landing:
     devDependencies:
       '@tailwindcss/cli':
@@ -383,7 +432,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.23.1
-        version: 1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260205.0)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+        version: 1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260329.1)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@cloudflare/workers-types':
         specifier: 4.20260504.1
         version: 4.20260504.1
@@ -8106,6 +8155,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==, tarball: https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -9254,6 +9304,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260205.0
 
+  '@cloudflare/unenv-preset@2.12.0(unenv@2.0.0-rc.24)(workerd@1.20260329.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260329.1
+
   '@cloudflare/unenv-preset@2.12.1(unenv@2.0.0-rc.24)(workerd@1.20260212.0)':
     dependencies:
       unenv: 2.0.0-rc.24
@@ -9269,6 +9325,19 @@ snapshots:
   '@cloudflare/vite-plugin@1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260205.0)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@cloudflare/unenv-preset': 2.12.0(unenv@2.0.0-rc.24)(workerd@1.20260205.0)
+      miniflare: 4.20260205.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      unenv: 2.0.0-rc.24
+      vite: 8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4)
+      wrangler: 4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - workerd
+
+  '@cloudflare/vite-plugin@1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260329.1)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@cloudflare/unenv-preset': 2.12.0(unenv@2.0.0-rc.24)(workerd@1.20260329.1)
       miniflare: 4.20260205.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       unenv: 2.0.0-rc.24
       vite: 8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ overrides:
 
 packages:
   - "api"
+  - "internal-dashboard"
   - "landing"
   - "packages/*"
   - "subgraph"

--- a/web/.env
+++ b/web/.env
@@ -1,3 +1,2 @@
-VITE_PORTAL_API_URL="https://portal-api.hemi.xyz"
 VITE_RPC_URL_MAINNET="https://eth.drpc.org"
 VITE_VETRO_API_URL="https://vetro-api.letshamsterdance.xyz"

--- a/web/README.md
+++ b/web/README.md
@@ -11,7 +11,6 @@ Vite only exposes variables prefixed with `VITE_` to the client bundle. Set thes
 | Variable               | Required | Description                                                                                    |
 | ---------------------- | -------- | ---------------------------------------------------------------------------------------------- |
 | `VITE_DEPLOY_ENV`      | No       | Set to `"production"` to hide source maps from browsers. Any other value serves them publicly. |
-| `VITE_PORTAL_API_URL`  | Yes      | Hemi Portal API base URL (used for token prices).                                              |
 | `VITE_RPC_URL_MAINNET` | No       | RPC URL for Ethereum mainnet. Falls back to viem's default when unset.                         |
 | `VITE_SENTRY_DSN`      | No       | Sentry DSN. When unset, Sentry is disabled.                                                    |
 | `VITE_VETRO_API_URL`   | Yes      | Vetro backend API base URL (analytics, APR history, exit tickets, rewards, etc.).              |

--- a/web/e2e/fixtures/wallet.ts
+++ b/web/e2e/fixtures/wallet.ts
@@ -1,8 +1,9 @@
 import { TEST_PRIVATE_KEY } from "@hemilabs/anvil-fork-setup/utils";
 import { test as base } from "@playwright/test";
 import { installMockWallet } from "@vetro-protocol/mock-wallet";
-import { http } from "viem";
+import { createTestClient, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
+import { revert, snapshot } from "viem/actions";
 import { mainnet } from "viem/chains";
 
 import { ANVIL_URL } from "../anvil";
@@ -18,6 +19,22 @@ export const test = base.extend({
       page,
       transports: { [mainnet.id]: http(ANVIL_URL) },
     });
+
+    // The fork is started and funded once in globalSetup, then shared across
+    // every test (workers: 1). Without isolation, on-chain mutations from one
+    // test leak into the next — e.g. a redeem leaves the gateway allowance set,
+    // so a later run skips the approval tx and the stepper jumps to "completed"
+    // with no wallet interaction. Snapshot the funded baseline before the test
+    // and revert after, so each test starts from the same chain state.
+    // installMockWallet only injects scripts (no chain writes), so the snapshot
+    // here still captures the clean funded state.
+    const testClient = createTestClient({
+      chain: mainnet,
+      mode: "anvil",
+      transport: http(ANVIL_URL),
+    });
+    const snapshotId = await snapshot(testClient);
     await use(page);
+    await revert(testClient, { id: snapshotId });
   },
 });

--- a/web/e2e/swap.spec.ts
+++ b/web/e2e/swap.spec.ts
@@ -68,21 +68,27 @@ test("swap USDC → VUSD via the gateway", async function ({ page }) {
     page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
   ).toBeVisible({ timeout: 30_000 });
 
-  // Pick USDC as the input token. The trigger opens a modal dialog where
-  // tokens are listed as buttons (pinned grid + rows), not ARIA options.
-  await page
+  // Pick USDC as the input token. The default input is whitelistedTokens[0],
+  // whose ordering isn't guaranteed (anvil forks at the latest block, so the
+  // set/order can differ between local and CI), and clicking an already
+  // selected token won't close the modal. So only open the picker while USDC
+  // isn't selected, and retry if a click doesn't register.
+  const fromTokenSelector = page
     .getByRole("button", { name: "Select token to swap" })
-    .first()
-    .click();
-  const tokenDialog = page.getByRole("dialog");
-  // The modal fades in via an opacity transition. Playwright's visibility
-  // check ignores opacity, so it would otherwise click a token mid-animation
-  // and race the open/close state, leaving the modal stuck open and blocking
-  // the Swap click. Wait for the entrance to finish before selecting.
-  await expect(tokenDialog).toHaveCSS("opacity", "1");
-  await tokenDialog.getByRole("button", { name: /USDC/ }).first().click();
+    .first();
+  await expect(fromTokenSelector).toBeVisible();
+  await expect(async function () {
+    if ((await fromTokenSelector.textContent())?.includes("USDC")) return;
+    await fromTokenSelector.click();
+    const tokenDialog = page.getByRole("dialog");
+    // The modal fades in via an opacity transition. Playwright's visibility
+    // check ignores opacity, so wait for the entrance to finish before clicking.
+    await expect(tokenDialog).toHaveCSS("opacity", "1");
+    await tokenDialog.getByRole("button", { name: /USDC/ }).first().click();
+    await expect(fromTokenSelector).toContainText("USDC", { timeout: 5_000 });
+  }).toPass({ timeout: 20_000 });
   // Ensure the modal is gone before interacting with the form underneath.
-  await expect(tokenDialog).toBeHidden();
+  await expect(page.getByRole("dialog")).toBeHidden();
 
   await page
     .locator('input[type="text"]:not([disabled])')

--- a/web/e2e/swap.spec.ts
+++ b/web/e2e/swap.spec.ts
@@ -70,25 +70,26 @@ test("swap USDC → VUSD via the gateway", async function ({ page }) {
 
   // Pick USDC as the input token. The default input is whitelistedTokens[0],
   // whose ordering isn't guaranteed (anvil forks at the latest block, so the
-  // set/order can differ between local and CI), and clicking an already
-  // selected token won't close the modal. So only open the picker while USDC
-  // isn't selected, and retry if a click doesn't register.
+  // set/order can differ between local and CI). Selecting any token closes the
+  // picker, so we can unconditionally open it and pick USDC — re-selecting it
+  // when it's already the default is a harmless no-op that still closes.
   const fromTokenSelector = page
     .getByRole("button", { name: "Select token to swap" })
     .first();
-  await expect(fromTokenSelector).toBeVisible();
-  await expect(async function () {
-    if ((await fromTokenSelector.textContent())?.includes("USDC")) return;
-    await fromTokenSelector.click();
-    const tokenDialog = page.getByRole("dialog");
-    // The modal fades in via an opacity transition. Playwright's visibility
-    // check ignores opacity, so wait for the entrance to finish before clicking.
-    await expect(tokenDialog).toHaveCSS("opacity", "1");
-    await tokenDialog.getByRole("button", { name: /USDC/ }).first().click();
-    await expect(fromTokenSelector).toContainText("USDC", { timeout: 5_000 });
-  }).toPass({ timeout: 20_000 });
-  // Ensure the modal is gone before interacting with the form underneath.
-  await expect(page.getByRole("dialog")).toBeHidden();
+  await fromTokenSelector.click();
+
+  // Wait for the picker to actually open before clicking inside it.
+  const fromTokenDialog = page.getByRole("dialog", { name: "Select a token" });
+  await expect(fromTokenDialog).toBeVisible();
+
+  // Auto-waits for the USDC row, covering the CI race where the token list is
+  // still loading when the dialog opens.
+  await fromTokenDialog.getByRole("button", { name: /USDC/ }).first().click();
+
+  await expect(fromTokenSelector).toContainText("USDC");
+  // Selecting a token closes the picker; ensure it's gone before interacting
+  // with the form underneath.
+  await expect(fromTokenDialog).toBeHidden();
 
   await page
     .locator('input[type="text"]:not([disabled])')
@@ -187,23 +188,23 @@ test("redeem VUSD → USDC via the gateway (instant redeem)", async function ({
     .locator("..")
     .getByRole("button", { name: "Select token to swap" });
   await expect(toTokenSelector).toBeVisible();
-  // Switch the output to USDC. Re-check inside toPass: a late form re-init can
-  // flip the default output, and clicking an already-selected token won't close
-  // the modal — so only open it while USDC isn't selected, and retry if a click
-  // doesn't register.
-  await expect(async function () {
-    if ((await toTokenSelector.textContent())?.includes("USDC")) return;
-    await toTokenSelector.click();
-    const tokenDialog = page.getByRole("dialog");
-    // The modal fades in via an opacity transition. Playwright's visibility
-    // check ignores opacity, so wait for the entrance to finish before clicking.
-    await expect(tokenDialog).toHaveCSS("opacity", "1");
-    await tokenDialog.getByRole("button", { name: /USDC/ }).first().click();
-    await expect(toTokenSelector).toContainText("USDC", { timeout: 5_000 });
-  }).toPass({ timeout: 20_000 });
-  // The modal closes via a CSS transition; ensure it's gone before interacting
+  // Switch the output to USDC. Selecting any token closes the picker, so we can
+  // unconditionally open it and pick USDC — re-selecting it when it's already
+  // the default is a harmless no-op that still closes.
+  await toTokenSelector.click();
+
+  // Wait for the picker to actually open before clicking inside it.
+  const toTokenDialog = page.getByRole("dialog", { name: "Select a token" });
+  await expect(toTokenDialog).toBeVisible();
+
+  // Auto-waits for the USDC row, covering the CI race where the token list is
+  // still loading when the dialog opens.
+  await toTokenDialog.getByRole("button", { name: /USDC/ }).first().click();
+
+  await expect(toTokenSelector).toContainText("USDC");
+  // Selecting a token closes the picker; ensure it's gone before interacting
   // with the form underneath.
-  await expect(page.getByRole("dialog")).toBeHidden();
+  await expect(toTokenDialog).toBeHidden();
 
   await page
     .locator('input[type="text"]:not([disabled])')

--- a/web/e2e/swap.spec.ts
+++ b/web/e2e/swap.spec.ts
@@ -50,20 +50,11 @@ test("swap USDC → VUSD via the gateway", async function ({ page }) {
 
   await page.goto("/swap");
 
-  // Two "Connect wallet" buttons: header trigger + form submit (disabled).
-  await page
-    .getByRole("button", { name: /connect wallet/i })
-    .first()
-    .click();
-
-  // The mock wallet announces EIP-6963 with rdns "com.example.mock-wallet".
-  // The modal occasionally re-renders as new providers announce, so click
-  // with force to bypass the stability check.
-  await page
-    .getByTestId("rk-wallet-option-com.example.mock-wallet")
-    .click({ force: true });
-
-  // Header button switches from "Connect wallet" to a 0x… short address.
+  // The mock wallet auto-connects silently via EIP-6963 (see fixtures/wallet),
+  // so don't open the RainbowKit connect modal here: useOverlay.handleClose
+  // no-ops while connectModalOpen is true, so a stale "connect modal open"
+  // state would stop the token picker from closing. Just wait for the header
+  // button to switch from "Connect wallet" to the 0x… short address.
   await expect(
     page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
   ).toBeVisible({ timeout: 30_000 });

--- a/web/e2e/swap.spec.ts
+++ b/web/e2e/swap.spec.ts
@@ -4,6 +4,8 @@ import { createPublicClient, http, parseUnits } from "viem";
 import { mainnet } from "viem/chains";
 import { balanceOf } from "viem-erc20/actions";
 
+import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts";
+import { whitelistInstantRedeem } from "../scripts/whitelistInstantRedeem.ts";
 import { knownTokens } from "../src/utils/tokenList.ts";
 
 import { ANVIL_URL } from "./anvil";
@@ -23,6 +25,11 @@ const usdc = getMainnetToken("USDC");
 const vusd = getMainnetToken("VUSD");
 const SWAP_AMOUNT_DISPLAY = "1";
 const SWAP_AMOUNT = parseUnits(SWAP_AMOUNT_DISPLAY, usdc.decimals);
+
+// The redeem burns VUSD (the pegged token), so the amount is measured in VUSD
+// decimals — not USDC's like the deposit above.
+const REDEEM_AMOUNT_DISPLAY = "2";
+const REDEEM_AMOUNT = parseUnits(REDEEM_AMOUNT_DISPLAY, vusd.decimals);
 
 test("swap USDC → VUSD via the gateway", async function ({ page }) {
   const publicClient = createPublicClient({
@@ -85,7 +92,7 @@ test("swap USDC → VUSD via the gateway", async function ({ page }) {
   await page.getByRole("button", { name: /^swap$/i }).click();
 
   // The success toast renders once the deposit tx is confirmed on the fork.
-  await expect(page.getByText("Deposit confirmed")).toBeVisible({
+  await expect(page.getByText("Swap successful")).toBeVisible({
     timeout: 40_000,
   });
 
@@ -107,4 +114,118 @@ test("swap USDC → VUSD via the gateway", async function ({ page }) {
     address: usdc.address,
   });
   expect(usdcAfter).toBe(usdcBefore - SWAP_AMOUNT);
+});
+
+test("redeem VUSD → USDC via the gateway (instant redeem)", async function ({
+  page,
+}) {
+  const publicClient = createPublicClient({
+    chain: mainnet,
+    transport: http(ANVIL_URL),
+  });
+
+  // Whitelist the test account for instant redeem so the redeem takes the
+  // one-step path (otherwise the gateway's withdrawal delay forces the
+  // two-step queue flow).
+  await whitelistInstantRedeem({
+    address: TEST_ADDRESS,
+    forkUrl: ANVIL_URL,
+    gateway: gatewayAddresses[0],
+  });
+
+  const [usdcBefore, vusdBefore] = await Promise.all([
+    balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: usdc.address,
+    }),
+    balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: vusd.address,
+    }),
+  ]);
+
+  await page.goto("/swap");
+
+  // Wait for the real form to render before toggling. While the whitelisted /
+  // pegged token queries are in flight, SwapForm shows SwapFormSkeleton, which
+  // renders a "Toggle swap direction" button with no onClick — clicking it is a
+  // no-op and the mode never lands in the URL. The "Select token to swap"
+  // button only exists in the loaded form (the skeleton uses a non-interactive
+  // token selector), so it's a reliable "form is interactive" signal.
+  await expect(
+    page.getByRole("button", { name: "Select token to swap" }).first(),
+  ).toBeVisible();
+
+  // Toggle to redeem BEFORE connecting. Connecting triggers a background
+  // refetch that can briefly remount the form (SwapFormSkeleton) and drop the
+  // toggle, since the mode lives in the URL (nuqs) and re-inits on remount.
+  // Doing it first — and waiting for the mode to land in the URL — means the
+  // remount re-initialises in redeem mode rather than reverting to deposit.
+  await page.getByRole("button", { name: "Toggle swap direction" }).click();
+  await expect(page).toHaveURL(/[?&]mode=redeem/);
+
+  // The mock wallet auto-connects silently via EIP-6963 (see fixtures/wallet),
+  // so no connect clicks are needed here — just wait for the header button to
+  // switch from "Connect wallet" to the 0x… short address.
+  await expect(
+    page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // Once connected and whitelisted, the redeem renders the instant one-step
+  // form with a selectable output token. Pick USDC unless it's already the
+  // default output (clicking the already-selected token won't close the
+  // modal). Scope to the "You will receive" section to avoid depending on the
+  // relative ordering of the two token selectors.
+  const toTokenSelector = page
+    .getByText("You will receive")
+    .locator("..")
+    .getByRole("button", { name: "Select token to swap" });
+  await expect(toTokenSelector).toBeVisible();
+  // Switch the output to USDC. Re-check inside toPass: a late form re-init can
+  // flip the default output, and clicking an already-selected token won't close
+  // the modal — so only open it while USDC isn't selected, and retry if a click
+  // doesn't register.
+  await expect(async function () {
+    if ((await toTokenSelector.textContent())?.includes("USDC")) return;
+    await toTokenSelector.click();
+    const tokenDialog = page.getByRole("dialog");
+    // The modal fades in via an opacity transition. Playwright's visibility
+    // check ignores opacity, so wait for the entrance to finish before clicking.
+    await expect(tokenDialog).toHaveCSS("opacity", "1");
+    await tokenDialog.getByRole("button", { name: /USDC/ }).first().click();
+    await expect(toTokenSelector).toContainText("USDC", { timeout: 5_000 });
+  }).toPass({ timeout: 20_000 });
+  // The modal closes via a CSS transition; ensure it's gone before interacting
+  // with the form underneath.
+  await expect(page.getByRole("dialog")).toBeHidden();
+
+  await page
+    .locator('input[type="text"]:not([disabled])')
+    .first()
+    .fill(REDEEM_AMOUNT_DISPLAY);
+
+  await page.getByRole("button", { name: /^redeem$/i }).click();
+  // The instant one-step redeem path shows the shared swap success toast.
+  await expect(page.getByText("Swap successful")).toBeVisible({
+    timeout: 40_000,
+  });
+
+  // No popups — the mock wallet signs and forwards to Anvil silently.
+  // Assert by polling balances directly against the fork.
+  await expect
+    .poll(
+      async () =>
+        balanceOf(publicClient, {
+          account: TEST_ADDRESS,
+          address: usdc.address,
+        }),
+      { timeout: 20_000 },
+    )
+    .toBeGreaterThan(usdcBefore);
+
+  const vusdAfter = await balanceOf(publicClient, {
+    account: TEST_ADDRESS,
+    address: vusd.address,
+  });
+  expect(vusdAfter).toBe(vusdBefore - REDEEM_AMOUNT);
 });

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -31,7 +31,6 @@ export default defineConfig({
       // Swap/redeem is fully on-chain; the backend APIs only supply USD display
       // values. Disable them so e2e stays hermetic (prices render as $0, which
       // these tests don't assert on). isValidUrl("") is false → query disabled.
-      VITE_PORTAL_API_URL: "",
       VITE_RPC_URL_MAINNET: ANVIL_URL,
       VITE_VETRO_API_URL: "",
     },

--- a/web/scripts/whitelistInstantRedeem.ts
+++ b/web/scripts/whitelistInstantRedeem.ts
@@ -1,0 +1,166 @@
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import {
+  type Address,
+  createPublicClient,
+  createTestClient,
+  http,
+  isAddress,
+  keccak256,
+  parseEther,
+  stringToBytes,
+} from "viem";
+import {
+  impersonateAccount,
+  readContract,
+  setBalance,
+  stopImpersonatingAccount,
+  waitForTransactionReceipt,
+  writeContract,
+} from "viem/actions";
+import { mainnet } from "viem/chains";
+
+import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
+import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts";
+
+// Whitelisting for instant redeem is `onlyRole(MAINTAINER_ROLE)`, and the
+// gateway delegates role checks to its Treasury (`Treasury.hasRole`). The
+// treasury owner holds DEFAULT_ADMIN_ROLE, which administers MAINTAINER_ROLE,
+// so we impersonate the owner, grant it MAINTAINER_ROLE on the treasury, then
+// whitelist the account on the gateway.
+const MAINTAINER_ROLE = keccak256(stringToBytes("MAINTAINER_ROLE"));
+
+const accessControlAbi = [
+  {
+    inputs: [
+      { name: "role", type: "bytes32" },
+      { name: "account", type: "address" },
+    ],
+    name: "grantRole",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { name: "role", type: "bytes32" },
+      { name: "account", type: "address" },
+    ],
+    name: "hasRole",
+    outputs: [{ type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export async function whitelistInstantRedeem({
+  address,
+  forkUrl = "http://127.0.0.1:8545",
+  gateway = gatewayAddresses[0],
+}: {
+  address: Address;
+  forkUrl?: string;
+  gateway?: Address;
+}) {
+  const transport = http(forkUrl);
+
+  const publicClient = createPublicClient({ chain: mainnet, transport });
+  const testClient = createTestClient({
+    chain: mainnet,
+    mode: "anvil",
+    transport,
+  });
+
+  const [owner, treasury, isWhitelisted] = await Promise.all([
+    readContract(publicClient, {
+      abi: gatewayAbi,
+      address: gateway,
+      functionName: "owner",
+    }),
+    readContract(publicClient, {
+      abi: gatewayAbi,
+      address: gateway,
+      functionName: "treasury",
+    }),
+    readContract(publicClient, {
+      abi: gatewayAbi,
+      address: gateway,
+      args: [address],
+      functionName: "isInstantRedeemWhitelisted",
+    }),
+  ]);
+
+  if (isWhitelisted) {
+    console.log(`${address} is already whitelisted for instant redeem.`);
+    return;
+  }
+
+  await impersonateAccount(testClient, { address: owner });
+  await setBalance(testClient, { address: owner, value: parseEther("1") });
+
+  try {
+    const ownerHasRole = await readContract(publicClient, {
+      abi: accessControlAbi,
+      address: treasury,
+      args: [MAINTAINER_ROLE, owner],
+      functionName: "hasRole",
+    });
+
+    if (!ownerHasRole) {
+      const grantHash = await writeContract(testClient, {
+        abi: accessControlAbi,
+        account: owner,
+        address: treasury,
+        args: [MAINTAINER_ROLE, owner],
+        functionName: "grantRole",
+      });
+      await waitForTransactionReceipt(publicClient, { hash: grantHash });
+    }
+
+    const whitelistHash = await writeContract(testClient, {
+      abi: gatewayAbi,
+      account: owner,
+      address: gateway,
+      args: [address],
+      functionName: "addToInstantRedeemWhitelist",
+    });
+    await waitForTransactionReceipt(publicClient, { hash: whitelistHash });
+  } finally {
+    await stopImpersonatingAccount(testClient, { address: owner });
+  }
+
+  console.log(
+    `${address} whitelisted for instant redeem on gateway ${gateway}.`,
+  );
+}
+
+// Allow running as a standalone script for consumers:
+//   node web/scripts/whitelistInstantRedeem.ts --address 0x… [--fork-url …] [--gateway …]
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { values } = parseArgs({
+    options: {
+      address: { short: "a", type: "string" },
+      "fork-url": { short: "f", type: "string" },
+      gateway: { short: "g", type: "string" },
+    },
+    strict: true,
+  });
+
+  if (values.gateway && !isAddress(values.gateway, { strict: false })) {
+    console.error("Invalid --gateway. Must be a valid address.");
+    process.exit(1);
+  }
+
+  if (!values.address || !isAddress(values.address, { strict: false })) {
+    console.error(
+      "Address is invalid. Usage: node web/scripts/whitelistInstantRedeem.ts --address 0xYourAddress",
+    );
+    process.exit(1);
+  }
+
+  await whitelistInstantRedeem({
+    address: values.address,
+    forkUrl: values["fork-url"],
+    gateway: (values.gateway as Address) ?? gatewayAddresses[0],
+  });
+}

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -317,9 +317,14 @@ export function Deposit({
       {showToast && (
         <Toast
           closable
-          description={t("pages.swap.toast.deposit-description")}
+          description={t("pages.swap.toast.swap-success-description", {
+            fromAmount: fromInputValue,
+            fromSymbol: fromToken.symbol,
+            toAmount: outputValue,
+            toSymbol: toToken.symbol,
+          })}
           onClose={() => setShowToast(false)}
-          title={t("pages.swap.toast.deposit-title")}
+          title={t("pages.swap.toast.swap-success-title")}
         />
       )}
     </>

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -328,9 +328,14 @@ export function OneStepRedeem({
       {showToast && (
         <Toast
           closable
-          description={t("pages.swap.toast.deposit-description")}
+          description={t("pages.swap.toast.swap-success-description", {
+            fromAmount: fromInputValue,
+            fromSymbol: fromToken.symbol,
+            toAmount: outputValue,
+            toSymbol: toToken.symbol,
+          })}
           onClose={() => setShowToast(false)}
-          title={t("pages.swap.toast.deposit-title")}
+          title={t("pages.swap.toast.swap-success-title")}
         />
       )}
     </>

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -312,12 +312,10 @@ export function TwoStepRedeem({
       {showToast && (
         <Toast
           closable
-          description={t("pages.swap.toast.your-cooldown-period-has-started", {
-            count: seconds,
-            seconds,
-          })}
+          description={t("pages.swap.toast.redeem-queued-description")}
           onClose={() => setShowToast(false)}
-          title={t("pages.swap.toast.deposited-to-queue", {
+          title={t("pages.swap.toast.redeem-queued-title", {
+            amount: fromInputValue,
             symbol: fromToken.symbol,
           })}
         />

--- a/web/src/hooks/useTokenPrices.ts
+++ b/web/src/hooks/useTokenPrices.ts
@@ -4,6 +4,7 @@ import {
   useQuery,
 } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
+import { isValidUrl } from "utils/url";
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
 
@@ -20,6 +21,7 @@ export const tokenPricesOptions = <TSelect = Prices>(
   options: QueryOptions<TSelect> = {} as QueryOptions<TSelect>,
 ) =>
   queryOptions({
+    enabled: apiUrl !== undefined && isValidUrl(apiUrl),
     queryFn: () =>
       fetch(`${apiUrl}/prices`).then(({ prices }) => prices as Prices),
     queryKey: tokenPricesQueryKey(),

--- a/web/src/hooks/useTokenPrices.ts
+++ b/web/src/hooks/useTokenPrices.ts
@@ -4,9 +4,8 @@ import {
   useQuery,
 } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
-import { isValidUrl } from "utils/url";
 
-const apiUrl = import.meta.env.VITE_PORTAL_API_URL;
+const apiUrl = import.meta.env.VITE_VETRO_API_URL;
 
 type Prices = Record<string, string>;
 
@@ -21,7 +20,6 @@ export const tokenPricesOptions = <TSelect = Prices>(
   options: QueryOptions<TSelect> = {} as QueryOptions<TSelect>,
 ) =>
   queryOptions({
-    enabled: apiUrl !== undefined && isValidUrl(apiUrl),
     queryFn: () =>
       fetch(`${apiUrl}/prices`).then(({ prices }) => prices as Prices),
     queryKey: tokenPricesQueryKey(),

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -423,10 +423,10 @@
       "select-option": "Select token to swap",
       "title": "Swap your tokens with Vetro assets",
       "toast": {
-        "deposit-description": "VUSD is now available in your wallet",
-        "deposit-title": "Deposit confirmed",
-        "deposited-to-queue": "{{symbol}} deposited to queue",
-        "your-cooldown-period-has-started": "Your {{seconds}}-second cooldown has started."
+        "redeem-queued-description": "You'll be able to redeem it once the cooldown ends.",
+        "redeem-queued-title": "{{amount}} {{symbol}} sent to queue",
+        "swap-success-description": "{{fromAmount}} {{fromSymbol}} converted to {{toAmount}} {{toSymbol}}.",
+        "swap-success-title": "Swap successful"
       },
       "treasury-reserves": "Treasury reserves",
       "tutorial": {

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -430,11 +430,10 @@
       "select-option": "Seleccione el token a intercambiar",
       "title": "Intercambie sus tokens por activos de Vetro",
       "toast": {
-        "deposit-description": "VUSD disponible en su billetera",
-        "deposit-title": "Depósito confirmado",
-        "deposited-to-queue": "{{symbol}} depositado en la cola",
-        "your-cooldown-period-has-started_one": "Su período de espera de {{seconds}} segundo ha comenzado.",
-        "your-cooldown-period-has-started_other": "Su período de espera de {{seconds}} segundos ha comenzado."
+        "redeem-queued-description": "Podrá canjearlo una vez que finalice el período de espera.",
+        "redeem-queued-title": "{{amount}} {{symbol}} enviado a la cola",
+        "swap-success-description": "{{fromAmount}} {{fromSymbol}} convertido a {{toAmount}} {{toSymbol}}.",
+        "swap-success-title": "Intercambio exitoso"
       },
       "treasury-reserves": "Reservas del tesoro",
       "tutorial": {

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -13,7 +13,6 @@ type Env = {
 const rpcUrls = allChains.flatMap((chain) => chain.rpcUrls.default.http);
 
 const allUrls: (string | undefined)[] = [
-  import.meta.env.VITE_PORTAL_API_URL,
   import.meta.env.VITE_VETRO_API_URL,
   ...rpcUrls,
   import.meta.env.VITE_SENTRY_DSN,

--- a/web/src/pages/earn/components/exitTickets/index.tsx
+++ b/web/src/pages/earn/components/exitTickets/index.tsx
@@ -33,7 +33,7 @@ const statusLabels = {
   withdrawn: "pages.earn.exit-tickets.withdrawn",
 } as const;
 
-const getColumns = ({
+export const getColumns = ({
   isWithdrawingAll,
   onDeleteSuccess,
   onWithdrawingChange,

--- a/web/src/pages/earn/components/exitTickets/skeleton.tsx
+++ b/web/src/pages/earn/components/exitTickets/skeleton.tsx
@@ -1,0 +1,31 @@
+import { Table } from "components/base/table";
+import { TopSection } from "components/base/table/topSection";
+import { useTranslation } from "react-i18next";
+
+import { getColumns } from ".";
+
+// Stable reference
+const emptyArray: never[] = [];
+
+export function ExitTicketsSkeleton() {
+  const { t } = useTranslation();
+  const columns = getColumns({
+    isWithdrawingAll: false,
+    onDeleteSuccess() {},
+    onWithdrawingChange() {},
+    t,
+  });
+
+  return (
+    <div>
+      <TopSection title={t("pages.earn.exit-tickets.title")} />
+      <Table
+        columns={columns}
+        data={emptyArray}
+        loading
+        maxBodyHeight="280px"
+        priorityColumnIdsOnSmall={["actions"]}
+      />
+    </div>
+  );
+}

--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -72,15 +72,19 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
         ) : (
           <Skeleton borderRadius={8} height={40} width={40} />
         )}
-        <PoolInfoItem label="Token" value={peggedToken?.symbol} />
-        <PoolInfoItem label={t("pages.earn.pool-info.pool-contract")}>
-          <ExternalLink
-            className="text-xsm font-semibold text-gray-600 transition-colors hover:text-gray-900"
-            href={`${explorerBaseUrl}/address/${stakingVaultAddress}`}
-          >
-            {formatEvmAddress(stakingVaultAddress)}
-          </ExternalLink>
-        </PoolInfoItem>
+        <div className="contents md:*:w-16">
+          <PoolInfoItem label="Token" value={peggedToken?.symbol} />
+        </div>
+        <div className="contents md:*:w-32">
+          <PoolInfoItem label={t("pages.earn.pool-info.pool-contract")}>
+            <ExternalLink
+              className="text-xsm font-semibold text-gray-600 transition-colors hover:text-gray-900"
+              href={`${explorerBaseUrl}/address/${stakingVaultAddress}`}
+            >
+              {formatEvmAddress(stakingVaultAddress)}
+            </ExternalLink>
+          </PoolInfoItem>
+        </div>
         <PoolInfoItem
           isLoading={isLoadingDeposits || (!prices && !isPricesError)}
           label={t("pages.earn.pool-info.pool-deposits")}

--- a/web/src/pages/earn/hooks/useShowExitTickets.ts
+++ b/web/src/pages/earn/hooks/useShowExitTickets.ts
@@ -13,8 +13,10 @@ export function useShowExitTickets() {
 
   return useQueries({
     // Show the exit tickets section when at least one vault cannot
-    // instant-withdraw (including while still loading), since that vault
-    // requires the non-instant request flow that produces exit tickets.
+    // instant-withdraw, since that vault requires the non-instant
+    // request flow that produces exit tickets. The loading state is
+    // exposed separately via `isLoading` so the caller can show a
+    // skeleton while the checks resolve.
     combine: (results) => ({
       data: results.some((result) => result.data === false),
       isLoading: results.some((result) => result.isLoading),

--- a/web/src/pages/earn/hooks/useShowExitTickets.ts
+++ b/web/src/pages/earn/hooks/useShowExitTickets.ts
@@ -17,6 +17,7 @@ export function useShowExitTickets() {
     // requires the non-instant request flow that produces exit tickets.
     combine: (results) => ({
       data: results.some((result) => result.data === false),
+      isLoading: results.some((result) => result.isLoading),
     }),
     queries: stakingVaultAddresses.map((stakingVaultAddress) =>
       canInstantWithdrawOptions({

--- a/web/src/pages/earn/index.tsx
+++ b/web/src/pages/earn/index.tsx
@@ -30,7 +30,7 @@ export function Earn() {
           <div className="border-b border-gray-200 bg-gray-100">
             <StripedDivider />
           </div>
-          {isLoading ? <ExitTicketsSkeleton /> : <ExitTickets />}
+          {showExitTickets ? <ExitTickets /> : <ExitTicketsSkeleton />}
         </>
       )}
     </>

--- a/web/src/pages/earn/index.tsx
+++ b/web/src/pages/earn/index.tsx
@@ -5,11 +5,12 @@ import { useTranslation } from "react-i18next";
 
 import { EarnStats } from "./components/earnStats";
 import { ExitTickets } from "./components/exitTickets";
+import { ExitTicketsSkeleton } from "./components/exitTickets/skeleton";
 import { PoolInfoBar } from "./components/poolInfoBar";
 import { useShowExitTickets } from "./hooks/useShowExitTickets";
 
 export function Earn() {
-  const { data: showExitTickets } = useShowExitTickets();
+  const { data: showExitTickets, isLoading } = useShowExitTickets();
   const { t } = useTranslation();
 
   return (
@@ -24,14 +25,12 @@ export function Earn() {
           stakingVaultAddress={stakingVaultAddress}
         />
       ))}
-      {/* TODO add skeleton loading for this section
-      See https://github.com/vetro-protocol/vetro-monorepo/issues/341 */}
-      {showExitTickets && (
+      {(isLoading || showExitTickets) && (
         <>
           <div className="border-b border-gray-200 bg-gray-100">
             <StripedDivider />
           </div>
-          <ExitTickets />
+          {isLoading ? <ExitTicketsSkeleton /> : <ExitTickets />}
         </>
       )}
     </>


### PR DESCRIPTION
 ## Release: master → prod

  This release includes 6 PRs merged into `master` since the last `prod` deploy.

  ### PRs included

  - #484 — Proxy price calls to Hemi Portal API
  - #485 — Show skeleton for Exit Queue while checks load
  - #482 — Fix flaky token picker in swap e2e tests
  - #481 — Align pool info columns on Earn page
  - #480 — Add internal-dashboard workspace
  - #478 — Update swap toasts and add redeem e2e coverage
