### PR TITLE
Add two-step queue redeem E2E test

### DIFF
--- a/web/e2e/anvil.ts
+++ b/web/e2e/anvil.ts
@@ -1,2 +1,9 @@
+import { createPublicClient, http } from "viem";
+import { mainnet } from "viem/chains";
+
 export const ANVIL_PORT = 8545;
 export const ANVIL_URL = `http://127.0.0.1:${ANVIL_PORT}`;
+
+// A viem public client pointed at the local Anvil mainnet fork.
+export const createEthereumClient = () =>
+  createPublicClient({ chain: mainnet, transport: http(ANVIL_URL) });

--- a/web/e2e/swap.spec.ts
+++ b/web/e2e/swap.spec.ts
@@ -1,14 +1,18 @@
 import { TEST_ADDRESS } from "@hemilabs/anvil-fork-setup/utils";
 import { expect } from "@playwright/test";
-import { createPublicClient, http, parseUnits } from "viem";
+import { parseUnits } from "viem";
+import { getBlock, readContract } from "viem/actions";
 import { mainnet } from "viem/chains";
 import { balanceOf } from "viem-erc20/actions";
 
+import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
 import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts";
+import { fastForwardTime } from "../scripts/fastForwardTime.ts";
+import { setRedeemDelay } from "../scripts/redeemDelay.ts";
 import { whitelistInstantRedeem } from "../scripts/whitelistInstantRedeem.ts";
 import { knownTokens } from "../src/utils/tokenList.ts";
 
-import { ANVIL_URL } from "./anvil";
+import { ANVIL_URL, createEthereumClient } from "./anvil";
 import { test } from "./fixtures/wallet";
 
 function getMainnetToken(symbol: string) {
@@ -32,10 +36,7 @@ const REDEEM_AMOUNT_DISPLAY = "2";
 const REDEEM_AMOUNT = parseUnits(REDEEM_AMOUNT_DISPLAY, vusd.decimals);
 
 test("swap USDC → VUSD via the gateway", async function ({ page }) {
-  const publicClient = createPublicClient({
-    chain: mainnet,
-    transport: http(ANVIL_URL),
-  });
+  const publicClient = createEthereumClient();
 
   const [usdcBefore, vusdBefore] = await Promise.all([
     balanceOf(publicClient, {
@@ -117,10 +118,7 @@ test("swap USDC → VUSD via the gateway", async function ({ page }) {
 test("redeem VUSD → USDC via the gateway (instant redeem)", async function ({
   page,
 }) {
-  const publicClient = createPublicClient({
-    chain: mainnet,
-    transport: http(ANVIL_URL),
-  });
+  const publicClient = createEthereumClient();
 
   // Whitelist the test account for instant redeem so the redeem takes the
   // one-step path (otherwise the gateway's withdrawal delay forces the
@@ -226,4 +224,166 @@ test("redeem VUSD → USDC via the gateway (instant redeem)", async function ({
     address: vusd.address,
   });
   expect(vusdAfter).toBe(vusdBefore - REDEEM_AMOUNT);
+});
+
+test("redeem VUSD via the gateway (two-step queue redeem)", async function ({
+  page,
+}) {
+  const publicClient = createEthereumClient();
+
+  // Enable the gateway's withdrawal delay and ensure the test account is NOT
+  // whitelisted for instant redeem, forcing the two-step (request → wait →
+  // claim) path. The per-test snapshot/revert already isolates any whitelisting
+  // done by the instant-redeem test, but we set this explicitly so the test is
+  // self-contained.
+  await setRedeemDelay({
+    address: TEST_ADDRESS,
+    enableDelay: true,
+    forkUrl: ANVIL_URL,
+    gateway: gatewayAddresses[0],
+  });
+
+  const vusdBefore = await balanceOf(publicClient, {
+    account: TEST_ADDRESS,
+    address: vusd.address,
+  });
+
+  await page.goto("/swap");
+
+  // Wait for the interactive form before toggling — the loading skeleton's
+  // toggle button is a no-op (see the instant-redeem test for the full
+  // rationale).
+  await expect(
+    page.getByRole("button", { name: "Select token to swap" }).first(),
+  ).toBeVisible();
+
+  // Toggle to redeem BEFORE connecting and wait for the mode to land in the URL,
+  // so the connect-triggered remount re-initialises in redeem mode.
+  await page.getByRole("button", { name: "Toggle swap direction" }).click();
+  await expect(page).toHaveURL(/[?&]mode=redeem/);
+
+  // The mock wallet auto-connects silently via EIP-6963 — just wait for the
+  // header button to switch to the 0x… short address.
+  await expect(
+    page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // Step 1 — request redeem. The two-step form has no output-token selector (the
+  // output is chosen later in the claim drawer); the input defaults to VUSD.
+  await page
+    .locator('input[type="text"]:not([disabled])')
+    .first()
+    .fill(REDEEM_AMOUNT_DISPLAY);
+
+  await page.getByRole("button", { name: /send to queue/i }).click();
+
+  // The toast confirms the VUSD reached the queue (covers approval + request).
+  await expect(page.getByText(/sent to queue/i)).toBeVisible({
+    timeout: 60_000,
+  });
+
+  // The VUSD is now locked in the gateway, so the wallet balance already dropped.
+  await expect
+    .poll(
+      async () =>
+        balanceOf(publicClient, {
+          account: TEST_ADDRESS,
+          address: vusd.address,
+        }),
+      { timeout: 20_000 },
+    )
+    .toBe(vusdBefore - REDEEM_AMOUNT);
+
+  // The queue now lists the request we just created — assert the
+  // redeemable-balance column shows the locked amount and pegged-token symbol.
+  const redeemQueue = page.locator("#redeem-queue");
+  await expect(
+    redeemQueue.getByText(`${REDEEM_AMOUNT_DISPLAY} ${vusd.symbol}`),
+  ).toBeVisible({ timeout: 20_000 });
+
+  // Skip the cooldown without waiting. Read claimableAt from the fork, then
+  // advance BOTH clocks past it:
+  //  - the fork's block.timestamp, by fast-forwarding past the cooldown, so the
+  //    claim tx passes the contract's `block.timestamp >= claimableAt` check
+  //    (Gateway._handleRedeemOrWithdraw),
+  //  - the browser clock, so the queue row's Date.now-based countdown
+  //    (useCountdown) reaches zero and enables the Redeem button.
+  const [, claimableAt] = await readContract(publicClient, {
+    abi: gatewayAbi,
+    address: gatewayAddresses[0],
+    args: [TEST_ADDRESS],
+    functionName: "getRedeemRequest",
+  });
+  // Fail loudly if the request wasn't recorded (claimableAt 0) instead of
+  // silently under-advancing the clock below.
+  expect(claimableAt).toBeGreaterThan(0n);
+
+  const { timestamp: chainNow } = await getBlock(publicClient);
+  // Mirror the fork's actual post-fast-forward timestamp onto the browser clock
+  // (rather than re-deriving an estimate) so the on-chain check and the UI
+  // countdown stay in sync.
+  const newTimestamp = await fastForwardTime({
+    forkUrl: ANVIL_URL,
+    seconds: Number(claimableAt - chainNow),
+  });
+  await page.clock.setFixedTime(Number(newTimestamp) * 1000);
+
+  // Step 2 — claim the now-redeemable position from the queue. The cooldown has
+  // elapsed, so the row's status flips to "Ready to redeem" and its Redeem
+  // button enables.
+  await expect(redeemQueue.getByText(/ready to redeem/i)).toBeVisible({
+    timeout: 20_000,
+  });
+  const queueRedeemButton = redeemQueue.getByRole("button", {
+    name: /^redeem$/i,
+  });
+  await expect(queueRedeemButton).toBeEnabled();
+  await queueRedeemButton.click();
+
+  // The claim drawer slides in ("Redeem your VUSD"). Scope to it by its title
+  // heading's container rather than brittle layout classes — the heading's
+  // parent holds the whole drawer body (amount input, token selector, buttons).
+  const drawerTitle = page.getByRole("heading", { name: /redeem your/i });
+  await expect(drawerTitle).toBeVisible();
+  const drawer = drawerTitle.locator("..");
+
+  // Redeem to the drawer's default output token. Switching it via the token
+  // modal would dismiss the drawer — the modal renders in its own portal, so the
+  // selection click registers as an outside-click for the drawer's
+  // click-outside handler — so read which stablecoin the default is and assert
+  // against that one.
+  const outputSymbol = (
+    await drawer
+      .getByRole("button", { name: "Select token to swap" })
+      .innerText()
+  ).trim();
+  const outputToken = getMainnetToken(outputSymbol);
+  const outputBefore = await balanceOf(publicClient, {
+    account: TEST_ADDRESS,
+    address: outputToken.address,
+  });
+
+  // Redeem the full locked amount.
+  await drawer.getByRole("button", { name: "MAX" }).click();
+  await drawer.getByRole("button", { name: /^redeem$/i }).click();
+
+  // The claim settled on the fork: the output stablecoin was received, and VUSD
+  // stays at its post-step-1 value (the locked balance was burned, not the
+  // wallet's).
+  await expect
+    .poll(
+      async () =>
+        balanceOf(publicClient, {
+          account: TEST_ADDRESS,
+          address: outputToken.address,
+        }),
+      { timeout: 20_000 },
+    )
+    .toBeGreaterThan(outputBefore);
+
+  const vusdAfterClaim = await balanceOf(publicClient, {
+    account: TEST_ADDRESS,
+    address: vusd.address,
+  });
+  expect(vusdAfterClaim).toBe(vusdBefore - REDEEM_AMOUNT);
 });

--- a/web/scripts/fastForwardTime.ts
+++ b/web/scripts/fastForwardTime.ts
@@ -1,0 +1,69 @@
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import { createTestClient, http } from "viem";
+import { getBlock, mine } from "viem/actions";
+import { mainnet } from "viem/chains";
+
+// Mainnet's ~12s block time. Each mined block advances the fork's
+// block.timestamp by this many seconds.
+const SECONDS_PER_BLOCK = 12;
+
+// Fast-forward the fork by at least `seconds` (mining enough 12s blocks to cover
+// it, always at least one) and return the fork's new block.timestamp. Useful for
+// stepping past time-locked gateway flows (e.g. the withdrawal delay on a
+// two-step redeem) without waiting in real time. Returning the actual timestamp
+// lets callers mirror it onto other clocks instead of re-deriving an estimate.
+export async function fastForwardTime({
+  forkUrl,
+  seconds,
+}: {
+  forkUrl: string;
+  seconds: number;
+}) {
+  const testClient = createTestClient({
+    chain: mainnet,
+    mode: "anvil",
+    transport: http(forkUrl),
+  });
+
+  const blocks = Math.max(1, Math.ceil(seconds / SECONDS_PER_BLOCK));
+  await mine(testClient, { blocks, interval: SECONDS_PER_BLOCK });
+
+  const { timestamp } = await getBlock(testClient);
+  return timestamp;
+}
+
+// Allow running as a standalone script:
+//   node web/scripts/fastForwardTime.ts --fork-url http://127.0.0.1:8545 --seconds 120
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { values } = parseArgs({
+    options: {
+      "fork-url": { short: "f", type: "string" },
+      seconds: { short: "s", type: "string" },
+    },
+    strict: true,
+  });
+
+  if (!values.seconds || !/^\d+$/.test(values.seconds)) {
+    console.error(
+      "Seconds is invalid. Usage: node web/scripts/fastForwardTime.ts --fork-url http://127.0.0.1:8545 --seconds 120",
+    );
+    process.exit(1);
+  }
+
+  if (!values["fork-url"]) {
+    console.error(
+      "Fork URL is required. Usage: node web/scripts/fastForwardTime.ts --fork-url http://127.0.0.1:8545 --seconds 120",
+    );
+    process.exit(1);
+  }
+
+  const timestamp = await fastForwardTime({
+    forkUrl: values["fork-url"],
+    seconds: Number(values.seconds),
+  });
+
+  console.log(
+    `Fast-forwarded ${values.seconds}s on ${values["fork-url"]} (new block.timestamp: ${timestamp}).`,
+  );
+}

--- a/web/scripts/redeemDelay.ts
+++ b/web/scripts/redeemDelay.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 import {
   type Address,
@@ -20,117 +21,87 @@ import { mainnet } from "viem/chains";
 import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
 import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts";
 
-const { values } = parseArgs({
-  options: {
-    address: { short: "a", type: "string" },
-    delay: { type: "boolean" },
-    "fork-url": { short: "f", type: "string" },
-    gateway: { short: "g", type: "string" },
-    "no-delay": { type: "boolean" },
-  },
-  strict: true,
-});
-
-if (values.gateway && !isAddress(values.gateway, { strict: false })) {
-  console.error("Invalid --gateway. Must be a valid address.");
-  process.exit(1);
-}
-
-const gateway = (values.gateway as Address) ?? gatewayAddresses[0];
-const forkUrl = values["fork-url"] ?? "http://127.0.0.1:8545";
-
-if (!values.address || !isAddress(values.address, { strict: false })) {
-  console.error(
-    "Address is invalid. Usage: node web/scripts/redeemDelay.ts --address 0xYourAddress --delay|--no-delay",
-  );
-  process.exit(1);
-}
-
-if (!values.delay && !values["no-delay"]) {
-  console.error("Exactly one of --delay or --no-delay must be provided.");
-  process.exit(1);
-}
-
-if (values.delay && values["no-delay"]) {
-  console.error("Exactly one of --delay or --no-delay must be provided.");
-  process.exit(1);
-}
-
-const { address } = values;
-const enableDelay = Boolean(values.delay);
-
 const WITHDRAWAL_DELAY_SECONDS = 72n;
 
-const transport = http(forkUrl);
+// Enable or disable the gateway's withdrawal delay by impersonating its owner.
+// When enabling, also remove the address from the instant-redeem whitelist so it
+// is forced down the two-step (request → wait → claim) redeem path.
+export async function setRedeemDelay({
+  address,
+  enableDelay,
+  forkUrl,
+  gateway = gatewayAddresses[0],
+}: {
+  address: Address;
+  enableDelay: boolean;
+  forkUrl: string;
+  gateway?: Address;
+}) {
+  const transport = http(forkUrl);
 
-const publicClient = createPublicClient({
-  chain: mainnet,
-  transport,
-});
+  const publicClient = createPublicClient({ chain: mainnet, transport });
+  const testClient = createTestClient({
+    chain: mainnet,
+    mode: "anvil",
+    transport,
+  });
 
-const testClient = createTestClient({
-  chain: mainnet,
-  mode: "anvil",
-  transport,
-});
+  const [owner, delayEnabledBefore] = await Promise.all([
+    readContract(publicClient, {
+      abi: gatewayAbi,
+      address: gateway,
+      functionName: "owner",
+    }),
+    readContract(publicClient, {
+      abi: gatewayAbi,
+      address: gateway,
+      functionName: "withdrawalDelayEnabled",
+    }),
+  ]);
 
-const [owner, delayEnabledBefore] = await Promise.all([
-  readContract(publicClient, {
-    abi: gatewayAbi,
-    address: gateway,
-    functionName: "owner",
-  }),
-  readContract(publicClient, {
-    abi: gatewayAbi,
-    address: gateway,
-    functionName: "withdrawalDelayEnabled",
-  }),
-]);
+  await impersonateAccount(testClient, { address: owner });
+  await setBalance(testClient, { address: owner, value: parseEther("1") });
 
-await impersonateAccount(testClient, { address: owner });
-await setBalance(testClient, { address: owner, value: parseEther("1") });
+  try {
+    if (enableDelay) {
+      if (!delayEnabledBefore) {
+        const hash = await writeContract(testClient, {
+          abi: gatewayAbi,
+          account: owner,
+          address: gateway,
+          args: [true],
+          functionName: "setWithdrawalDelayEnabled",
+        });
+        await waitForTransactionReceipt(publicClient, { hash });
+      }
 
-try {
-  if (enableDelay) {
-    if (!delayEnabledBefore) {
-      const hash = await writeContract(testClient, {
-        abi: gatewayAbi,
-        account: owner,
-        address: gateway,
-        args: [true],
-        functionName: "setWithdrawalDelayEnabled",
-      });
-      await waitForTransactionReceipt(publicClient, { hash });
-    }
+      const [, isWhitelisted] = await Promise.all([
+        writeContract(testClient, {
+          abi: gatewayAbi,
+          account: owner,
+          address: gateway,
+          args: [WITHDRAWAL_DELAY_SECONDS],
+          functionName: "updateWithdrawalDelay",
+        }).then((hash) => waitForTransactionReceipt(publicClient, { hash })),
+        readContract(publicClient, {
+          abi: gatewayAbi,
+          address: gateway,
+          args: [address],
+          functionName: "isInstantRedeemWhitelisted",
+        }),
+      ]);
 
-    const [, isWhitelisted] = await Promise.all([
-      writeContract(testClient, {
-        abi: gatewayAbi,
-        account: owner,
-        address: gateway,
-        args: [WITHDRAWAL_DELAY_SECONDS],
-        functionName: "updateWithdrawalDelay",
-      }).then((hash) => waitForTransactionReceipt(publicClient, { hash })),
-      readContract(publicClient, {
-        abi: gatewayAbi,
-        address: gateway,
-        args: [address],
-        functionName: "isInstantRedeemWhitelisted",
-      }),
-    ]);
-
-    if (isWhitelisted) {
-      const hash = await writeContract(testClient, {
-        abi: gatewayAbi,
-        account: owner,
-        address: gateway,
-        args: [address],
-        functionName: "removeFromInstantRedeemWhitelist",
-      });
-      await waitForTransactionReceipt(publicClient, { hash });
-    }
-  } else {
-    if (delayEnabledBefore) {
+      if (isWhitelisted) {
+        const hash = await writeContract(testClient, {
+          abi: gatewayAbi,
+          account: owner,
+          address: gateway,
+          args: [address],
+          functionName: "removeFromInstantRedeemWhitelist",
+        });
+        await waitForTransactionReceipt(publicClient, { hash });
+      }
+    } else if (delayEnabledBefore) {
       const hash = await writeContract(testClient, {
         abi: gatewayAbi,
         account: owner,
@@ -140,25 +111,68 @@ try {
       });
       await waitForTransactionReceipt(publicClient, { hash });
     }
+
+    const [delayEnabledAfter, delay] = await Promise.all([
+      readContract(publicClient, {
+        abi: gatewayAbi,
+        address: gateway,
+        functionName: "withdrawalDelayEnabled",
+      }),
+      readContract(publicClient, {
+        abi: gatewayAbi,
+        address: gateway,
+        functionName: "withdrawalDelay",
+      }),
+    ]);
+
+    return { delay, delayEnabledAfter, delayEnabledBefore };
+  } finally {
+    await stopImpersonatingAccount(testClient, { address: owner });
+  }
+}
+
+// Allow running as a standalone script:
+//   node web/scripts/redeemDelay.ts --address 0xYourAddress --delay|--no-delay
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { values } = parseArgs({
+    options: {
+      address: { short: "a", type: "string" },
+      delay: { type: "boolean" },
+      "fork-url": { short: "f", type: "string" },
+      gateway: { short: "g", type: "string" },
+      "no-delay": { type: "boolean" },
+    },
+    strict: true,
+  });
+
+  if (values.gateway && !isAddress(values.gateway, { strict: false })) {
+    console.error("Invalid --gateway. Must be a valid address.");
+    process.exit(1);
   }
 
-  const [delayEnabledAfter, withdrawalDelay] = await Promise.all([
-    readContract(publicClient, {
-      abi: gatewayAbi,
-      address: gateway,
-      functionName: "withdrawalDelayEnabled",
-    }),
-    readContract(publicClient, {
-      abi: gatewayAbi,
-      address: gateway,
-      functionName: "withdrawalDelay",
-    }),
-  ]);
+  if (!values.address || !isAddress(values.address, { strict: false })) {
+    console.error(
+      "Address is invalid. Usage: node web/scripts/redeemDelay.ts --address 0xYourAddress --delay|--no-delay",
+    );
+    process.exit(1);
+  }
+
+  if (values.delay === values["no-delay"]) {
+    console.error("Exactly one of --delay or --no-delay must be provided.");
+    process.exit(1);
+  }
+
+  const { delay, delayEnabledAfter, delayEnabledBefore } = await setRedeemDelay(
+    {
+      address: values.address,
+      enableDelay: Boolean(values.delay),
+      forkUrl: values["fork-url"] ?? "http://127.0.0.1:8545",
+      gateway: values.gateway as Address | undefined,
+    },
+  );
 
   console.log(
     `withdrawalDelayEnabled: ${delayEnabledBefore} -> ${delayEnabledAfter}`,
   );
-  console.log(`withdrawalDelay: ${withdrawalDelay}s`);
-} finally {
-  await stopImpersonatingAccount(testClient, { address: owner });
+  console.log(`withdrawalDelay: ${delay}s`);
 }


### PR DESCRIPTION
### Description

Adds an end-to-end test covering the gateway's two-step (queue) redeem path: request → wait out the withdrawal delay → claim. This complements the existing instant-redeem test, exercising the flow that non-whitelisted accounts take when the withdrawal delay is enabled.

To support the test:
- `redeemDelay.ts` is refactored to export a reusable `setRedeemDelay()` function (enabling the delay and removing the address from the instant-redeem whitelist), while keeping its standalone CLI entrypoint behind an `import.meta.url` guard.
- Adds `fastForwardTime.ts`, a helper (and CLI) that mines enough blocks to advance the fork's `block.timestamp` past the cooldown and returns the new timestamp, so the test can skip the delay without waiting in real time.
- The test mirrors the fork's post-fast-forward timestamp onto the browser clock (`page.clock.setFixedTime`) so the on-chain `claimableAt` check and the UI countdown stay in sync.
- Extracts a shared `createEthereumClient()` helper in `anvil.ts` and reuses it across the swap/redeem tests.

### Screenshots

Test running!

https://github.com/user-attachments/assets/86d40555-5edb-450a-af95-15a8f37c6b8b

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.