### PR TITLE
Add wallet connect terms and privacy disclaimer

### DIFF
--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -26,7 +26,8 @@
     "search": "Search",
     "search-token-placeholder": "Search by name or symbol",
     "select-token": "Select a token",
-    "try-different-search": "Try searching with a different term"
+    "try-different-search": "Try searching with a different term",
+    "wallet-disclaimer": "By connecting a wallet, you agree to Vetro <terms>Terms of Use</terms> and consent to its <privacy>Privacy Policy</privacy>."
   },
   "language": {
     "switch-to": "Switch to Spanish"

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -26,7 +26,8 @@
     "search": "Buscar",
     "search-token-placeholder": "Buscar por nombre o símbolo",
     "select-token": "Seleccionar un token",
-    "try-different-search": "Intente con un término de búsqueda diferente"
+    "try-different-search": "Intente con un término de búsqueda diferente",
+    "wallet-disclaimer": "Al conectar una billetera, usted acepta los <terms>Términos de uso</terms> de Vetro y consiente su <privacy>Política de privacidad</privacy>."
   },
   "language": {
     "switch-to": "Cambiar a Inglés"

--- a/web/src/providers/web3Provider.tsx
+++ b/web/src/providers/web3Provider.tsx
@@ -1,7 +1,13 @@
-import { getDefaultConfig, RainbowKitProvider } from "@rainbow-me/rainbowkit";
+import {
+  type DisclaimerComponent,
+  getDefaultConfig,
+  RainbowKitProvider,
+} from "@rainbow-me/rainbowkit";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Trans } from "react-i18next";
 import { http, WagmiProvider } from "wagmi";
 
+import { ExternalLink } from "../components/base/externalLink";
 import { allChains } from "../networks";
 
 export const config = getDefaultConfig({
@@ -14,10 +20,37 @@ export const config = getDefaultConfig({
 
 const queryClient = new QueryClient();
 
+const disclaimerLinkClassName =
+  "font-medium text-blue-500 transition-colors hover:text-blue-600";
+
+const WalletDisclaimer: DisclaimerComponent = ({ Text }) => (
+  <Text>
+    <Trans
+      components={{
+        privacy: (
+          <ExternalLink
+            className={disclaimerLinkClassName}
+            href="https://vetro.org/privacy-policy"
+          />
+        ),
+        terms: (
+          <ExternalLink
+            className={disclaimerLinkClassName}
+            href="https://vetro.org/terms-of-use"
+          />
+        ),
+      }}
+      i18nKey="common.wallet-disclaimer"
+    />
+  </Text>
+);
+
 export const Web3Provider = ({ children }: { children: React.ReactNode }) => (
   <WagmiProvider config={config}>
     <QueryClientProvider client={queryClient}>
-      <RainbowKitProvider>{children}</RainbowKitProvider>
+      <RainbowKitProvider appInfo={{ disclaimer: WalletDisclaimer }}>
+        {children}
+      </RainbowKitProvider>
     </QueryClientProvider>
   </WagmiProvider>
 );


### PR DESCRIPTION
### Description

Adds a legal disclaimer to the RainbowKit connect-wallet modal via `appInfo.disclaimer`: "By connecting a wallet, you agree to Vetro Terms of Use and consent to its Privacy Policy."

"Terms of Use" links to https://vetro.org/terms-of-use and "Privacy Policy" to https://vetro.org/privacy-policy (both open in a new tab; URLs are fixed regardless of language). Links are styled in the app's brand blue (`blue-500`, `blue-600` on hover). The sentence is translated for `en`/`es` through a `<Trans>` component while the URLs stay hardcoded.

### Screenshots

<img width="1112" height="1512" alt="image" src="https://github.com/user-attachments/assets/0a318be9-799d-4db5-b7c7-565d0020e0b6" />

https://github.com/user-attachments/assets/c6460cfc-bd20-4825-9d9e-b963cc6fd1f5

### Related issue(s)

Closes #526

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A. → N/A
- [x] Documentation updated, or N/A. → N/A
- [x] Environment variables set in CI, or N/A. → N/A