### PR TITLE
web: allow inline scripts in dev for Vite preamble

### DIFF
--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -70,6 +70,16 @@ const connectSrc = [
 
 const workerSrc = import.meta.env.VITE_SENTRY_DSN ? "blob:" : "'none'";
 
+// In dev, Vite injects an inline React Fast Refresh preamble script, so
+// 'unsafe-inline' is required for it to run. Production keeps the stricter
+// policy without it.
+const scriptSrc = [
+  "'self'",
+  "https://static.cloudflareinsights.com", // Web Analytics beacon.
+  "https://challenges.cloudflare.com", // Cloudflare bot management / challenge widget.
+  ...(import.meta.env.DEV ? ["'unsafe-inline'"] : []),
+].join(" ");
+
 // Deny all permissions – mirrors api/src/security-headers.ts.
 const permissionsPolicy = [
   "accelerometer",
@@ -133,9 +143,7 @@ const csp = [
   // (bot management / Turnstile) render in iframes.
   `frame-src 'self' ${walletFrameSrc} https://challenges.cloudflare.com`,
   `img-src 'self' data: https://hemilabs.github.io ${walletImgSrc}`,
-  // static.cloudflareinsights.com: Web Analytics beacon.
-  // challenges.cloudflare.com: Cloudflare bot management / challenge widget.
-  "script-src 'self' https://static.cloudflareinsights.com https://challenges.cloudflare.com",
+  `script-src ${scriptSrc}`,
   // Tailwind v4 injects styles via a <style> tag, so 'unsafe-inline' is needed.
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   `worker-src ${workerSrc}`,


### PR DESCRIPTION
### Description

[PR #535](https://github.com/vetro-protocol/vetro-monorepo/pull/535) tightened the worker CSP and dropped `'unsafe-inline'` from `script-src`. In dev, Vite injects an inline React Fast Refresh preamble script, so the stricter policy blocked it and every component threw `@vitejs/plugin-react can't detect preamble`, breaking local dev.

This re-adds `'unsafe-inline'` to `script-src` only when [`import.meta.env.DEV`](https://vite.dev/guide/env-and-mode) is set, so production keeps the strict policy.

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
