### PR TITLE
Add frxUSD to local token list and fund setup

### DIFF
--- a/web/scripts/fundAccount.ts
+++ b/web/scripts/fundAccount.ts
@@ -18,6 +18,7 @@ import { knownTokens } from "../src/utils/tokenList.ts";
 
 export const defaultSetupSymbols = [
   "cbBTC",
+  "frxUSD",
   "hemiBTC",
   "USDC",
   "USDT",

--- a/web/src/utils/tokenList.ts
+++ b/web/src/utils/tokenList.ts
@@ -29,6 +29,18 @@ export const knownTokens: Token[] = [
     symbol: "USDC",
   },
   {
+    address: "0xCAcd6fd266aF91b8AeD52aCCc382b4e165586E29",
+    chainId: mainnet.id,
+    decimals: 18,
+    extensions: {
+      allowanceSlot: 1n,
+      balanceSlot: 0,
+    },
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/frxusd.svg",
+    name: "Frax USD",
+    symbol: "frxUSD",
+  },
+  {
     address: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
     chainId: mainnet.id,
     decimals: 8,


### PR DESCRIPTION
### Description

frxUSD has been whitelisted as a token for VUSD and loads automatically on chain. This PR adds it to the local token list (`knownTokens`) for faster reading — including its mainnet address, decimals, and storage slot extensions (`allowanceSlot`/`balanceSlot`) — and includes it in the `defaultSetupSymbols` of the account funding script so test accounts get funded with frxUSD.

The token logo is served from the `hemilabs/token-list` repo via `logoURI`, so logo handling is out of scope for this repo.

### Screenshots

<img width="428" height="588" alt="image" src="https://github.com/user-attachments/assets/836538d8-eb78-44ac-aae5-bccf482d9c09" />

<img width="638" height="400" alt="image" src="https://github.com/user-attachments/assets/29d450f1-e60e-497b-83e7-923bec1beb83" />

### Related issue(s)

Closes #503

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.