### PR TITLE
Use custom RPC for e2e mainnet fork

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,6 +31,7 @@ jobs:
       - run: pnpm --filter @vetro-protocol/web exec playwright test
         env:
           DEBUG: pw:webserver
+          VITE_RPC_URL_MAINNET: ${{ secrets.INFURA_API }}
       - if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
### Description

The e2e suite's anvil mainnet fork (`web/e2e/global-setup.ts`) forks from `VITE_RPC_URL_MAINNET`, falling back to viem's default public RPC when it's unset. That public RPC is rate-limited, which makes the fork flaky in CI. This passes a dedicated endpoint to the Playwright step via the `INFURA_API` secret so the fork has a reliable, non-rate-limited upstream.

Note: the app under test still talks to the local anvil fork — `playwright.config.ts` overrides `VITE_RPC_URL_MAINNET` to the anvil URL for the web server. The secret is only used as the fork's upstream in global setup.

Now E2E should pass 😄 

### Screenshots

They do!

<img width="886" height="162" alt="image" src="https://github.com/user-attachments/assets/78be8afc-59bf-427d-a13a-f5e722b78eb0" />


### Related issue(s)

Related to #506

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.