### PR TITLE
Use FMV for transfers

### DIFF
--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -207,13 +207,7 @@ export function handleTransfer(event: Transfer): void {
 
   // Update the sending party: decrement shares and totalCostBasis proportionally.
   const fromId = buildId(vaultAddress, event.params.from.toHexString());
-  // Defensive: the entity should always exist (created by handleDeposit or a
-  // prior transfer-in), but the contract is upgradeable — bail out gracefully
-  // if a future code path mints shares without emitting Deposit.
-  const fromEntity = UserStakingPosition.load(fromId);
-  if (fromEntity == null) {
-    return;
-  }
+  const fromEntity = UserStakingPosition.load(fromId)!;
 
   if (fromEntity.shares.le(value)) {
     // All shares transferred out (or tracked shares already at/below the

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -207,7 +207,13 @@ export function handleTransfer(event: Transfer): void {
 
   // Update the sending party: decrement shares and totalCostBasis proportionally.
   const fromId = buildId(vaultAddress, event.params.from.toHexString());
-  const fromEntity = UserStakingPosition.load(fromId)!;
+  // Defensive: the entity should always exist (created by handleDeposit or a
+  // prior transfer-in), but the contract is upgradeable — bail out gracefully
+  // if a future code path mints shares without emitting Deposit.
+  const fromEntity = UserStakingPosition.load(fromId);
+  if (fromEntity == null) {
+    return;
+  }
 
   if (fromEntity.shares.le(value)) {
     // All shares transferred out (or tracked shares already at/below the
@@ -231,8 +237,15 @@ export function handleTransfer(event: Transfer): void {
     return;
   }
 
-  // Update the receiving party: increment shares, keep totalCostBasis unchanged.
-  // Received shares are valued at 0, diluting the average price proportionally.
+  // Update the receiving party: increment shares and totalCostBasis at FMV.
+  // Value incoming shares at their current underlying asset value
+  // (convertToAssets) so that transfers — including DeFi round-trips through
+  // LP pools, routers, etc. — don't artificially deflate cost basis. If
+  // convertToAssets reverts (empty vault edge case), fall back to 1:1.
+  const vault = StakingVault.bind(vaultAddress);
+  const assetValueResult = vault.try_convertToAssets(value);
+  const assetValue = assetValueResult.reverted ? value : assetValueResult.value;
+
   const toId = buildId(vaultAddress, event.params.to.toHexString());
   let toEntity = UserStakingPosition.load(toId);
   if (toEntity == null) {
@@ -244,6 +257,7 @@ export function handleTransfer(event: Transfer): void {
   }
 
   toEntity.shares = toEntity.shares.plus(value);
+  toEntity.totalCostBasis = toEntity.totalCostBasis.plus(assetValue.times(WAD));
 
   toEntity.save();
 }

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -824,13 +824,27 @@ describe("handleWithdrawClaimed", function () {
   });
 });
 
+// Mock convertToAssets for a specific share amount at a 1.2:1 rate (each
+// share is worth 1.2 underlying assets). Mirrors the vault's exchange rate.
+function mockConvertToAssetsForAmount(shares: BigInt): void {
+  // 1.2:1 rate: assets = shares * 12 / 10
+  const assets = shares.times(BigInt.fromI32(12)).div(BigInt.fromI32(10));
+  createMockedFunction(
+    vaultAddress,
+    "convertToAssets",
+    "convertToAssets(uint256):(uint256)",
+  )
+    .withArgs([ethereum.Value.fromUnsignedBigInt(shares)])
+    .returns([ethereum.Value.fromUnsignedBigInt(assets)]);
+}
+
 describe("handleTransfer", function () {
   beforeEach(function () {
     clearStore();
     dataSourceMock.setAddress(vaultAddressString);
   });
 
-  test("updates shares on transfer-in, keeps totalCostBasis unchanged", function () {
+  test("updates shares and totalCostBasis at FMV on transfer-in", function () {
     // t0: Deposit 120 VUSD -> 100 sVUSD. shares=100e18, totalCostBasis=120e36
     handleDeposit(
       createDepositEvent(
@@ -851,8 +865,11 @@ describe("handleTransfer", function () {
       ),
     );
 
-    // t1: Receive 50 sVUSD via transfer. shares=150e18, totalCostBasis=120e36 (unchanged)
-    // averagePrice = 120e36 / 150e18 = 0.8e18
+    // Mock convertToAssets(50e18) → 60e18 (1.2:1 rate)
+    mockConvertToAssetsForAmount(BigInt.fromString("50000000000000000000"));
+
+    // t1: Receive 50 sVUSD via transfer. shares=150e18
+    // totalCostBasis = 120e36 + 60e18*WAD = 120e36 + 60e36 = 180e36
     handleTransfer(
       createTransferEvent(
         receiverAddress,
@@ -872,7 +889,7 @@ describe("handleTransfer", function () {
       "UserStakingPosition",
       id,
       "totalCostBasis",
-      "120000000000000000000000000000000000000",
+      "180000000000000000000000000000000000000",
     );
   });
 
@@ -897,7 +914,11 @@ describe("handleTransfer", function () {
       ),
     );
 
-    // t1: Receive 50 sVUSD. shares=150e18, totalCostBasis=120e36. avg=0.8e18
+    // Mock convertToAssets for both transfer amounts at 1.2:1
+    mockConvertToAssetsForAmount(BigInt.fromString("50000000000000000000"));
+    mockConvertToAssetsForAmount(BigInt.fromString("150000000000000000000"));
+
+    // t1: Receive 50 sVUSD. FMV = 60e18. totalCostBasis = 120e36 + 60e36 = 180e36
     handleTransfer(
       createTransferEvent(
         receiverAddress,
@@ -906,7 +927,7 @@ describe("handleTransfer", function () {
       ),
     );
 
-    // t2: Receive 150 sVUSD. shares=300e18, totalCostBasis=120e36. avg=0.4e18
+    // t2: Receive 150 sVUSD. FMV = 180e18. totalCostBasis = 180e36 + 180e36 = 360e36
     handleTransfer(
       createTransferEvent(
         receiverAddress,
@@ -926,11 +947,11 @@ describe("handleTransfer", function () {
       "UserStakingPosition",
       id,
       "totalCostBasis",
-      "120000000000000000000000000000000000000",
+      "360000000000000000000000000000000000000",
     );
   });
 
-  test("sets shares to transferred amount and totalCostBasis to 0 for new user", function () {
+  test("sets shares and totalCostBasis at FMV for new user on transfer-in", function () {
     // Give receiverAddress shares so it can transfer them
     handleDeposit(
       createDepositEvent(
@@ -941,7 +962,10 @@ describe("handleTransfer", function () {
       ),
     );
 
-    // User with no prior position receives 100 sVUSD
+    // Mock convertToAssets(100e18) → 120e18 (1.2:1 rate)
+    mockConvertToAssetsForAmount(BigInt.fromString("100000000000000000000"));
+
+    // User with no prior position receives 100 sVUSD at FMV = 120e18
     handleTransfer(
       createTransferEvent(
         receiverAddress,
@@ -958,7 +982,12 @@ describe("handleTransfer", function () {
       "shares",
       "100000000000000000000",
     );
-    assert.fieldEquals("UserStakingPosition", id, "totalCostBasis", "0");
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "totalCostBasis",
+      "120000000000000000000000000000000000000",
+    );
     assert.fieldEquals("UserStakingPosition", id, "owner", ownerAddressString);
   });
 
@@ -972,6 +1001,9 @@ describe("handleTransfer", function () {
         BigInt.fromString("100000000000000000000"),
       ),
     );
+
+    // Mock convertToAssets(30e18) → 36e18 (1.2:1 rate) for receiver's FMV
+    mockConvertToAssetsForAmount(BigInt.fromString("30000000000000000000"));
 
     // Transfer 30 sVUSD out. Remaining: 70e18 shares.
     // totalCostBasis = 120e36 * 70/100 = 84e36. avg = 84e36/70e18 = 1.2e18 (unchanged)
@@ -997,7 +1029,7 @@ describe("handleTransfer", function () {
       "84000000000000000000000000000000000000",
     );
 
-    // Receiver gets shares with totalCostBasis unchanged (0 for new user)
+    // Receiver gets shares with totalCostBasis at FMV: 36e18 * WAD = 36e36
     const receiverId = `${vaultAddressString}-${receiverAddressString}`;
     assert.fieldEquals(
       "UserStakingPosition",
@@ -1009,7 +1041,7 @@ describe("handleTransfer", function () {
       "UserStakingPosition",
       receiverId,
       "totalCostBasis",
-      "0",
+      "36000000000000000000000000000000000000",
     );
   });
 
@@ -1023,6 +1055,9 @@ describe("handleTransfer", function () {
         BigInt.fromString("100000000000000000000"),
       ),
     );
+
+    // Mock convertToAssets(100e18) → 120e18 for receiver's FMV
+    mockConvertToAssetsForAmount(BigInt.fromString("100000000000000000000"));
 
     // Transfer all 100 sVUSD out.
     handleTransfer(
@@ -1042,6 +1077,8 @@ describe("handleTransfer", function () {
     // Setup: owner deposits then transfers everything out, leaving a position
     // with shares=0. A further non-zero transfer-out (tracked shares diverged
     // from on-chain balance) must reset to zero instead of dividing by zero.
+    mockConvertToAssetsForAmount(BigInt.fromString("100000000000000000000"));
+    mockConvertToAssetsForAmount(BigInt.fromString("30000000000000000000"));
     handleDeposit(
       createDepositEvent(
         BigInt.fromString("120000000000000000000"),
@@ -1217,6 +1254,55 @@ describe("handleTransfer", function () {
       id,
       "totalCostBasis",
       "120000000000000000000000000000000000000",
+    );
+  });
+
+  test("falls back to 1:1 when convertToAssets reverts on transfer-in", function () {
+    // Give receiverAddress shares so it can transfer them
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("100000000000000000000"),
+        receiverAddress,
+        receiverAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    // Explicitly make convertToAssets revert for this transfer amount
+    createMockedFunction(
+      vaultAddress,
+      "convertToAssets",
+      "convertToAssets(uint256):(uint256)",
+    )
+      .withArgs([
+        ethereum.Value.fromUnsignedBigInt(
+          BigInt.fromString("100000000000000000000"),
+        ),
+      ])
+      .reverts();
+
+    // Transfer 100 sVUSD to owner. convertToAssets reverts, so the handler
+    // falls back to 1:1: assetValue = value = 100e18, totalCostBasis = 100e36
+    handleTransfer(
+      createTransferEvent(
+        receiverAddress,
+        ownerAddress,
+        BigInt.fromString("100000000000000000000"),
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "shares",
+      "100000000000000000000",
+    );
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "totalCostBasis",
+      "100000000000000000000000000000000000000",
     );
   });
 });


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The subgraph valued incoming sVUSD transfers at 0 cost basis. When users round-tripped shares through DeFi protocols (Curve LPs, routers, etc.), cost basis "leaked" on every cycle — the outgoing transfer removed cost proportionally, but the returning shares added nothing back. This produced phantom earnings.

#### Fix

Value incoming transfers at fair market value using `convertToAssets(shares)` at the block of receipt (falls back to 1:1 if the call reverts). This matches how Aave's scaled-balance model implicitly handles transferred aTokens — the industry-standard approach for transferable yield-bearing tokens.

The from-side proportional reduction is unchanged (correct under average cost accounting).

#### Auto summary

This pull request updates the handling of share transfers in the staking subgraph to track cost basis more accurately. Instead of keeping the receiving user's `totalCostBasis` unchanged on transfer-in, the cost basis is now incremented by the fair market value (FMV) of the incoming shares, ensuring that metrics remain correct even when shares are routed through DeFi protocols or the vault's exchange rate changes. The code is also made more robust to contract upgrades and edge cases. The test suite is updated accordingly to validate these new behaviors.

**Core logic changes:**

* The `handleTransfer` function now increments the receiving user's `totalCostBasis` by the FMV of incoming shares, using `convertToAssets` to determine value, and falls back to a 1:1 rate if the call reverts (e.g., empty vault edge case). [[1]](diffhunk://#diff-21fb7fcabbd216361917473329a8f2b8f8204e46e9cc18ff473fdca61ca48e9eL234-R248) [[2]](diffhunk://#diff-21fb7fcabbd216361917473329a8f2b8f8204e46e9cc18ff473fdca61ca48e9eR260)
* Defensive coding: The transfer handler now gracefully exits if the sender's staking position does not exist, to handle potential future contract upgrades.

**Testing improvements:**

* The test suite for `handleTransfer` is updated to check that cost basis is set at FMV for transfer-ins, not left unchanged or set to zero. Tests now mock `convertToAssets` at a 1.2:1 rate and verify correct cost basis calculation for both new and existing users. [[1]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2R827-R847) [[2]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L854-R872) [[3]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L875-R892) [[4]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L900-R921) [[5]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L909-R930) [[6]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L929-R954) [[7]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L944-R968) [[8]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L961-R990) [[9]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2R1005-R1007) [[10]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L1000-R1032) [[11]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2L1012-R1044) [[12]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2R1059-R1061) [[13]](diffhunk://#diff-b74dd3f95bad2b490bb56c7f921b2d74b20de91c8bbd17d066732522d2f892a2R1080-R1081)
* Added a new test to verify fallback behavior when `convertToAssets` reverts, ensuring cost basis defaults to a 1:1 rate.

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
