### PR TITLE
Fix redeem optimistic amount from wrong transfer

### DIFF
--- a/web/src/hooks/useRedeem.ts
+++ b/web/src/hooks/useRedeem.ts
@@ -158,9 +158,8 @@ export const useRedeem = function ({
           logs: receipt.logs,
         });
         const actualAmount =
-          transferLogs.find((log) =>
-            isAddressEqual(log.args.from, peggedToken.gatewayAddress),
-          )?.args.value ?? minAmountOut;
+          transferLogs.find((log) => isAddressEqual(log.args.to, account))?.args
+            .value ?? minAmountOut;
 
         if (hasDelay) {
           // if there's a delay, the PeggedToken was burned from the Gateway vault


### PR DESCRIPTION
### Description

A redeem transaction emits **two** ERC-20 `Transfer` events: one burning the user's pegged-token shares (from the Gateway vault) and one sending the output tokens to the user. The optimistic update in `useRedeem` was reading the redeemed amount off the **burn** transfer — it matched the log by `from === gatewayAddress` — so the amount reflected after a redeem was the burned shares rather than the tokens the user actually received, producing an incorrect optimistic balance.

This matches the transfer by `to === account` instead, so we read the value of the tokens actually transferred to the user.

Found while writing the two-step queue redeem E2E test.

### Screenshots

N/A

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.