### PR TITLE
Add daily vault APR history to subgraph

### DIFF
--- a/subgraph/abis/StakingVault.json
+++ b/subgraph/abis/StakingVault.json
@@ -64,6 +64,19 @@
     "stateMutability": "view"
   },
   {
+    "type": "function",
+    "name": "yieldDistributor",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
     "type": "event",
     "name": "Deposit",
     "inputs": [

--- a/subgraph/abis/YieldDistributor.json
+++ b/subgraph/abis/YieldDistributor.json
@@ -1,0 +1,28 @@
+[
+  {
+    "type": "function",
+    "name": "periodFinish",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "rewardRate",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  }
+]

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vetro-app-subgraph",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "MIT",
   "scripts": {
     "prebuild": "npm run codegen",

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -39,7 +39,7 @@ type VaultApyHistory @entity(immutable: false) {
   id: ID!
   apr: BigInt! # WAD-scaled annualized reward rate; daily maximum. APY = e^(apr/1e18) - 1
   stakingVaultAddress: Bytes!
-  timestamp: BigInt! # UTC day start (00:00:00) of the day the APY was observed
+  timestamp: BigInt! # UTC day start (00:00:00) of the day the APR was observed
 }
 
 type VaultConfig @entity(immutable: true) {

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -35,7 +35,7 @@ type UserStakingPosition @entity(immutable: false) {
   totalCostBasis: BigInt! # WAD-scaled (36 decimals when asset has 18 decimals)
 }
 
-type VaultApyHistory @entity(immutable: false) {
+type VaultAprHistory @entity(immutable: false) {
   id: ID!
   apr: BigInt! # WAD-scaled annualized reward rate; daily maximum. APY = e^(apr/1e18) - 1
   stakingVaultAddress: Bytes!

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -35,6 +35,13 @@ type UserStakingPosition @entity(immutable: false) {
   totalCostBasis: BigInt! # WAD-scaled (36 decimals when asset has 18 decimals)
 }
 
+type VaultApyHistory @entity(immutable: false) {
+  id: ID!
+  apr: BigInt! # WAD-scaled annualized reward rate; daily maximum. APY = e^(apr/1e18) - 1
+  stakingVaultAddress: Bytes!
+  timestamp: BigInt! # UTC day start (00:00:00) of the day the APY was observed
+}
+
 type VaultConfig @entity(immutable: true) {
   id: Bytes! # vault address
   decimals: Int!

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -4,6 +4,7 @@ import {
   ExitTicket,
   ExitTicketQueueSummary,
   UserStakingPosition,
+  VaultApyHistory,
   VaultConfig,
   VaultHistory,
 } from "../generated/schema";
@@ -16,11 +17,87 @@ import {
   WithdrawRequested,
   // The code generated is the same for both vaults
 } from "../generated/sVusdStakingVault/StakingVault";
+import { YieldDistributor } from "../generated/sVusdStakingVault/YieldDistributor";
 
 const buildId = (vaultAddress: Address, suffix: string): string =>
   `${vaultAddress.toHexString()}-${suffix}`;
 
 const WAD = BigInt.fromI32(10).pow(18);
+const SECONDS_PER_YEAR = BigInt.fromI32(31536000); // 365 days
+
+/**
+ * Read the vault's current forward-looking APR: apr = rewardRate * SECONDS_PER_YEAR /
+ * totalAssets, where rewardRate is the YieldDistributor's WAD-scaled reward-per-second,
+ * so apr is itself WAD-scaled (the WAD cancels rewardRate's own scaling). Returns 0
+ * when there is no active drip — no distributor configured, period ended, zero rate, or
+ * empty vault — matching the API's getApy. Returns null when a required on-chain read
+ * reverts, so the caller skips this block's update rather than recording a bogus value.
+ * All reads use try_* so a single failure never aborts the handler.
+ */
+function readVaultApr(
+  vault: StakingVault,
+  block: ethereum.Block,
+): BigInt | null {
+  const distributorResult = vault.try_yieldDistributor();
+  if (distributorResult.reverted) {
+    return null;
+  }
+  if (distributorResult.value.equals(Address.zero())) {
+    return BigInt.fromI32(0);
+  }
+
+  const distributor = YieldDistributor.bind(distributorResult.value);
+  const rewardRateResult = distributor.try_rewardRate();
+  const periodFinishResult = distributor.try_periodFinish();
+  const totalAssetsResult = vault.try_totalAssets();
+  if (
+    rewardRateResult.reverted ||
+    periodFinishResult.reverted ||
+    totalAssetsResult.reverted
+  ) {
+    return null;
+  }
+
+  const rewardRate = rewardRateResult.value;
+  const periodFinish = periodFinishResult.value;
+  const totalAssets = totalAssetsResult.value;
+  if (periodFinish.lt(block.timestamp) || totalAssets.le(BigInt.fromI32(0))) {
+    return BigInt.fromI32(0);
+  }
+  return rewardRate.times(SECONDS_PER_YEAR).div(totalAssets);
+}
+
+/**
+ * Record the daily maximum APR in VaultApyHistory. Continuous-compounding APY is a
+ * strictly increasing function of APR, so tracking the daily maximum APR captures the
+ * daily maximum APY; the API converts apr -> apy. Runs on every polling block (no early
+ * return) so intra-day fluctuations are captured.
+ */
+function handleDailyApy(
+  vaultAddress: Address,
+  vault: StakingVault,
+  block: ethereum.Block,
+): void {
+  const apr = readVaultApr(vault, block);
+  if (apr === null) {
+    return;
+  }
+
+  const daySeconds = BigInt.fromI32(86400);
+  const dayTimestamp = block.timestamp.div(daySeconds).times(daySeconds);
+  const id = buildId(vaultAddress, dayTimestamp.toString());
+  let entity = VaultApyHistory.load(id);
+  if (entity == null) {
+    entity = new VaultApyHistory(id);
+    entity.timestamp = dayTimestamp;
+    entity.stakingVaultAddress = vaultAddress;
+    entity.apr = apr;
+    entity.save();
+  } else if (apr.gt(entity.apr)) {
+    entity.apr = apr;
+    entity.save();
+  }
+}
 
 function loadOrCreateQueueSummary(
   vaultAddress: Address,
@@ -39,6 +116,10 @@ function loadOrCreateQueueSummary(
 export function handleBlock(block: ethereum.Block): void {
   const vaultAddress = dataSource.address();
   const vault = StakingVault.bind(vaultAddress);
+
+  // Record the daily-maximum APY. Runs on every polling block (no early return) so
+  // intra-day APY changes are captured; see handleDailyApy.
+  handleDailyApy(vaultAddress, vault, block);
 
   // To speed up the sync process, minimize RPC calls and entity writes, only
   // save one history record per day (the first time this handler runs for that

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -61,7 +61,7 @@ function readVaultApr(
   const rewardRate = rewardRateResult.value;
   const periodFinish = periodFinishResult.value;
   const totalAssets = totalAssetsResult.value;
-  if (periodFinish.lt(block.timestamp) || totalAssets.le(BigInt.fromI32(0))) {
+  if (periodFinish.lt(block.timestamp) || totalAssets.isZero()) {
     return BigInt.fromI32(0);
   }
   return rewardRate.times(SECONDS_PER_YEAR).div(totalAssets);

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -4,7 +4,7 @@ import {
   ExitTicket,
   ExitTicketQueueSummary,
   UserStakingPosition,
-  VaultApyHistory,
+  VaultAprHistory,
   VaultConfig,
   VaultHistory,
 } from "../generated/schema";
@@ -68,7 +68,7 @@ function readVaultApr(
 }
 
 /**
- * Record the daily maximum APR in VaultApyHistory. Continuous-compounding APY is a
+ * Record the daily maximum APR in VaultAprHistory. Continuous-compounding APY is a
  * strictly increasing function of APR, so tracking the daily maximum APR captures the
  * daily maximum APY; the API converts apr -> apy. Runs on every polling block (no early
  * return) so intra-day fluctuations are captured.
@@ -86,9 +86,9 @@ function handleDailyApr(
   const daySeconds = BigInt.fromI32(86400);
   const dayTimestamp = block.timestamp.div(daySeconds).times(daySeconds);
   const id = buildId(vaultAddress, dayTimestamp.toString());
-  let entity = VaultApyHistory.load(id);
+  let entity = VaultAprHistory.load(id);
   if (entity == null) {
-    entity = new VaultApyHistory(id);
+    entity = new VaultAprHistory(id);
     entity.timestamp = dayTimestamp;
     entity.stakingVaultAddress = vaultAddress;
     entity.apr = apr;

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -117,8 +117,8 @@ export function handleBlock(block: ethereum.Block): void {
   const vaultAddress = dataSource.address();
   const vault = StakingVault.bind(vaultAddress);
 
-  // Record the daily-maximum APY. Runs on every polling block (no early return) so
-  // intra-day APY changes are captured; see handleDailyApr.
+  // Record the daily-maximum APR. Runs on every polling block (no early return) so
+  // intra-day APR changes are captured; see handleDailyApr.
   handleDailyApr(vaultAddress, vault, block);
 
   // To speed up the sync process, minimize RPC calls and entity writes, only

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -73,7 +73,7 @@ function readVaultApr(
  * daily maximum APY; the API converts apr -> apy. Runs on every polling block (no early
  * return) so intra-day fluctuations are captured.
  */
-function handleDailyApy(
+function handleDailyApr(
   vaultAddress: Address,
   vault: StakingVault,
   block: ethereum.Block,
@@ -118,8 +118,8 @@ export function handleBlock(block: ethereum.Block): void {
   const vault = StakingVault.bind(vaultAddress);
 
   // Record the daily-maximum APY. Runs on every polling block (no early return) so
-  // intra-day APY changes are captured; see handleDailyApy.
-  handleDailyApy(vaultAddress, vault, block);
+  // intra-day APY changes are captured; see handleDailyApr.
+  handleDailyApr(vaultAddress, vault, block);
 
   // To speed up the sync process, minimize RPC calls and entity writes, only
   // save one history record per day (the first time this handler runs for that

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -19,11 +19,14 @@ dataSources:
         - ExitTicket
         - ExitTicketQueueSummary
         - UserStakingPosition
+        - VaultApyHistory
         - VaultConfig
         - VaultHistory
       abis:
         - name: StakingVault
           file: ./abis/StakingVault.json
+        - name: YieldDistributor
+          file: ./abis/YieldDistributor.json
       eventHandlers:
         - event: Deposit(indexed address,indexed address,uint256,uint256)
           handler: handleDeposit
@@ -56,11 +59,14 @@ dataSources:
         - ExitTicket
         - ExitTicketQueueSummary
         - UserStakingPosition
+        - VaultApyHistory
         - VaultConfig
         - VaultHistory
       abis:
         - name: StakingVault
           file: ./abis/StakingVault.json
+        - name: YieldDistributor
+          file: ./abis/YieldDistributor.json
       eventHandlers:
         - event: Deposit(indexed address,indexed address,uint256,uint256)
           handler: handleDeposit

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -19,7 +19,7 @@ dataSources:
         - ExitTicket
         - ExitTicketQueueSummary
         - UserStakingPosition
-        - VaultApyHistory
+        - VaultAprHistory
         - VaultConfig
         - VaultHistory
       abis:
@@ -59,7 +59,7 @@ dataSources:
         - ExitTicket
         - ExitTicketQueueSummary
         - UserStakingPosition
-        - VaultApyHistory
+        - VaultAprHistory
         - VaultConfig
         - VaultHistory
       abis:

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -393,6 +393,28 @@ describe("handleDailyApr", function () {
 
     assert.entityCount("VaultApyHistory", 2);
   });
+
+  test("skips recording when a required on-chain read reverts", function () {
+    const decimals = 18;
+    const shareValue = BigInt.fromString("1050000000000000000");
+    const totalAssets = BigInt.fromString("5000000000000000000000");
+    const timestamp = BigInt.fromI32(1769734800);
+
+    mockVaultCalls(decimals, shareValue, totalAssets);
+    // yieldDistributor() reverts -> readVaultApr returns null, so the handler
+    // skips the update entirely instead of recording a bogus apr 0.
+    createMockedFunction(
+      vaultAddress,
+      "yieldDistributor",
+      "yieldDistributor():(address)",
+    )
+      .withArgs([])
+      .reverts();
+
+    handleBlock(createMockBlock(BigInt.fromI32(100), timestamp));
+
+    assert.entityCount("VaultApyHistory", 0);
+  });
 });
 
 describe("handleDeposit", function () {

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -62,7 +62,7 @@ function mockVaultCalls(
     .returns([ethereum.Value.fromUnsignedBigInt(totalAssets)]);
 }
 
-// Mock the reads handleDailyApy performs: yieldDistributor() on the vault, then
+// Mock the reads handleDailyApr performs: yieldDistributor() on the vault, then
 // rewardRate()/periodFinish() on the distributor. totalAssets() is mocked separately
 // (mockVaultCalls / each test) since the VaultHistory path reads it too.
 function mockDistributorCalls(rewardRate: BigInt, periodFinish: BigInt): void {
@@ -214,7 +214,7 @@ describe("handleBlock", function () {
     )
       .withArgs([ethereum.Value.fromUnsignedBigInt(oneShare)])
       .reverts();
-    // An empty vault reports zero totalAssets, so handleDailyApy records apr 0.
+    // An empty vault reports zero totalAssets, so handleDailyApr records apr 0.
     createMockedFunction(vaultAddress, "totalAssets", "totalAssets():(uint256)")
       .withArgs([])
       .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(0))]);
@@ -276,7 +276,7 @@ describe("handleBlock", function () {
   });
 });
 
-describe("handleDailyApy", function () {
+describe("handleDailyApr", function () {
   beforeEach(function () {
     clearStore();
     dataSourceMock.setAddress(vaultAddressString);

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -33,8 +33,11 @@ const ownerAddressString = "0x1111111111111111111111111111111111111111";
 const ownerAddress = Address.fromString(ownerAddressString);
 const receiverAddressString = "0x2222222222222222222222222222222222222222";
 const receiverAddress = Address.fromString(receiverAddressString);
+const distributorAddressString = "0x3333333333333333333333333333333333333333";
+const distributorAddress = Address.fromString(distributorAddressString);
 
 const daySeconds = BigInt.fromI32(86400);
+const secondsPerYear = BigInt.fromI32(31536000);
 
 function mockVaultCalls(
   decimals: i32,
@@ -59,6 +62,33 @@ function mockVaultCalls(
     .returns([ethereum.Value.fromUnsignedBigInt(totalAssets)]);
 }
 
+// Mock the reads handleDailyApy performs: yieldDistributor() on the vault, then
+// rewardRate()/periodFinish() on the distributor. totalAssets() is mocked separately
+// (mockVaultCalls / each test) since the VaultHistory path reads it too.
+function mockDistributorCalls(rewardRate: BigInt, periodFinish: BigInt): void {
+  createMockedFunction(
+    vaultAddress,
+    "yieldDistributor",
+    "yieldDistributor():(address)",
+  )
+    .withArgs([])
+    .returns([ethereum.Value.fromAddress(distributorAddress)]);
+  createMockedFunction(
+    distributorAddress,
+    "rewardRate",
+    "rewardRate():(uint256)",
+  )
+    .withArgs([])
+    .returns([ethereum.Value.fromUnsignedBigInt(rewardRate)]);
+  createMockedFunction(
+    distributorAddress,
+    "periodFinish",
+    "periodFinish():(uint256)",
+  )
+    .withArgs([])
+    .returns([ethereum.Value.fromUnsignedBigInt(periodFinish)]);
+}
+
 describe("handleBlock", function () {
   beforeEach(function () {
     clearStore();
@@ -72,6 +102,7 @@ describe("handleBlock", function () {
     const timestamp = BigInt.fromI32(1769731200); // 2026-01-30 00:00:00 UTC
 
     mockVaultCalls(decimals, currentShareValue, currentTotalAssets);
+    mockDistributorCalls(BigInt.fromI32(0), BigInt.fromI32(0));
     const block = createMockBlock(BigInt.fromI32(100), timestamp);
     handleBlock(block);
 
@@ -114,6 +145,7 @@ describe("handleBlock", function () {
     const timestamp2 = BigInt.fromI32(1769774400); // 2026-01-30 12:00:00 UTC
 
     mockVaultCalls(decimals, initialShareValue, initialTotalAssets);
+    mockDistributorCalls(BigInt.fromI32(0), BigInt.fromI32(0));
     const block1 = createMockBlock(BigInt.fromI32(100), timestamp1);
     handleBlock(block1);
 
@@ -182,6 +214,11 @@ describe("handleBlock", function () {
     )
       .withArgs([ethereum.Value.fromUnsignedBigInt(oneShare)])
       .reverts();
+    // An empty vault reports zero totalAssets, so handleDailyApy records apr 0.
+    createMockedFunction(vaultAddress, "totalAssets", "totalAssets():(uint256)")
+      .withArgs([])
+      .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(0))]);
+    mockDistributorCalls(BigInt.fromI32(0), BigInt.fromI32(0));
 
     const block = createMockBlock(BigInt.fromI32(100), timestamp);
     handleBlock(block);
@@ -198,6 +235,7 @@ describe("handleBlock", function () {
     const timestamp2 = BigInt.fromI32(1769817600); // 2026-01-31 00:00:00 UTC
 
     mockVaultCalls(decimals, shareValue, totalAssets);
+    mockDistributorCalls(BigInt.fromI32(0), BigInt.fromI32(0));
     const block1 = createMockBlock(BigInt.fromI32(100), timestamp1);
     handleBlock(block1);
 
@@ -235,6 +273,125 @@ describe("handleBlock", function () {
     // Still only one VaultConfig entity, two VaultHistory entities (one per day)
     assert.entityCount("VaultConfig", 1);
     assert.entityCount("VaultHistory", 2);
+  });
+});
+
+describe("handleDailyApy", function () {
+  beforeEach(function () {
+    clearStore();
+    dataSourceMock.setAddress(vaultAddressString);
+  });
+
+  test("records the daily maximum APR across same-day blocks", function () {
+    const decimals = 18;
+    const shareValue = BigInt.fromString("1050000000000000000");
+    const totalAssets = BigInt.fromString("5000000000000000000000"); // 5000e18
+    const rewardRateLow = BigInt.fromString("10000000000000000000000000000"); // 1e28
+    const rewardRateMid = BigInt.fromString("20000000000000000000000000000"); // 2e28
+    const rewardRateHigh = BigInt.fromString("30000000000000000000000000000"); // 3e28
+    // Three timestamps on the same UTC day (2026-01-30).
+    const timestamp1 = BigInt.fromI32(1769734800); // 01:00
+    const timestamp2 = BigInt.fromI32(1769745600); // 04:00
+    const timestamp3 = BigInt.fromI32(1769760000); // 08:00
+    const dayTimestamp = timestamp1.div(daySeconds).times(daySeconds);
+    const periodFinish = dayTimestamp.plus(daySeconds); // active all day
+    const id = `${vaultAddressString}-${dayTimestamp.toString()}`;
+
+    mockVaultCalls(decimals, shareValue, totalAssets);
+
+    // Block 1: mid reward rate establishes the record.
+    mockDistributorCalls(rewardRateMid, periodFinish);
+    handleBlock(createMockBlock(BigInt.fromI32(100), timestamp1));
+    const expectedMid = rewardRateMid.times(secondsPerYear).div(totalAssets);
+    assert.entityCount("VaultApyHistory", 1);
+    assert.fieldEquals("VaultApyHistory", id, "apr", expectedMid.toString());
+    assert.fieldEquals(
+      "VaultApyHistory",
+      id,
+      "timestamp",
+      dayTimestamp.toString(),
+    );
+    assert.fieldEquals(
+      "VaultApyHistory",
+      id,
+      "stakingVaultAddress",
+      vaultAddressString,
+    );
+
+    // Block 2: a lower reward rate the same day is ignored (max kept).
+    mockDistributorCalls(rewardRateLow, periodFinish);
+    handleBlock(createMockBlock(BigInt.fromI32(200), timestamp2));
+    assert.entityCount("VaultApyHistory", 1);
+    assert.fieldEquals("VaultApyHistory", id, "apr", expectedMid.toString());
+
+    // Block 3: a higher reward rate the same day overwrites the max.
+    mockDistributorCalls(rewardRateHigh, periodFinish);
+    handleBlock(createMockBlock(BigInt.fromI32(300), timestamp3));
+    const expectedHigh = rewardRateHigh.times(secondsPerYear).div(totalAssets);
+    assert.entityCount("VaultApyHistory", 1);
+    assert.fieldEquals("VaultApyHistory", id, "apr", expectedHigh.toString());
+  });
+
+  test("records apr 0 when the reward period has finished", function () {
+    const decimals = 18;
+    const shareValue = BigInt.fromString("1050000000000000000");
+    const totalAssets = BigInt.fromString("5000000000000000000000");
+    const rewardRate = BigInt.fromString("20000000000000000000000000000");
+    const timestamp = BigInt.fromI32(1769734800);
+    const dayTimestamp = timestamp.div(daySeconds).times(daySeconds);
+    // periodFinish in the past -> no active drip -> apr 0.
+    const periodFinish = timestamp.minus(BigInt.fromI32(1));
+    const id = `${vaultAddressString}-${dayTimestamp.toString()}`;
+
+    mockVaultCalls(decimals, shareValue, totalAssets);
+    mockDistributorCalls(rewardRate, periodFinish);
+    handleBlock(createMockBlock(BigInt.fromI32(100), timestamp));
+
+    assert.entityCount("VaultApyHistory", 1);
+    assert.fieldEquals("VaultApyHistory", id, "apr", "0");
+  });
+
+  test("records apr 0 when the vault has no yield distributor", function () {
+    const decimals = 18;
+    const shareValue = BigInt.fromString("1050000000000000000");
+    const totalAssets = BigInt.fromString("5000000000000000000000");
+    const timestamp = BigInt.fromI32(1769734800);
+    const dayTimestamp = timestamp.div(daySeconds).times(daySeconds);
+    const id = `${vaultAddressString}-${dayTimestamp.toString()}`;
+
+    mockVaultCalls(decimals, shareValue, totalAssets);
+    // yieldDistributor() returns the zero address -> no drip configured. The reward
+    // rate / period finish are intentionally left unmocked: the handler must not read
+    // them for a zero distributor.
+    createMockedFunction(
+      vaultAddress,
+      "yieldDistributor",
+      "yieldDistributor():(address)",
+    )
+      .withArgs([])
+      .returns([ethereum.Value.fromAddress(Address.zero())]);
+
+    handleBlock(createMockBlock(BigInt.fromI32(100), timestamp));
+
+    assert.entityCount("VaultApyHistory", 1);
+    assert.fieldEquals("VaultApyHistory", id, "apr", "0");
+  });
+
+  test("creates a separate record per UTC day", function () {
+    const decimals = 18;
+    const shareValue = BigInt.fromString("1050000000000000000");
+    const totalAssets = BigInt.fromString("5000000000000000000000");
+    const rewardRate = BigInt.fromString("20000000000000000000000000000");
+    const periodFinish = BigInt.fromI32(1900000000); // far future
+    const timestamp1 = BigInt.fromI32(1769734800); // 2026-01-30 01:00
+    const timestamp2 = BigInt.fromI32(1769821200); // 2026-01-31 01:00
+
+    mockVaultCalls(decimals, shareValue, totalAssets);
+    mockDistributorCalls(rewardRate, periodFinish);
+    handleBlock(createMockBlock(BigInt.fromI32(100), timestamp1));
+    handleBlock(createMockBlock(BigInt.fromI32(200), timestamp2));
+
+    assert.entityCount("VaultApyHistory", 2);
   });
 });
 

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -303,16 +303,16 @@ describe("handleDailyApr", function () {
     mockDistributorCalls(rewardRateMid, periodFinish);
     handleBlock(createMockBlock(BigInt.fromI32(100), timestamp1));
     const expectedMid = rewardRateMid.times(secondsPerYear).div(totalAssets);
-    assert.entityCount("VaultApyHistory", 1);
-    assert.fieldEquals("VaultApyHistory", id, "apr", expectedMid.toString());
+    assert.entityCount("VaultAprHistory", 1);
+    assert.fieldEquals("VaultAprHistory", id, "apr", expectedMid.toString());
     assert.fieldEquals(
-      "VaultApyHistory",
+      "VaultAprHistory",
       id,
       "timestamp",
       dayTimestamp.toString(),
     );
     assert.fieldEquals(
-      "VaultApyHistory",
+      "VaultAprHistory",
       id,
       "stakingVaultAddress",
       vaultAddressString,
@@ -321,15 +321,15 @@ describe("handleDailyApr", function () {
     // Block 2: a lower reward rate the same day is ignored (max kept).
     mockDistributorCalls(rewardRateLow, periodFinish);
     handleBlock(createMockBlock(BigInt.fromI32(200), timestamp2));
-    assert.entityCount("VaultApyHistory", 1);
-    assert.fieldEquals("VaultApyHistory", id, "apr", expectedMid.toString());
+    assert.entityCount("VaultAprHistory", 1);
+    assert.fieldEquals("VaultAprHistory", id, "apr", expectedMid.toString());
 
     // Block 3: a higher reward rate the same day overwrites the max.
     mockDistributorCalls(rewardRateHigh, periodFinish);
     handleBlock(createMockBlock(BigInt.fromI32(300), timestamp3));
     const expectedHigh = rewardRateHigh.times(secondsPerYear).div(totalAssets);
-    assert.entityCount("VaultApyHistory", 1);
-    assert.fieldEquals("VaultApyHistory", id, "apr", expectedHigh.toString());
+    assert.entityCount("VaultAprHistory", 1);
+    assert.fieldEquals("VaultAprHistory", id, "apr", expectedHigh.toString());
   });
 
   test("records apr 0 when the reward period has finished", function () {
@@ -347,8 +347,8 @@ describe("handleDailyApr", function () {
     mockDistributorCalls(rewardRate, periodFinish);
     handleBlock(createMockBlock(BigInt.fromI32(100), timestamp));
 
-    assert.entityCount("VaultApyHistory", 1);
-    assert.fieldEquals("VaultApyHistory", id, "apr", "0");
+    assert.entityCount("VaultAprHistory", 1);
+    assert.fieldEquals("VaultAprHistory", id, "apr", "0");
   });
 
   test("records apr 0 when the vault has no yield distributor", function () {
@@ -373,8 +373,8 @@ describe("handleDailyApr", function () {
 
     handleBlock(createMockBlock(BigInt.fromI32(100), timestamp));
 
-    assert.entityCount("VaultApyHistory", 1);
-    assert.fieldEquals("VaultApyHistory", id, "apr", "0");
+    assert.entityCount("VaultAprHistory", 1);
+    assert.fieldEquals("VaultAprHistory", id, "apr", "0");
   });
 
   test("creates a separate record per UTC day", function () {
@@ -391,7 +391,7 @@ describe("handleDailyApr", function () {
     handleBlock(createMockBlock(BigInt.fromI32(100), timestamp1));
     handleBlock(createMockBlock(BigInt.fromI32(200), timestamp2));
 
-    assert.entityCount("VaultApyHistory", 2);
+    assert.entityCount("VaultAprHistory", 2);
   });
 
   test("skips recording when a required on-chain read reverts", function () {
@@ -413,7 +413,7 @@ describe("handleDailyApr", function () {
 
     handleBlock(createMockBlock(BigInt.fromI32(100), timestamp));
 
-    assert.entityCount("VaultApyHistory", 0);
+    assert.entityCount("VaultAprHistory", 0);
   });
 });
 


### PR DESCRIPTION
### Description

First part of the work for hemilabs/ui-monorepo#1967, adding historic APY tracking on the subgraph side.

It introduces a `VaultApyHistory` entity that records the **daily-maximum APR** per staking vault. On every polling block, a new `handleDailyApy` step reads the vault's `YieldDistributor` and computes the forward-looking APR as `rewardRate * SECONDS_PER_YEAR / totalAssets` (WAD-scaled). Since continuous-compounding APY is strictly increasing in APR, storing the daily-maximum APR lets the API derive the daily-maximum APY. It records `0` when there is no active drip (no distributor, finished period, or empty vault) and skips the update when a required on-chain read reverts.

Example query:

```graphql
{
  vaultAprHistories(orderBy: timestamp, orderDirection: desc) {
    apr
    stakingVaultAddress
    timestamp
  }
}
```

<details>
<summary>Example output</summary>

```json
{
  "data": {
    "vaultAprHistories": [
      {
        "apr": "94723044492686656",
        "stakingVaultAddress": "0x476310e34d2810f7d79c43a74e4d79405bd7a925",
        "timestamp": "1782172800"
      },
      {
        "apr": "19700775428957182",
        "stakingVaultAddress": "0x0cb9d84d4bcec8d3d5b2d99a6f07f4605325987e",
        "timestamp": "1782172800"
      },
      {
        "apr": "94839702556818495",
        "stakingVaultAddress": "0x476310e34d2810f7d79c43a74e4d79405bd7a925",
        "timestamp": "1782086400"
      },
      {
        "apr": "19700775428957182",
        "stakingVaultAddress": "0x0cb9d84d4bcec8d3d5b2d99a6f07f4605325987e",
        "timestamp": "1782086400"
      },
      {
        "apr": "94839702556818495",
        "stakingVaultAddress": "0x476310e34d2810f7d79c43a74e4d79405bd7a925",
        "timestamp": "1782000000"
      },
      {
        "apr": "0",
        "stakingVaultAddress": "0x0cb9d84d4bcec8d3d5b2d99a6f07f4605325987e",
        "timestamp": "1782000000"
      },
      {
        "apr": "94839702556818495",
        "stakingVaultAddress": "0x476310e34d2810f7d79c43a74e4d79405bd7a925",
        "timestamp": "1781913600"
      },
      {
        "apr": "0",
        "stakingVaultAddress": "0x0cb9d84d4bcec8d3d5b2d99a6f07f4605325987e",
        "timestamp": "1781913600"
      },
      {
        "apr": "94839702556818495",
        "stakingVaultAddress": "0x476310e34d2810f7d79c43a74e4d79405bd7a925",
        "timestamp": "1781827200"
      },
      {
        "apr": "0",
        "stakingVaultAddress": "0x0cb9d84d4bcec8d3d5b2d99a6f07f4605325987e",
        "timestamp": "1781827200"
      },
      {
        "apr": "94846058734292707",
        "stakingVaultAddress": "0x476310e34d2810f7d79c43a74e4d79405bd7a925",
        "timestamp": "1781740800"
      },
      {
        "apr": "0",
        "stakingVaultAddress": "0x0cb9d84d4bcec8d3d5b2d99a6f07f4605325987e",
        "timestamp": "1781740800"
      },
      {
        "apr": "94846058734292707",
        "stakingVaultAddress": "0x476310e34d2810f7d79c43a74e4d79405bd7a925",
        "timestamp": "1781654400"
      },
      {
        "apr": "0",
        "stakingVaultAddress": "0x0cb9d84d4bcec8d3d5b2d99a6f07f4605325987e",
        "timestamp": "1781654400"
      },
      {
        "apr": "0",
        "stakingVaultAddress": "0x476310e34d2810f7d79c43a74e4d79405bd7a925",
        "timestamp": "1781568000"
      },
      {
        "apr": "0",
        "stakingVaultAddress": "0x0cb9d84d4bcec8d3d5b2d99a6f07f4605325987e",
        "timestamp": "1781568000"
      },
      {
        "apr": "0",
        "stakingVaultAddress": "0x476310e34d2810f7d79c43a74e4d79405bd7a925",
        "timestamp": "1781481600"
      },
      {
        "apr": "0",
        "stakingVaultAddress": "0x0cb9d84d4bcec8d3d5b2d99a6f07f4605325987e",
        "timestamp": "1781481600"
      },
      {
        "apr": "0",
        "stakingVaultAddress": "0x476310e34d2810f7d79c43a74e4d79405bd7a925",
        "timestamp": "1781395200"
      },
      {
        "apr": "0",
        "stakingVaultAddress": "0x0cb9d84d4bcec8d3d5b2d99a6f07f4605325987e",
        "timestamp": "1781395200"
      }
    ]
  }
}
```

</details>

### Screenshots

How the chart will (eventually) look

<img width="1255" height="535" alt="image" src="https://github.com/user-attachments/assets/5127c8bc-2558-4abe-b9f6-cf2d00c38087" />


### Related issue(s)

Related to hemilabs/ui-monorepo#1967

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
