### PR TITLE
Add Earn deposit e2e test with shared helpers

### DIFF
--- a/web/e2e/earn.spec.ts
+++ b/web/e2e/earn.spec.ts
@@ -1,0 +1,144 @@
+import { TEST_ADDRESS } from "@hemilabs/anvil-fork-setup/utils";
+import { expect } from "@playwright/test";
+import { parseAbiItem, parseEventLogs, parseUnits } from "viem";
+import { getTransactionReceipt } from "viem/actions";
+import { balanceOf } from "viem-erc20/actions";
+
+import { sVusdAddress } from "../../packages/earn/src/stakingVaultAddresses.ts";
+
+import { createEthereumClient } from "./anvil";
+import { test } from "./fixtures/wallet";
+import { getMainnetToken, waitForBalance } from "./helpers";
+
+const vusd = getMainnetToken("VUSD");
+const DEPOSIT_DISPLAY = "5";
+const DEPOSIT_AMOUNT = parseUnits(DEPOSIT_DISPLAY, vusd.decimals);
+
+// The VUSD pool is the sVUSD ERC-4626 vault. A deposit emits the standard
+// ERC-4626 Deposit(sender, owner, assets, shares); `shares` is exactly the
+// sVUSD minted to the receiver, so we read it straight off the deposit tx.
+const depositEvent = parseAbiItem(
+  "event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)",
+);
+
+test("deposit VUSD into the Earn pool", async function ({
+  page,
+  walletTxHashes,
+}) {
+  const publicClient = createEthereumClient();
+
+  const [vusdBefore, svusdBefore] = await Promise.all([
+    balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: vusd.address,
+    }),
+    balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: sVusdAddress,
+    }),
+  ]);
+
+  await page.goto("/");
+
+  // The mock wallet auto-connects silently via EIP-6963 (see fixtures/wallet),
+  // so just wait for the header button to switch from "Connect wallet" to the
+  // 0x… short address — don't open the RainbowKit connect modal.
+  await expect(
+    page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // Navigate to Earn from the navbar. Routes are locale-prefixed (/en/earn), so
+  // a bare page.goto("/earn") is parsed as lang="earn" and falls back to the
+  // default page — clicking the nav link is both correct and what a user does.
+  await page.getByRole("link", { name: "Earn" }).click();
+  await expect(page).toHaveURL(/\/en\/earn/);
+
+  // The Earn page renders one PoolInfoBar per vault (VUSD, vetBTC). Scope the
+  // Deposit click to the bar that shows the "VUSD" token symbol so the test
+  // doesn't depend on pool ordering. The only element containing both the VUSD
+  // label and a Deposit button is the pool bar itself; `.last()` picks that
+  // innermost match rather than an ancestor container.
+  const vusdPool = page
+    .locator("div")
+    .filter({ has: page.getByText("VUSD", { exact: true }) })
+    .filter({ has: page.getByRole("button", { name: "Deposit" }) })
+    .last();
+  await vusdPool.getByRole("button", { name: "Deposit" }).click();
+
+  // The stake drawer slides in ("Manage your stake position").
+  await expect(
+    page.getByRole("heading", { name: "Manage your stake position" }),
+  ).toBeVisible();
+
+  await page
+    .locator('input[type="text"]:not([disabled])')
+    .first()
+    .fill(DEPOSIT_DISPLAY);
+
+  // Per-test snapshot/revert resets the allowance to 0, so the deposit takes the
+  // two-tx path: the submit button reads "Approve and deposit". The mock wallet
+  // signs both txs (approve, then deposit) with no popups.
+  await page.getByRole("button", { name: /approve and deposit/i }).click();
+
+  // The success toast renders once both txs confirm on the fork (60s budget to
+  // cover the two sequential signatures + confirmations).
+  await expect(page.getByText("Stake deposit confirmed")).toBeVisible({
+    timeout: 60_000,
+  });
+
+  // Assertion 1 — VUSD balance dropped by exactly the deposited amount.
+  await waitForBalance({ client: publicClient, token: vusd.address }).toBe(
+    vusdBefore - DEPOSIT_AMOUNT,
+  );
+
+  // Assertion 2 — read how many sVUSD were minted straight from the deposit tx.
+  // The mock wallet sends approve then deposit, so walletTxHashes ends with the
+  // deposit; its receipt carries the vault's ERC-4626 Deposit event, whose
+  // `shares` is exactly the sVUSD minted to us — no block-range scan, no summing.
+  const depositTxHash = walletTxHashes.at(-1);
+  expect(depositTxHash).toBeDefined();
+  const receipt = await getTransactionReceipt(publicClient, {
+    hash: depositTxHash!,
+  });
+  const depositLogs = parseEventLogs({
+    abi: [depositEvent],
+    args: { owner: TEST_ADDRESS },
+    eventName: "Deposit",
+    logs: receipt.logs,
+  });
+  expect(depositLogs).toHaveLength(1);
+  const svusdMinted = depositLogs[0].args.shares;
+  expect(svusdMinted).toBeGreaterThan(0n);
+
+  const svusdAfter = await balanceOf(publicClient, {
+    account: TEST_ADDRESS,
+    address: sVusdAddress,
+  });
+  expect(svusdAfter - svusdBefore).toBe(svusdMinted);
+
+  // Assertion 3 — the staked position surfaces on the Earn page without any
+  // backend API. The drawer auto-closes ~2s after success and clears its
+  // stake-mode URL params (nuqs); wait for that so the reload lands on a clean
+  // /en/earn — otherwise the persisted params reopen the drawer and its backdrop
+  // overlay intercepts the badge hover below.
+  await expect(
+    page.getByRole("heading", { name: "Manage your stake position" }),
+  ).toBeHidden({ timeout: 15_000 });
+
+  // Reload so the staked-balance queries refetch the post-deposit state, then
+  // assert the on-chain-derived "From 1 pool" badge appears and its tooltip
+  // shows the staked VUSD amount (vault.convertToAssets(sVUSD)).
+  await page.reload();
+  await expect(
+    page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  const fromPoolsBadge = page.getByText(/from 1 pool/i);
+  await expect(fromPoolsBadge).toBeVisible({ timeout: 20_000 });
+
+  await fromPoolsBadge.hover();
+  // The tooltip lists the pool's staked balance as "(<amount> VUSD)".
+  await expect(page.getByText(/\([\d.,]+\s*VUSD\)/)).toBeVisible({
+    timeout: 10_000,
+  });
+});

--- a/web/e2e/earn.spec.ts
+++ b/web/e2e/earn.spec.ts
@@ -78,7 +78,19 @@ test("deposit VUSD into the Earn pool", async function ({
   // Per-test snapshot/revert resets the allowance to 0, so the deposit takes the
   // two-tx path: the submit button reads "Approve and deposit". The mock wallet
   // signs both txs (approve, then deposit) with no popups.
-  await page.getByRole("button", { name: /approve and deposit/i }).click();
+  //
+  // Dispatch the click straight to the button rather than a coordinate click:
+  // the ApproveSection's info-icon tooltip (rc-tooltip, placement="top") in the
+  // CollapsibleSection just below renders its overlay directly over this button,
+  // and in CI it swallows the pointer events so a normal .click() never lands and
+  // the test times out. dispatchEvent bypasses hit-testing and triggers the
+  // form's submit handler directly; await the enabled state first so we don't
+  // submit before balances load (the form's onSubmit no-ops while inputError set).
+  const submitButton = page.getByRole("button", {
+    name: /approve and deposit/i,
+  });
+  await expect(submitButton).toBeEnabled();
+  await submitButton.dispatchEvent("click");
 
   // The success toast renders once both txs confirm on the fork (60s budget to
   // cover the two sequential signatures + confirmations).

--- a/web/e2e/fixtures/wallet.ts
+++ b/web/e2e/fixtures/wallet.ts
@@ -1,23 +1,55 @@
 import { TEST_PRIVATE_KEY } from "@hemilabs/anvil-fork-setup/utils";
 import { test as base } from "@playwright/test";
 import { installMockWallet } from "@vetro-protocol/mock-wallet";
-import { createTestClient, http } from "viem";
+import {
+  type EIP1193RequestFn,
+  type Hex,
+  type Transport,
+  createTestClient,
+  http,
+} from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { revert, snapshot } from "viem/actions";
 import { mainnet } from "viem/chains";
 
 import { ANVIL_URL } from "../anvil";
 
+// An http transport that records the hash returned by every
+// eth_sendRawTransaction it forwards. The mock wallet executes writes in Node
+// (installMockWallet runs the wallet client behind page.exposeFunction), so the
+// browser never makes this call and Playwright page routing can't observe it —
+// tapping the wallet's own transport is the reliable way to learn which tx it
+// sent. Reads (eth_call, eth_getLogs, …) pass through untouched.
+function recordingTransport(txHashes: Hex[]): Transport {
+  const inner = http(ANVIL_URL);
+  return function recording(params) {
+    const transport = inner(params);
+    const request = async function (args: Parameters<EIP1193RequestFn>[0]) {
+      const result = await transport.request(args);
+      if (args.method === "eth_sendRawTransaction") {
+        txHashes.push(result as Hex);
+      }
+      return result;
+    };
+    return { ...transport, request: request as EIP1193RequestFn };
+  };
+}
+
+type WalletFixtures = {
+  // Hashes of the txs the mock wallet sent during the test, oldest first.
+  walletTxHashes: Hex[];
+};
+
 // `installMockWallet` injects an EIP-6963-announcing EIP-1193 provider into
 // the page before the dApp scripts run. RainbowKit then sees the wallet via
 // EIP-6963 and connects silently — no extension popup, no confirm clicks.
-export const test = base.extend({
-  async page({ page }, use) {
+export const test = base.extend<WalletFixtures>({
+  async page({ page, walletTxHashes }, use) {
     await installMockWallet({
       account: privateKeyToAccount(TEST_PRIVATE_KEY),
       chain: mainnet,
       page,
-      transports: { [mainnet.id]: http(ANVIL_URL) },
+      transports: { [mainnet.id]: recordingTransport(walletTxHashes) },
     });
 
     // The fork is started and funded once in globalSetup, then shared across
@@ -36,5 +68,11 @@ export const test = base.extend({
     const snapshotId = await snapshot(testClient);
     await use(page);
     await revert(testClient, { id: snapshotId });
+  },
+  // Playwright requires the first fixture arg to be a destructuring pattern even
+  // when the fixture has no dependencies, so the empty pattern is intentional.
+  // eslint-disable-next-line no-empty-pattern
+  async walletTxHashes({}, use) {
+    await use([]);
   },
 });

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -1,0 +1,36 @@
+import { TEST_ADDRESS } from "@hemilabs/anvil-fork-setup/utils";
+import { expect } from "@playwright/test";
+import type { Address } from "viem";
+import { mainnet } from "viem/chains";
+import { balanceOf } from "viem-erc20/actions";
+
+import { knownTokens } from "../src/utils/tokenList.ts";
+
+import type { createEthereumClient } from "./anvil";
+
+export function getMainnetToken(symbol: string) {
+  const token = knownTokens.find(
+    (t) => t.chainId === mainnet.id && t.symbol === symbol,
+  );
+  if (!token) {
+    throw new Error(`Token ${symbol} not found in tokenList for mainnet`);
+  }
+  return token;
+}
+
+/**
+ * Polls the test account's on-chain balance of `token` until the chained matcher
+ * passes (or 20s elapses). Returns the expect.poll proxy so the call site keeps
+ * the meaningful assertion: `waitForBalance({ client, token }).toBe(x)` / `.toBeGreaterThan(x)`.
+ */
+export const waitForBalance = ({
+  client,
+  token,
+}: {
+  client: ReturnType<typeof createEthereumClient>;
+  token: Address;
+}) =>
+  expect.poll(
+    () => balanceOf(client, { account: TEST_ADDRESS, address: token }),
+    { timeout: 20_000 },
+  );

--- a/web/e2e/swap.spec.ts
+++ b/web/e2e/swap.spec.ts
@@ -2,7 +2,6 @@ import { TEST_ADDRESS } from "@hemilabs/anvil-fork-setup/utils";
 import { expect } from "@playwright/test";
 import { parseUnits } from "viem";
 import { getBlock, readContract } from "viem/actions";
-import { mainnet } from "viem/chains";
 import { balanceOf } from "viem-erc20/actions";
 
 import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
@@ -10,20 +9,10 @@ import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts
 import { fastForwardTime } from "../scripts/fastForwardTime.ts";
 import { setRedeemDelay } from "../scripts/redeemDelay.ts";
 import { whitelistInstantRedeem } from "../scripts/whitelistInstantRedeem.ts";
-import { knownTokens } from "../src/utils/tokenList.ts";
 
 import { ANVIL_URL, createEthereumClient } from "./anvil";
 import { test } from "./fixtures/wallet";
-
-function getMainnetToken(symbol: string) {
-  const token = knownTokens.find(
-    (t) => t.chainId === mainnet.id && t.symbol === symbol,
-  );
-  if (!token) {
-    throw new Error(`Token ${symbol} not found in tokenList for mainnet`);
-  }
-  return token;
-}
+import { getMainnetToken, waitForBalance } from "./helpers";
 
 const usdc = getMainnetToken("USDC");
 const vusd = getMainnetToken("VUSD");
@@ -97,16 +86,10 @@ test("swap USDC → VUSD via the gateway", async function ({ page }) {
 
   // No popups — the mock wallet signs and forwards to Anvil silently.
   // Assert by polling balances directly against the fork.
-  await expect
-    .poll(
-      async () =>
-        balanceOf(publicClient, {
-          account: TEST_ADDRESS,
-          address: vusd.address,
-        }),
-      { timeout: 20_000 },
-    )
-    .toBeGreaterThan(vusdBefore);
+  await waitForBalance({
+    client: publicClient,
+    token: vusd.address,
+  }).toBeGreaterThan(vusdBefore);
 
   const usdcAfter = await balanceOf(publicClient, {
     account: TEST_ADDRESS,
@@ -208,16 +191,10 @@ test("redeem VUSD → USDC via the gateway (instant redeem)", async function ({
 
   // No popups — the mock wallet signs and forwards to Anvil silently.
   // Assert by polling balances directly against the fork.
-  await expect
-    .poll(
-      async () =>
-        balanceOf(publicClient, {
-          account: TEST_ADDRESS,
-          address: usdc.address,
-        }),
-      { timeout: 20_000 },
-    )
-    .toBeGreaterThan(usdcBefore);
+  await waitForBalance({
+    client: publicClient,
+    token: usdc.address,
+  }).toBeGreaterThan(usdcBefore);
 
   const vusdAfter = await balanceOf(publicClient, {
     account: TEST_ADDRESS,
@@ -283,16 +260,9 @@ test("redeem VUSD via the gateway (two-step queue redeem)", async function ({
   });
 
   // The VUSD is now locked in the gateway, so the wallet balance already dropped.
-  await expect
-    .poll(
-      async () =>
-        balanceOf(publicClient, {
-          account: TEST_ADDRESS,
-          address: vusd.address,
-        }),
-      { timeout: 20_000 },
-    )
-    .toBe(vusdBefore - REDEEM_AMOUNT);
+  await waitForBalance({ client: publicClient, token: vusd.address }).toBe(
+    vusdBefore - REDEEM_AMOUNT,
+  );
 
   // The queue now lists the request we just created — assert the
   // redeemable-balance column shows the locked amount and pegged-token symbol.
@@ -370,16 +340,10 @@ test("redeem VUSD via the gateway (two-step queue redeem)", async function ({
   // The claim settled on the fork: the output stablecoin was received, and VUSD
   // stays at its post-step-1 value (the locked balance was burned, not the
   // wallet's).
-  await expect
-    .poll(
-      async () =>
-        balanceOf(publicClient, {
-          account: TEST_ADDRESS,
-          address: outputToken.address,
-        }),
-      { timeout: 20_000 },
-    )
-    .toBeGreaterThan(outputBefore);
+  await waitForBalance({
+    client: publicClient,
+    token: outputToken.address,
+  }).toBeGreaterThan(outputBefore);
 
   const vusdAfterClaim = await balanceOf(publicClient, {
     account: TEST_ADDRESS,


### PR DESCRIPTION
### Description

Adds an end-to-end test for the Earn page stake flow: deposit VUSD into the sVUSD ERC-4626 vault and verify the result on-chain and in the UI.

The test connects the mock wallet (silent EIP-6963 auto-connect), navigates to Earn, opens the VUSD pool's stake drawer, and runs the two-tx "Approve and deposit" path. It then asserts three things: the VUSD balance dropped by exactly the deposited amount; the sVUSD minted (read straight off the deposit tx's ERC-4626 `Deposit` event) matches the sVUSD balance increase; and the staked position surfaces on the Earn page via the on-chain-derived "From 1 pool" badge and its tooltip.

To read the exact transaction the mock wallet sent, this adds a `walletTxHashes` fixture backed by a recording `http` transport that taps `eth_sendRawTransaction`. The wallet executes writes in Node, so the browser never makes that call and Playwright page routing can't observe it — tapping the wallet's own transport is the reliable way to learn which tx it sent.

It also extracts the shared `getMainnetToken` helper and a new `waitForBalance` polling helper into `web/e2e/helpers.ts`, and refactors `swap.spec.ts` to use them (removing the duplicated `getMainnetToken` and the repeated inline `expect.poll(balanceOf …)` blocks).

### Screenshots

https://github.com/user-attachments/assets/757de556-178c-4768-ac42-dbe8deb3a20a

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
