### PR TITLE
Add formal-tone rule to i18n translations skill

### DIFF
--- a/.claude/skills/i18n-translations/SKILL.md
+++ b/.claude/skills/i18n-translations/SKILL.md
@@ -23,10 +23,19 @@ description: Add, modify, or validate translations in the project's locale files
    ```
 
 6. These terms stay in English in the other locales: **bridge**, **earn**, **stablecoins**, **stake**, **staked**, **staking**.
+7. **Translations must address the user with a formal, respectful register.** Machine translation defaults to the informal register, so always review the tone of any string you add or edit. For Spanish (`es`), use the formal _usted_ form, never the informal _tú_/_vos_:
+   - Possessives: `su` / `sus`, not `tu` / `tus` (e.g. "sus fondos", not "tus fondos").
+   - Verbs and imperatives: conjugate for _usted_ — "Haga clic", "Use", "Conecte", "Ingrese", "Revise", "Confirme", "Intente de nuevo" — not "Haz clic", "Usa", "Conecta", "Ingresa", "Revisa", "Confirma", "Intenta de nuevo".
+   - Pronouns: prefer "le" / "lo" / "la"; avoid "te" / "ti".
+
+   Existing strings that follow this convention (use as reference):
+   - `common.enter-amount` → "Ingrese un monto"
+   - `common.approve-10x-tooltip` → "Apruebe hasta 10× el monto de **su** transacción… Puede revocarlo en cualquier momento."
+   - `pages.borrow.progress.confirm-description` → "Revise los detalles y confirme el préstamo en **su** billetera."
 
 ## Workflow
 
 1. Read both locale files before making changes.
 2. Add keys in alphabetical order within their section, matching existing nesting.
-3. Write the English value and a natural Spanish translation (respecting rule 6).
+3. Write the English value and a natural Spanish translation, respecting the English-only terms (rule 6) and the formal register (rule 7).
 4. Verify both files have matching key structures.

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -202,8 +202,8 @@
         "from-chain": "desde {{chain}}",
         "on-chain": "en {{chain}}",
         "preview-error": "No se pudo estimar la tarifa",
-        "you-are-sending": "Estás enviando",
-        "you-will-receive": "Recibirás"
+        "you-are-sending": "Está enviando",
+        "you-will-receive": "Va a recibir"
       },
       "progress": {
         "approve-description": "Esto permite al contrato del puente gastar este token.",
@@ -383,7 +383,7 @@
         "redeemable-for_other": "Intercambiable por {{allButLast}} y {{lastSymbol}}",
         "send-to-queue": "Enviar a la cola",
         "swap": "Intercambiar",
-        "you-are-swapping": "Vas a intercambiar",
+        "you-are-swapping": "Va a intercambiar",
         "you-will-receive-estimated": "Va a recibir (estimado)"
       },
       "progress": {

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -383,7 +383,7 @@
         "redeemable-for_other": "Intercambiable por {{allButLast}} y {{lastSymbol}}",
         "send-to-queue": "Enviar a la cola",
         "swap": "Intercambiar",
-        "you-are-swapping": "Va a intercambiar",
+        "you-are-swapping": "Está intercambiando",
         "you-will-receive-estimated": "Va a recibir (estimado)"
       },
       "progress": {


### PR DESCRIPTION
### Description

Adds a formal-register rule to the `i18n-translations` skill so AI-assisted and machine translations address users formally. Spanish must use the _usted_ form ("su"/"sus", "Ingrese", "Confirme") instead of the informal _tú_/_vos_ register these tools default to. The rule breaks down possessives, verbs/imperatives, and pronouns, and points to existing strings that already follow the convention.

This mirrors the same guidance added in hemilabs/ui-monorepo#2036 (Spanish-only here, since this repo has no Portuguese locale).

Also fixes three existing informal strings in the `es` locale to match the new rule: the Bridge and Swap form labels ("Estás enviando" → "Está enviando", "Recibirás" → "Va a recibir", "Vas a intercambiar" → "Va a intercambiar").

### Screenshots

N/A — translation copy and skill documentation only.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.