### PR TITLE
Add WalletConnect project id and CSP hosts

### DIFF
--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -19,10 +19,27 @@ const allUrls: (string | undefined)[] = [
   import.meta.env.VITE_SENTRY_DSN,
 ];
 
+// Wallet provider endpoints reached by RainbowKit's default connectors. These
+// hosts must be allowed for wallet connection to work.
+const walletDomains = [
+  // Reown (ex-WalletConnect), via the WalletConnect connector
+  "https://api.web3modal.org",
+  "https://*.walletconnect.com",
+  "wss://*.walletconnect.com",
+  "https://*.walletconnect.org",
+  "wss://relay.walletconnect.org",
+  // Coinbase Wallet
+  "https://cca-lite.coinbase.com",
+  "https://chain-proxy.wallet.coinbase.com",
+  "https://keys.coinbase.com",
+  "wss://www.walletlink.org/rpc",
+];
+
 // Build connect-src dynamically from env vars baked in at build time.
 const connectSrc = [
   "'self'",
   ...allUrls.map(getUrlOrigin).filter(Boolean),
+  ...walletDomains,
 ].join(" ");
 
 const workerSrc = import.meta.env.VITE_SENTRY_DSN ? "blob:" : "'none'";
@@ -86,7 +103,8 @@ const csp = [
   "font-src 'self' https://fonts.gstatic.com",
   "form-action 'none'",
   "frame-ancestors 'none'",
-  "img-src 'self' data: https://hemilabs.github.io",
+  "frame-src 'self' https://*.walletconnect.org",
+  "img-src 'self' data: https://hemilabs.github.io https://*.walletconnect.com",
   "script-src 'self'",
   // Tailwind v4 injects styles via a <style> tag, so 'unsafe-inline' is needed.
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",

--- a/web/src/providers/web3Provider.tsx
+++ b/web/src/providers/web3Provider.tsx
@@ -7,8 +7,7 @@ import { allChains } from "../networks";
 export const config = getDefaultConfig({
   appName: "Vetro",
   chains: allChains,
-  // TODO add project id for wallet connect
-  projectId: "YOUR_PROJECT_ID_HERE",
+  projectId: import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID,
   transports: Object.fromEntries(allChains.map((chain) => [chain.id, http()])),
 });
 


### PR DESCRIPTION
### Description

Wires up WalletConnect by reading the project id from the `VITE_WALLET_CONNECT_PROJECT_ID` env var (injected at build time) instead of the `YOUR_PROJECT_ID_HERE` placeholder.

It also widens the worker's Content-Security-Policy so wallet connection actually works — the strict `default-src 'none'` policy was blocking every wallet provider request. Added the endpoints RainbowKit's default WalletConnect and Coinbase connectors reach (Reown relay / web3modal and Coinbase / walletlink hosts) to `connect-src`, the WalletConnect logo host to `img-src`, and the WalletConnect verify iframe origin via a new `frame-src` directive.

Note: `VITE_WALLET_CONNECT_PROJECT_ID` must be set in CI for the build to pick it up.

### Screenshots

N/A — no UI changes.

### Related issue(s)

N/A

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.