### PR TITLE
Optimize analytics API and add multi-RPC fallback

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -234,15 +234,15 @@ Returns all user's variable stake exit tickets to i.e. allow claiming the withdr
 Environment variables are configured in `wrangler.jsonc`.
 Secrets are set separately using the Wrangler CLI.
 
-| Variable                  | Description                                                                                           | Default                 |
-| ------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------- |
-| CUSTOM_RPC_URL_MAINNET    | Ethereum RPC node URL. Overrides `viem`'s default                                                     |                         |
-| MERKL_OPPORTUNITY_SVETBTC | Merkl opportunity id for the sVetBTC staking vault. Optional; if unset, that vault yields no rewards. |                         |
-| MERKL_OPPORTUNITY_SVUSD   | Merkl opportunity id for the sVUSD staking vault. Optional; if unset, that vault yields no rewards.   |                         |
-| ORIGINS                   | Comma-separated list of allowed origins. (1)                                                          | `http://localhost:5173` |
-| SUBGRAPH_API_KEY          | The subgraph API key.                                                                                 |                         |
-| SUBGRAPH_ID               | The subgraph id.                                                                                      |                         |
-| SUBGRAPH_URL_TEMPLATE     | The subgraph URL template. (2)                                                                        | (localhost)             |
+| Variable                  | Description                                                                                                   | Default                 |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| CUSTOM_RPC_URL_MAINNET    | Ethereum RPC node URL(s). Overrides `viem`'s default. Several URLs joined by `+` become a fallback transport. |                         |
+| MERKL_OPPORTUNITY_SVETBTC | Merkl opportunity id for the sVetBTC staking vault. Optional; if unset, that vault yields no rewards.         |                         |
+| MERKL_OPPORTUNITY_SVUSD   | Merkl opportunity id for the sVUSD staking vault. Optional; if unset, that vault yields no rewards.           |                         |
+| ORIGINS                   | Comma-separated list of allowed origins. (1)                                                                  | `http://localhost:5173` |
+| SUBGRAPH_API_KEY          | The subgraph API key.                                                                                         |                         |
+| SUBGRAPH_ID               | The subgraph id.                                                                                              |                         |
+| SUBGRAPH_URL_TEMPLATE     | The subgraph URL template. (2)                                                                                | (localhost)             |
 
 (1) Globs with stars (`*`) are supported. I.e. `https://*.hemi.xyz` will match any subdomain or subdomain chain.
 (2) API key and id are replaced in the template at the `$API_KEY` and `$ID` positions.

--- a/api/README.md
+++ b/api/README.md
@@ -4,23 +4,6 @@ Service that provides data to the Vetro web application.
 
 ## Data endpoints
 
-### `GET /prices`
-
-Proxies the portal API token prices endpoint. Returns the upstream response as-is on success.
-
-#### Sample response
-
-```json
-{
-  "prices": {
-    "ETH": "2450.12",
-    "BTC": "65000.00",
-    "USDT": "0.999881",
-    "USDC": "1.00009"
-  }
-}
-```
-
 ### `GET /analytics/pegged-token-backing/:gatewayAddress`
 
 Get the total strategic reserves and the total surplus for a given gateway's pegged token.
@@ -257,7 +240,6 @@ Secrets are set separately using the Wrangler CLI.
 | MERKL_OPPORTUNITY_SVETBTC | Merkl opportunity id for the sVetBTC staking vault. Optional; if unset, that vault yields no rewards. |                         |
 | MERKL_OPPORTUNITY_SVUSD   | Merkl opportunity id for the sVUSD staking vault. Optional; if unset, that vault yields no rewards.   |                         |
 | ORIGINS                   | Comma-separated list of allowed origins. (1)                                                          | `http://localhost:5173` |
-| PORTAL_API_URL            | Upstream portal API base URL for token prices.                                                        | (see wrangler.jsonc)    |
 | SUBGRAPH_API_KEY          | The subgraph API key.                                                                                 |                         |
 | SUBGRAPH_ID               | The subgraph id.                                                                                      |                         |
 | SUBGRAPH_URL_TEMPLATE     | The subgraph URL template. (2)                                                                        | (localhost)             |

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -87,7 +87,7 @@ app.get(
   "/analytics/treasury/:gatewayAddress",
   validateGatewayAddress,
   cache({
-    cacheControl: "max-age=15, stale-while-revalidate=45",
+    cacheControl: "max-age=60",
     cacheName: "vetro-api",
   }),
   async function (c) {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -32,36 +32,6 @@ app.use("*", async function (c, next) {
 app.use("*", securityHeaders);
 
 app.get(
-  "/prices",
-  cache({
-    cacheControl: "max-age=60",
-    cacheName: "vetro-api",
-  }),
-  async function (c) {
-    let response: Response;
-    try {
-      response = await fetch(new URL("/prices", c.env.PORTAL_API_URL));
-    } catch (error) {
-      console.error("Hemi Portal API unreachable:", error.message);
-      return c.json({ error: "Service Unavailable" }, 503);
-    }
-
-    if (!response.ok) {
-      console.warn(`Hemi Portal API returned ${response.status}`);
-      return c.json({ error: "Bad Gateway" }, 502);
-    }
-
-    try {
-      const data = await response.json();
-      return c.json(data);
-    } catch (error) {
-      console.warn("Hemi Portal API returned invalid JSON:", error.message);
-      return c.json({ error: "Bad Gateway" }, 502);
-    }
-  },
-);
-
-app.get(
   "/analytics/pegged-token-backing/:gatewayAddress",
   validateGatewayAddress,
   cache({

--- a/api/src/mainnet-client.ts
+++ b/api/src/mainnet-client.ts
@@ -1,18 +1,30 @@
-import { createPublicClient, http } from "viem";
+import { createPublicClient, fallback, http } from "viem";
 import { mainnet } from "viem/chains";
 
+import { updateRpcUrls } from "./update-rpc-urls.ts";
+
 /**
- * Create a viem public client for Ethereum mainnet using the given RPC URL.
- * When `rpcUrl` is undefined, viem falls back to the chain's default RPC.
+ * Create a viem public client for Ethereum mainnet from the given RPC URL
+ * config. `rpcUrl` may hold a single URL or several joined by "+", matching the
+ * portal/web convention; multiple URLs become a viem `fallback` transport, one
+ * becomes a plain `http` transport, and none falls back to the chain's default
+ * RPC.
  *
  * `batch.multicall` aggregates contract reads issued in the same tick into a
  * single `eth_call` to Multicall3, and `http({ batch: true })` packs any
  * remaining concurrent calls into one JSON-RPC request. Together they collapse
  * the many reads each analytics endpoint makes into a handful of round trips.
  */
-export const createMainnetClient = (rpcUrl: string | undefined) =>
-  createPublicClient({
+export const createMainnetClient = function (rpcUrl: string | undefined) {
+  const chain = updateRpcUrls(mainnet, rpcUrl);
+  const urls = chain.rpcUrls.default.http;
+  const transport =
+    urls.length > 1
+      ? fallback(urls.map((url) => http(url, { batch: true })))
+      : http(urls[0], { batch: true });
+  return createPublicClient({
     batch: { multicall: true },
-    chain: mainnet,
-    transport: http(rpcUrl, { batch: true }),
+    chain,
+    transport,
   });
+};

--- a/api/src/mainnet-client.ts
+++ b/api/src/mainnet-client.ts
@@ -4,6 +4,15 @@ import { mainnet } from "viem/chains";
 /**
  * Create a viem public client for Ethereum mainnet using the given RPC URL.
  * When `rpcUrl` is undefined, viem falls back to the chain's default RPC.
+ *
+ * `batch.multicall` aggregates contract reads issued in the same tick into a
+ * single `eth_call` to Multicall3, and `http({ batch: true })` packs any
+ * remaining concurrent calls into one JSON-RPC request. Together they collapse
+ * the many reads each analytics endpoint makes into a handful of round trips.
  */
 export const createMainnetClient = (rpcUrl: string | undefined) =>
-  createPublicClient({ chain: mainnet, transport: http(rpcUrl) });
+  createPublicClient({
+    batch: { multicall: true },
+    chain: mainnet,
+    transport: http(rpcUrl, { batch: true }),
+  });

--- a/api/src/update-rpc-urls.ts
+++ b/api/src/update-rpc-urls.ts
@@ -1,0 +1,28 @@
+import { type Chain, defineChain } from "viem";
+
+const isValidUrl = function (url: string) {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const updateRpcUrls = function (chain: Chain, rpcUrlEnv?: string) {
+  if (typeof rpcUrlEnv !== "string") {
+    return chain;
+  }
+  const urls = rpcUrlEnv.split("+").filter(isValidUrl);
+  if (urls.length > 0) {
+    return defineChain({
+      ...chain,
+      rpcUrls: {
+        default: {
+          http: urls,
+        },
+      },
+    });
+  }
+  return chain;
+};

--- a/api/src/worker-env.d.ts
+++ b/api/src/worker-env.d.ts
@@ -6,7 +6,6 @@ interface Env {
   MERKL_OPPORTUNITY_SVETBTC?: string;
   MERKL_OPPORTUNITY_SVUSD?: string;
   ORIGINS: string;
-  PORTAL_API_URL: string;
   SUBGRAPH_API_KEY?: string;
   SUBGRAPH_ID?: string;
   SUBGRAPH_URL_TEMPLATE: string;

--- a/api/test/update-rpc-urls.test.ts
+++ b/api/test/update-rpc-urls.test.ts
@@ -1,0 +1,68 @@
+import { mainnet } from "viem/chains";
+import { describe, expect, it } from "vitest";
+
+import { updateRpcUrls } from "../src/update-rpc-urls.ts";
+
+describe("update-rpc-urls", function () {
+  describe("updateRpcUrls", function () {
+    it("should return the original chain when rpcUrlEnv is undefined", function () {
+      const result = updateRpcUrls(mainnet);
+      expect(result).toBe(mainnet);
+    });
+
+    it("should return the original chain when rpcUrlEnv is not a string", function () {
+      // @ts-expect-error testing invalid input
+      const result = updateRpcUrls(mainnet, null);
+      expect(result).toBe(mainnet);
+    });
+
+    it("should return the original chain when rpcUrlEnv contains no valid URLs", function () {
+      const result = updateRpcUrls(mainnet, "invalid+also-invalid");
+      expect(result).toBe(mainnet);
+    });
+
+    it("should update RPC URLs with valid URLs from environment string", function () {
+      const rpcUrlEnv =
+        "https://ethereum-rpc.publicnode.com+https://1rpc.io/eth";
+      const result = updateRpcUrls(mainnet, rpcUrlEnv);
+
+      // Assert on the rpcUrls we care about rather than deep-equaling the whole
+      // chain: viem's defineChain attaches a fresh `extend` method, so a full
+      // toEqual against `{ ...mainnet }` would fail on the function reference.
+      expect(result).not.toBe(mainnet);
+      expect(result.rpcUrls.default.http).toEqual([
+        "https://ethereum-rpc.publicnode.com",
+        "https://1rpc.io/eth",
+      ]);
+
+      // Verify original RPC URLs are not kept
+      mainnet.rpcUrls.default.http.forEach((originalUrl) =>
+        expect(result.rpcUrls.default.http).not.toContain(originalUrl),
+      );
+    });
+
+    it("should filter out invalid URLs while keeping valid ones", function () {
+      const rpcUrlEnv = "https://eth.drpc.org+invalid-url+https://1rpc.io/eth";
+      const result = updateRpcUrls(mainnet, rpcUrlEnv);
+
+      expect(result).not.toBe(mainnet);
+      expect(result.rpcUrls.default.http).toEqual([
+        "https://eth.drpc.org",
+        "https://1rpc.io/eth",
+      ]);
+    });
+
+    it("should handle single valid URL", function () {
+      const rpcUrlEnv = "https://eth.drpc.org";
+      const result = updateRpcUrls(mainnet, rpcUrlEnv);
+
+      expect(result).not.toBe(mainnet);
+      expect(result.rpcUrls.default.http).toEqual(["https://eth.drpc.org"]);
+    });
+
+    it("should handle empty string", function () {
+      const result = updateRpcUrls(mainnet, "");
+      expect(result).toBe(mainnet);
+    });
+  });
+});

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -15,7 +15,6 @@
     "MERKL_OPPORTUNITY_SVETBTC": "",
     "MERKL_OPPORTUNITY_SVUSD": "",
     "ORIGINS": "http://localhost:3000,http://localhost:5173",
-    "PORTAL_API_URL": "https://portal-api.hemi.xyz",
     "SUBGRAPH_URL_TEMPLATE": "http://localhost:8000/subgraphs/name/vetro-app-subgraph",
   },
   "env": {
@@ -24,7 +23,6 @@
       "vars": {
         "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
         "ORIGINS": "https://*.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev",
-        "PORTAL_API_URL": "https://portal-api.hemi.xyz",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
       },
@@ -43,7 +41,6 @@
       "vars": {
         "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
         "ORIGINS": "https://app.vetro.org,https://beta.vetro.org,https://*.hemi.xyz",
-        "PORTAL_API_URL": "https://portal-api.hemi.xyz",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
       },

--- a/web/.env
+++ b/web/.env
@@ -1,2 +1,3 @@
+VITE_PORTAL_API_URL="https://portal-api.hemi.xyz"
 VITE_RPC_URL_MAINNET="https://eth.drpc.org"
 VITE_VETRO_API_URL="https://vetro-api.letshamsterdance.xyz"

--- a/web/README.md
+++ b/web/README.md
@@ -11,6 +11,7 @@ Vite only exposes variables prefixed with `VITE_` to the client bundle. Set thes
 | Variable               | Required | Description                                                                                    |
 | ---------------------- | -------- | ---------------------------------------------------------------------------------------------- |
 | `VITE_DEPLOY_ENV`      | No       | Set to `"production"` to hide source maps from browsers. Any other value serves them publicly. |
+| `VITE_PORTAL_API_URL`  | Yes      | Hemi Portal API base URL (used for token prices).                                              |
 | `VITE_RPC_URL_MAINNET` | No       | RPC URL for Ethereum mainnet. Falls back to viem's default when unset.                         |
 | `VITE_SENTRY_DSN`      | No       | Sentry DSN. When unset, Sentry is disabled.                                                    |
 | `VITE_VETRO_API_URL`   | Yes      | Vetro backend API base URL (analytics, APR history, exit tickets, rewards, etc.).              |

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       // Swap/redeem is fully on-chain; the backend APIs only supply USD display
       // values. Disable them so e2e stays hermetic (prices render as $0, which
       // these tests don't assert on). isValidUrl("") is false → query disabled.
+      VITE_PORTAL_API_URL: "",
       VITE_RPC_URL_MAINNET: ANVIL_URL,
       VITE_VETRO_API_URL: "",
     },

--- a/web/src/hooks/useTokenPrices.ts
+++ b/web/src/hooks/useTokenPrices.ts
@@ -6,7 +6,7 @@ import {
 import fetch from "fetch-plus-plus";
 import { isValidUrl } from "utils/url";
 
-const apiUrl = import.meta.env.VITE_VETRO_API_URL;
+const apiUrl = import.meta.env.VITE_PORTAL_API_URL;
 
 type Prices = Record<string, string>;
 

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -13,6 +13,7 @@ type Env = {
 const rpcUrls = allChains.flatMap((chain) => chain.rpcUrls.default.http);
 
 const allUrls: (string | undefined)[] = [
+  import.meta.env.VITE_PORTAL_API_URL,
   import.meta.env.VITE_VETRO_API_URL,
   ...rpcUrls,
   import.meta.env.VITE_SENTRY_DSN,


### PR DESCRIPTION
### Description

Speeds up and hardens the analytics API's on-chain data path, and reverts the token-prices proxy.

- **Batch RPC reads via multicall** — the shared mainnet viem client now enables `batch.multicall` plus `http({ batch: true })`, collapsing the dozens of individual `eth_call`s each analytics endpoint made (treasury composition fanned out to ~50) into a handful of round trips.
- **Multi-URL RPC fallback** — `CUSTOM_RPC_URL_MAINNET` can now hold several URLs joined by `+`; multiple URLs build a viem `fallback` transport (one → plain `http`, none → chain default), so a dead or rate-limited lead RPC is skipped transparently. This is the failover strategy from #506 (paid RPC with a public fallback). Helper + test ported from the portal/web `updateRpcUrls`.
- **Raise treasury cache to 60s and drop `stale-while-revalidate`** — see below.
- **Revert the `/prices` proxy (#484)** — the web app fetches token prices directly from the Hemi Portal API again (`VITE_PORTAL_API_URL`, committed in `web/.env`) instead of routing through the API worker.

**Why `stale-while-revalidate` was removed:** the treasury route's cache was `max-age=15, stale-while-revalidate=45`, but Hono's `cache` middleware is backed by the Cloudflare **Workers Cache API** (`caches.open`), which [explicitly does not support `stale-while-revalidate`](https://developers.cloudflare.com/workers/runtime-apis/cache/) ("The `stale-while-revalidate` and `stale-if-error` directives are not supported when using the `cache.put` or `cache.match` methods"). So the 45s SWR window was a no-op and the effective TTL was a hard 15s — every request after 15s paid the full ~1.5s recompute. `max-age=60` (no SWR) is what actually cuts the frequency of blocking misses. SWR *is* honored by Cloudflare's CDN edge cache, a [separate layer](https://developers.cloudflare.com/changelog/post/2026-02-26-async-stale-while-revalidate/) from the Workers Cache API this middleware uses.

**Commits:**

- 2f765e3 Raise treasury cache TTL to 60s
- 458bd81 Remove /prices proxy, fetch prices from Portal
- ca20752 Batch mainnet RPC reads via multicall
- c0e0747 Support multi-URL fallback for mainnet RPC

**Note for reviewers:** the prices revert makes the browser call `portal-api.hemi.xyz` directly (cross-origin) again — pre-#484 behavior, but it relies on the Portal API still sending CORS headers for the prod web origins (`app.vetro.org`, `beta.vetro.org`, `*.hemi.xyz`). Worth a quick confirmation before merge.

### Screenshots

N/A — backend/config changes only.

### Related issue(s)

Related to #506

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
