### PR TITLE
Add Docs and Privacy Policy header menu links

### DIFF
--- a/web/src/components/headerMenu.tsx
+++ b/web/src/components/headerMenu.tsx
@@ -40,6 +40,11 @@ export function HeaderMenu() {
           icon: <HomeIcon className={itemIconClassName} />,
           label: t("nav.header-menu.homepage"),
         },
+        {
+          href: "https://docs.vetro.org/",
+          icon: <DocumentIcon className={itemIconClassName} />,
+          label: t("nav.header-menu.docs"),
+        },
       ],
     },
     {
@@ -63,6 +68,11 @@ export function HeaderMenu() {
           href: "https://vetro.org/terms-of-use",
           icon: <DocumentIcon className={itemIconClassName} />,
           label: t("nav.header-menu.terms-of-use"),
+        },
+        {
+          href: "https://vetro.org/privacy-policy",
+          icon: <DocumentIcon className={itemIconClassName} />,
+          label: t("nav.header-menu.privacy-policy"),
         },
       ],
       label: t("nav.header-menu.company"),

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -38,9 +38,11 @@
     "earn": "Earn",
     "header-menu": {
       "company": "Company",
+      "docs": "Docs",
       "homepage": "Homepage",
       "linkedin": "LinkedIn",
       "open": "Open menu",
+      "privacy-policy": "Privacy Policy",
       "socials": "Socials",
       "terms-of-use": "Terms of Use",
       "x": "X"

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -38,9 +38,11 @@
     "earn": "Earn",
     "header-menu": {
       "company": "Empresa",
+      "docs": "Documentación",
       "homepage": "Inicio",
       "linkedin": "LinkedIn",
       "open": "Abrir menú",
+      "privacy-policy": "Política de privacidad",
       "socials": "Redes sociales",
       "terms-of-use": "Términos de uso",
       "x": "X"


### PR DESCRIPTION
### Description

Adds two external links to the header dropdown ("⋯") menu:

- **Docs** → https://docs.vetro.org/, placed under Homepage
- **Privacy Policy** → https://vetro.org/privacy-policy, placed under Terms of Use in the Company group

Both reuse the existing document icon (same as Terms of Use) and open in a new tab via the shared `ExternalLink` wrapper. English and Spanish translations are included.

### Screenshots

<img width="461" height="351" alt="image" src="https://github.com/user-attachments/assets/b4e37e85-8363-4ef3-a3ed-1fe439cdc7df" />

### Related issue(s)

Closes #529

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.