### PR TITLE
api: move prod CUSTOM_RPC_URL_MAINNET var to a secret

### DIFF
--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -41,7 +41,6 @@
         },
       },
       "vars": {
-        "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
         "ORIGINS": "https://app.vetro.org,https://beta.vetro.org,https://*.hemi.xyz",
         "PORTAL_API_URL": "https://portal-api.hemi.xyz",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",


### PR DESCRIPTION
### Description

Remove `CUSTOM_RPC_URL_MAINNET` from the api `wrangler.jsonc` file's `production` environment, as the value has now been moved to a secret variable.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
