### PR TITLE
Remove treasury reserves from swap TX drawers

### DIFF
--- a/web/src/components/swapForm/claimRedeemProgressDrawer.tsx
+++ b/web/src/components/swapForm/claimRedeemProgressDrawer.tsx
@@ -18,7 +18,6 @@ import type { Address } from "viem";
 import { OutputLabel, type UnitPreview } from "./outputLabel";
 import { SwapFees } from "./swapFees";
 import { ToTokenBalance } from "./toTokenBalance";
-import { TreasuryReserves } from "./treasuryReserves";
 import type { ClaimRedeemFlowStatus } from "./types";
 
 type Props = {
@@ -132,9 +131,6 @@ export function ClaimRedeemProgressDrawer({
               : t("pages.swap.redeem-queue.redeem")}
         </Button>
       </div>
-      <DrawerFeesContainer>
-        <TreasuryReserves gatewayAddress={fromToken.gatewayAddress} />
-      </DrawerFeesContainer>
       <DrawerFeesContainer>
         <SwapFees
           fromToken={fromToken}

--- a/web/src/components/swapForm/swapProgressDrawer.tsx
+++ b/web/src/components/swapForm/swapProgressDrawer.tsx
@@ -11,7 +11,6 @@ import type { Address } from "viem";
 
 import { OutputLabel, type UnitPreview } from "./outputLabel";
 import { SwapFees } from "./swapFees";
-import { TreasuryReserves } from "./treasuryReserves";
 
 type Props = {
   fromAmount: string;
@@ -87,9 +86,6 @@ export function SwapProgressDrawer({
             </div>
           )}
         </div>
-        <DrawerFeesContainer>
-          <TreasuryReserves gatewayAddress={fromToken.gatewayAddress} />
-        </DrawerFeesContainer>
         <DrawerFeesContainer>
           <SwapFees
             fromToken={fromToken}


### PR DESCRIPTION
### Description

The "Treasury reserves" row was shown inside the swap progress and claim-redeem progress drawers on the swap page. This PR removes it from those two drawers. The `TreasuryReserves` component still renders below the form in the deposit/redeem flows, so only the drawer usages were removed — the underlying data fetch (used for gas estimation and cache invalidation) is untouched.

### Screenshots

<img width="1014" height="1612" alt="image" src="https://github.com/user-attachments/assets/1ee13cf6-f71d-4064-a042-491cf7713dd7" />

<img width="962" height="1444" alt="image" src="https://github.com/user-attachments/assets/7ba84652-a020-4348-bf7f-12430ff919da" />

### Related issue(s)

Closes #470

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.