### PR TITLE
Fix borrow endpoints after Morpho schema change

### DIFF
--- a/api/src/morpho.ts
+++ b/api/src/morpho.ts
@@ -1,6 +1,10 @@
+import { mainnet } from "viem/chains";
+
 import * as graphql from "./graphql.ts";
 
 const morphoApiUrl = "https://api.morpho.org/graphql";
+
+const chainId = mainnet.id;
 
 export async function getLoanAssetAddress({
   marketId,
@@ -8,24 +12,25 @@ export async function getLoanAssetAddress({
   marketId: string;
 }): Promise<string> {
   const query = `
-    query ($marketId: String!) {
-      marketByUniqueKey(uniqueKey: $marketId) {
+    query ($chainId: Int!, $marketId: String!) {
+      marketById(marketId: $marketId, chainId: $chainId) {
         loanAsset {
           address
         }
       }
     }`;
   const variables = {
+    chainId,
     marketId,
   };
-  const { marketByUniqueKey } = await graphql.runQuery<{
-    marketByUniqueKey: {
+  const { marketById } = await graphql.runQuery<{
+    marketById: {
       loanAsset: {
         address: string;
       };
     };
   }>(morphoApiUrl, query, variables);
-  return marketByUniqueKey.loanAsset.address;
+  return marketById.loanAsset.address;
 }
 
 export async function getHistoricalBorrowApy({
@@ -43,8 +48,8 @@ export async function getHistoricalBorrowApy({
   }[]
 > {
   const query = `
-    query ($marketId: String!, $options: TimeseriesOptions) {
-      marketByUniqueKey(uniqueKey: $marketId) {
+    query ($chainId: Int!, $marketId: String!, $options: TimeseriesOptions) {
+      marketById(marketId: $marketId, chainId: $chainId) {
         historicalState {
           borrowApy(options: $options) {
             x
@@ -54,14 +59,15 @@ export async function getHistoricalBorrowApy({
       }
     }`;
   const variables = {
+    chainId,
     marketId,
     options: {
       interval,
       startTimestamp,
     },
   };
-  const { marketByUniqueKey } = await graphql.runQuery<{
-    marketByUniqueKey: {
+  const { marketById } = await graphql.runQuery<{
+    marketById: {
       historicalState: {
         borrowApy: {
           x: number;
@@ -70,7 +76,7 @@ export async function getHistoricalBorrowApy({
       };
     };
   }>(morphoApiUrl, query, variables);
-  return marketByUniqueKey.historicalState.borrowApy;
+  return marketById.historicalState.borrowApy;
 }
 
 export async function getCollateralAssets({
@@ -79,22 +85,23 @@ export async function getCollateralAssets({
   marketId: string;
 }): Promise<number> {
   const query = `
-    query ($marketId: String!) {
-      marketByUniqueKey(uniqueKey: $marketId) {
+    query ($chainId: Int!, $marketId: String!) {
+      marketById(marketId: $marketId, chainId: $chainId) {
         state {
           collateralAssets
         }
       }
     }`;
   const variables = {
+    chainId,
     marketId,
   };
-  const { marketByUniqueKey } = await graphql.runQuery<{
-    marketByUniqueKey: {
+  const { marketById } = await graphql.runQuery<{
+    marketById: {
       state: {
         collateralAssets: number;
       };
     };
   }>(morphoApiUrl, query, variables);
-  return marketByUniqueKey.state.collateralAssets;
+  return marketById.state.collateralAssets;
 }


### PR DESCRIPTION
### Description

The Borrow page "Pool size" rendered `-` because `GET /borrow/{marketId}/collateral-assets` returned 404.

Morpho changed its public GraphQL schema: the `marketByUniqueKey(uniqueKey: ...)` query was removed and replaced by `marketById(marketId: ..., chainId: ...)`, where `chainId` is now required and the `uniqueKey` field was renamed to `marketId`. All three queries in `api/src/morpho.ts` still used the removed field, so each threw — and the borrow route's validation step caught the error and returned 404. This silently broke both `/collateral-assets` (reported) and `/apr-history/:period` (same cause).

The fix switches all three queries to `marketById` and passes the mainnet chain id (these markets live on Ethereum mainnet), using the existing `viem/chains` `mainnet.id` convention.

### Screenshots

<img width="394" height="500" alt="image" src="https://github.com/user-attachments/assets/5344ecf2-58fc-4657-b86e-308303bbd6c9" />


### Related issue(s)

Closes #494

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.