### PR TITLE
Add live current value to share-value-history endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -128,10 +128,10 @@ Returns the APY for each supported staking vault, indexed by staking vault addre
 
 ### `GET /variable-stake/share-value-history/:stakingVaultAddress/:period`
 
-Returns the historical share value for a staking vault over the given period (Earn token vs underlying pegged token, e.g. sVUSD per VUSD). One entry per UTC day. Results across multiple subgraph pages are concatenated, so long windows return their full history (e.g. `"1y"` may include up to ~366 entries).
+Returns the historical share value for a staking vault over the given period (Earn token vs underlying pegged token, e.g. sVUSD per VUSD). One entry per UTC day from the subgraph, plus a final point read live from the vault's on-chain `convertToAssets` (one whole share) at request time. The subgraph writes its history once per UTC day, so its latest point can lag the actual share value by up to ~24h; the appended live point keeps the last value in sync with the current exchange rate. Results across multiple subgraph pages are concatenated, so long windows return their full history (e.g. `"1y"` may include up to ~366 entries plus the live point). If the live read fails the series is returned without the appended point.
 Valid periods are: `"1w"`, `"1m"`, `"3m"` and `"1y"`.
 `:stakingVaultAddress` must be a known staking vault. Returns `400` if malformed and `404` if the address is not a known staking vault.
-`shareValue` is a number with the 18-decimal wad already pre-scaled (e.g. `1.000412938421`). `timestamp` is the UTC day-start in milliseconds.
+`shareValue` is a number already pre-scaled by the underlying asset's decimals to a human-readable exchange rate (e.g. `1.000412938421`). `timestamp` is in milliseconds (UTC day-start for subgraph entries, current time for the live point).
 
 #### Sample Response for "1w"
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -235,7 +235,7 @@ app.get(
   validateStakingVaultAddress,
   validateParam("period", vaultHistoryValidPeriods),
   cache({
-    cacheControl: "max-age=3600",
+    cacheControl: "max-age=300",
     cacheName: "vetro-api",
   }),
   async function (c) {
@@ -245,6 +245,7 @@ app.get(
       const period = c.req.param("period");
       const data = await getShareValueHistory({
         period,
+        rpcUrl: c.env.CUSTOM_RPC_URL_MAINNET,
         stakingVaultAddress,
         url,
       });

--- a/api/src/share-value-history.ts
+++ b/api/src/share-value-history.ts
@@ -1,21 +1,80 @@
 import { type Address, formatUnits } from "viem";
+import { decimals } from "viem-erc20/actions";
+import { asset, convertToAssets } from "viem-erc4626/actions";
 
+import { createMainnetClient } from "./mainnet-client.ts";
 import { paginateSubgraphQuery } from "./paginate-subgraph-query.ts";
 import { getPeriodStart } from "./vault-history-period.ts";
 
 type Row = { shareValue: string; timestamp: string };
 
+type Client = ReturnType<typeof createMainnetClient>;
+
+/**
+ * Read the vault's current share value live from the chain: the assets returned
+ * for one whole share (10^shareDecimals), in the asset's base units. The
+ * subgraph only writes a VaultHistory entry once per UTC day, so its latest
+ * point can lag the actual share value by up to ~24h; appending a live point
+ * keeps the series' last value in sync with the on-chain rate. Returns null (so
+ * the caller falls back to the subgraph series alone) if the read fails — which
+ * also covers the empty vault case, where convertToAssets reverts on zero total
+ * supply. The caller scales the returned value by the asset decimals.
+ */
+async function getLiveShareValue({
+  client,
+  stakingVaultAddress,
+}: {
+  client: Client;
+  stakingVaultAddress: Address;
+}) {
+  try {
+    const shareDecimals = await decimals(client, {
+      address: stakingVaultAddress,
+    });
+    return await convertToAssets(client, {
+      address: stakingVaultAddress,
+      // one whole share
+      shares: 10n ** BigInt(shareDecimals),
+    });
+  } catch (error) {
+    console.warn(
+      `Failed to read live share value for ${stakingVaultAddress}: ${error.message}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Read the decimals of the vault's underlying asset. convertToAssets returns a
+ * value denominated in that asset, so both the subgraph's stored share values
+ * and the live read are scaled by these decimals to a human-readable rate.
+ */
+async function getAssetDecimals({
+  client,
+  stakingVaultAddress,
+}: {
+  client: Client;
+  stakingVaultAddress: Address;
+}) {
+  const assetAddress = await asset(client, { address: stakingVaultAddress });
+  return decimals(client, { address: assetAddress });
+}
+
 /**
  * Query the subgraph for the share value history of a staking vault over the
  * given period. Paginates over the subgraph's 100-result page cap so that long
- * windows (e.g. "1y", up to ~366 daily entries) are returned in full.
+ * windows (e.g. "1y", up to ~366 daily entries) are returned in full. A live
+ * on-chain share value read is appended as the final point so the latest value
+ * reflects the current exchange rate rather than the last daily snapshot.
  */
 export async function getShareValueHistory({
   period,
+  rpcUrl,
   stakingVaultAddress,
   url,
 }: {
   period: string;
+  rpcUrl: string | undefined;
   stakingVaultAddress: Address;
   url: string;
 }): Promise<{ shareValue: number; timestamp: number }[]> {
@@ -38,19 +97,37 @@ export async function getShareValueHistory({
       }
     }`;
 
-  const all = await paginateSubgraphQuery<Row>({
-    cursor: {
-      getValue: (row) => row.timestamp,
-      variable: "start",
-    },
-    field: "vaultHistories",
-    query,
-    url,
-    variables: { stakingVault, start },
-  });
+  const client = createMainnetClient(rpcUrl);
 
-  return all.map((h) => ({
-    shareValue: Number(formatUnits(BigInt(h.shareValue), 18)),
+  // The subgraph pagination, the asset-decimals read, and the live share-value
+  // read are independent, so run them concurrently rather than in sequence.
+  const [all, assetDecimals, liveShareValue] = await Promise.all([
+    paginateSubgraphQuery<Row>({
+      cursor: {
+        getValue: (row) => row.timestamp,
+        variable: "start",
+      },
+      field: "vaultHistories",
+      query,
+      url,
+      variables: { stakingVault, start },
+    }),
+    getAssetDecimals({ client, stakingVaultAddress }),
+    getLiveShareValue({ client, stakingVaultAddress }),
+  ]);
+
+  const history = all.map((h) => ({
+    shareValue: Number(formatUnits(BigInt(h.shareValue), assetDecimals)),
     timestamp: Number.parseInt(h.timestamp, 10) * 1000,
   }));
+
+  const livePoint =
+    liveShareValue === null
+      ? null
+      : {
+          shareValue: Number(formatUnits(liveShareValue, assetDecimals)),
+          timestamp: Date.now(),
+        };
+
+  return livePoint ? [...history, livePoint] : history;
 }

--- a/api/test/share-value-history.test.ts
+++ b/api/test/share-value-history.test.ts
@@ -1,29 +1,71 @@
 import { sVusdAddress } from "@vetro-protocol/earn";
-import { describe, expect, it, vi } from "vitest";
+import { type Address } from "viem";
+import { decimals } from "viem-erc20/actions";
+import { asset, convertToAssets } from "viem-erc4626/actions";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as graphql from "../src/graphql.ts";
 import { getShareValueHistory } from "../src/share-value-history.ts";
+
+// Hoisted so the vi.mock factory below (which vitest hoists above the module
+// body) can reference it as asset()'s fixed return value.
+const { assetAddress } = vi.hoisted(() => ({
+  assetAddress: "0x000000000000000000000000000000000000dEaD" as Address,
+}));
 
 vi.mock("../src/graphql.ts", () => ({
   runQuery: vi.fn(),
 }));
 
+vi.mock("viem-erc20/actions", () => ({
+  decimals: vi.fn(),
+}));
+
+vi.mock("viem-erc4626/actions", () => ({
+  // asset() never varies across tests, so its return lives in the definition.
+  asset: vi.fn().mockResolvedValue(assetAddress),
+  convertToAssets: vi.fn(),
+}));
+
 const url = "https://subgraph.example/v1";
+const rpcUrl = "https://rpc.example";
+
+// Fixed "now" so the appended live point's timestamp is deterministic.
+const now = 1_708_000_000_000;
+const liveShareValue = 1_000_600_000_000_000_000n;
+const livePoint = { shareValue: 1.0006, timestamp: now };
 
 const fetchHistory = (period = "1w") =>
-  getShareValueHistory({ period, stakingVaultAddress: sVusdAddress, url });
+  getShareValueHistory({
+    period,
+    rpcUrl,
+    stakingVaultAddress: sVusdAddress,
+    url,
+  });
 
 const lastCallVariables = <T>() =>
   vi.mocked(graphql.runQuery).mock.calls.at(-1)?.[2] as T | undefined;
 
 describe("share-value-history/getShareValueHistory", function () {
-  it("returns [] when the subgraph returns no entries", async function () {
-    vi.mocked(graphql.runQuery).mockResolvedValue({ vaultHistories: [] });
-
-    expect(await fetchHistory()).toEqual([]);
+  beforeEach(function () {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    vi.mocked(asset).mockResolvedValue(assetAddress);
+    vi.mocked(decimals).mockResolvedValue(18);
+    vi.mocked(convertToAssets).mockResolvedValue(liveShareValue);
   });
 
-  it("scales shareValue from 18-decimal wad to number and converts timestamp to ms", async function () {
+  afterEach(function () {
+    vi.useRealTimers();
+  });
+
+  it("returns only the live point when the subgraph returns no entries", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({ vaultHistories: [] });
+
+    expect(await fetchHistory()).toEqual([livePoint]);
+  });
+
+  it("scales shareValue to a number and converts timestamp to ms, with a live point appended", async function () {
     vi.mocked(graphql.runQuery).mockResolvedValue({
       vaultHistories: [
         { shareValue: "1000412938421000000", timestamp: "1707782400" },
@@ -34,7 +76,56 @@ describe("share-value-history/getShareValueHistory", function () {
     expect(await fetchHistory()).toEqual([
       { shareValue: 1.000412938421, timestamp: 1_707_782_400_000 },
       { shareValue: 1.000506129482, timestamp: 1_707_868_800_000 },
+      livePoint,
     ]);
+  });
+
+  it("scales by the asset decimals while using the share decimals for one share", async function () {
+    const assetDecimals = 6;
+    const shareDecimals = 18;
+    vi.mocked(decimals).mockImplementation((_client, { address }) =>
+      Promise.resolve(address === assetAddress ? assetDecimals : shareDecimals),
+    );
+    // 1.6 in the asset's 6-decimal base units
+    vi.mocked(convertToAssets).mockResolvedValue(1_600_000n);
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      // 1.5 in the asset's 6-decimal base units
+      vaultHistories: [{ shareValue: "1500000", timestamp: "1707782400" }],
+    });
+
+    expect(await fetchHistory()).toEqual([
+      { shareValue: 1.5, timestamp: 1_707_782_400_000 },
+      { shareValue: 1.6, timestamp: now },
+    ]);
+    // one whole share uses the share token's decimals, not the asset's
+    expect(vi.mocked(convertToAssets)).toHaveBeenCalledWith(expect.anything(), {
+      address: sVusdAddress,
+      shares: 10n ** 18n,
+    });
+  });
+
+  it("falls back to the subgraph series when the live share value read fails", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultHistories: [
+        { shareValue: "1000412938421000000", timestamp: "1707782400" },
+      ],
+    });
+    vi.mocked(convertToAssets).mockRejectedValue(new Error("rpc down"));
+
+    expect(await fetchHistory()).toEqual([
+      { shareValue: 1.000412938421, timestamp: 1_707_782_400_000 },
+    ]);
+  });
+
+  it("rejects when the on-chain asset decimals read fails", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultHistories: [
+        { shareValue: "1000412938421000000", timestamp: "1707782400" },
+      ],
+    });
+    vi.mocked(decimals).mockRejectedValue(new Error("rpc down"));
+
+    await expect(fetchHistory()).rejects.toThrow("rpc down");
   });
 
   it("queries the subgraph with the staking vault address lowercased", async function () {


### PR DESCRIPTION
### Description

The Peg Stability chart on the Analytics page is fed by `GET /variable-stake/share-value-history/:stakingVaultAddress/:period`, which previously returned only the subgraph's daily `VaultHistory` snapshots. The subgraph records one entry per UTC day, so the chart could lag the real share value by up to ~24h and never reflected the in-progress day.

This appends a live datapoint read on-chain via `convertToAssets` (one whole share), run concurrently with the subgraph query, so the series' last value tracks the current exchange rate. If the live read fails (e.g. an empty vault, where `convertToAssets` reverts), the series falls back to the subgraph data alone.

Both the stored and live values are now scaled by the underlying asset's decimals (read on-chain via `asset()` → `decimals()`) instead of a hardcoded `18`, since `convertToAssets` returns asset-denominated amounts.

Finally, the endpoint's edge cache is lowered from 1h to 5m to match the frontend's React Query `staleTime`, so the cache can't serve data staler than the client expects.

### Screenshots

Yesterday, there was an increase in value in `sVUSD` measured in `VUSD`

The snapshot did not impacted yet on the subgraph, per the issue description

Without this change

<img width="1996" height="702" alt="image" src="https://github.com/user-attachments/assets/8060070a-a60b-4ab6-b9da-7eccf61be8a0" />

With this change

<img width="2194" height="636" alt="image" src="https://github.com/user-attachments/assets/e634b484-e3bb-4250-9d91-a8dbe44bc902" />

### Related issue(s)

Closes #486

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
