### PR TITLE
Add staking vault APY history endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -145,9 +145,26 @@ Returns the APY for each supported staking vault, indexed by staking vault addre
 }
 ```
 
+### `GET /variable-stake/apy-history/:stakingVaultAddress/:period`
+
+Returns the historical APY for a staking vault over the given period — the same forward-looking, continuous-compounding figure as `GET /variable-stake/apy`, recorded over time. The subgraph stores one point per UTC day (the day's **maximum** APR, as the rate fluctuates intraday), which this endpoint converts to APY. A live on-chain point is appended as the last entry so the latest value tracks the current rate rather than the subgraph's daily snapshot, which can lag by up to ~24h; if that read fails, only the subgraph series is returned. The series never has two points on the same UTC day: a live point on a day the subgraph already covers replaces that day's point, or is dropped when the APY is unchanged. Long windows return their full history (`"1y"` is up to ~366 daily points plus the live one).
+Valid periods are: `"1w"`, `"1m"`, `"3m"` and `"1y"`.
+`:stakingVaultAddress` must be a known staking vault. Returns `400` if malformed and `404` if the address is not a known staking vault.
+`apy` is a percentage number (e.g. `9.95` means 9.95%), the same unit as `GET /variable-stake/apy`. `timestamp` is in milliseconds (UTC day-start for subgraph entries, current time for the live point).
+
+#### Sample Response for "1w"
+
+```jsonc
+[
+  { "apy": 9.81, "timestamp": 1707782400000 },
+  { "apy": 9.95, "timestamp": 1707868800000 },
+  // ...more records...
+]
+```
+
 ### `GET /variable-stake/share-value-history/:stakingVaultAddress/:period`
 
-Returns the historical share value for a staking vault over the given period (Earn token vs underlying pegged token, e.g. sVUSD per VUSD). One entry per UTC day from the subgraph, plus a final point read live from the vault's on-chain `convertToAssets` (one whole share) at request time. The subgraph writes its history once per UTC day, so its latest point can lag the actual share value by up to ~24h; the appended live point keeps the last value in sync with the current exchange rate. Results across multiple subgraph pages are concatenated, so long windows return their full history (e.g. `"1y"` may include up to ~366 entries plus the live point). If the live read fails the series is returned without the appended point.
+Returns the historical share value for a staking vault over the given period (Earn token vs underlying pegged token, e.g. sVUSD per VUSD). One entry per UTC day from the subgraph, plus a final point read live from the vault's on-chain `convertToAssets` (one whole share) at request time. The subgraph writes its history once per UTC day, so its latest point can lag the actual share value by up to ~24h; the appended live point keeps the last value in sync with the current exchange rate. When the subgraph already has a point for the current UTC day, the live point is not added as a duplicate: it is skipped if its share value matches that day's point, or it replaces that day's point if the share value differs, so the series never has two points on the same day. Results across multiple subgraph pages are concatenated, so long windows return their full history (e.g. `"1y"` may include up to ~366 entries plus the live point). If the live read fails the series is returned without the appended point.
 Valid periods are: `"1w"`, `"1m"`, `"3m"` and `"1y"`.
 `:stakingVaultAddress` must be a known staking vault. Returns `400` if malformed and `404` if the address is not a known staking vault.
 `shareValue` is a number already pre-scaled by the underlying asset's decimals to a human-readable exchange rate (e.g. `1.000412938421`). `timestamp` is in milliseconds (UTC day-start for subgraph entries, current time for the live point).
@@ -164,7 +181,7 @@ Valid periods are: `"1w"`, `"1m"`, `"3m"` and `"1y"`.
 
 ### `GET /variable-stake/total-deposits-history/:stakingVaultAddress/:period`
 
-Returns the historical total deposits for a staking vault over the given period — the vault's total underlying pegged token holdings (ERC4626 `totalAssets`), i.e. the same value shown as "Pool deposits" on the Earn page. One entry per UTC day from the subgraph, plus a final point read live from the vault's on-chain `totalAssets()` at request time. The subgraph writes its history once per UTC day, so its latest point can lag actual TVL by up to ~24h; the appended live point keeps the last value in sync with current TVL. Results across multiple subgraph pages are concatenated, so long windows return their full history (e.g. `"1y"` may include up to ~366 entries plus the live point). If the live read fails the series is returned without the appended point.
+Returns the historical total deposits for a staking vault over the given period — the vault's total underlying pegged token holdings (ERC4626 `totalAssets`), i.e. the same value shown as "Pool deposits" on the Earn page. One entry per UTC day from the subgraph, plus a final point read live from the vault's on-chain `totalAssets()` at request time. The subgraph writes its history once per UTC day, so its latest point can lag actual TVL by up to ~24h; the appended live point keeps the last value in sync with current TVL. When the subgraph already has a point for the current UTC day, the live point is not added as a duplicate: it is skipped if its total deposits match that day's point, or it replaces that day's point if they differ, so the series never has two points on the same day. Results across multiple subgraph pages are concatenated, so long windows return their full history (e.g. `"1y"` may include up to ~366 entries plus the live point). If the live read fails the series is returned without the appended point.
 Valid periods are: `"1w"`, `"1m"`, `"3m"` and `"1y"`.
 `:stakingVaultAddress` must be a known staking vault. Returns `400` if malformed and `404` if the address is not a known staking vault.
 `totalDeposits` is the raw `uint256` amount in the pegged token's base units (not pre-scaled); format it with the token's decimals on the client. `timestamp` is in milliseconds.

--- a/api/src/append-live-point.ts
+++ b/api/src/append-live-point.ts
@@ -1,0 +1,39 @@
+const DAY_MS = 86_400_000;
+
+const sameUtcDay = (a: number, b: number) =>
+  Math.floor(a / DAY_MS) === Math.floor(b / DAY_MS);
+
+/**
+ * Append a live on-chain reading to a daily subgraph series while keeping at most
+ * one point per UTC day. The subgraph writes a history entry once per UTC day, so
+ * its latest point can lag the current on-chain value by up to ~24h; the live
+ * point keeps the series' last value in sync with the current rate. When the
+ * subgraph already has a point for the current UTC day, the live point is not
+ * added as a duplicate: it is skipped if its value matches that day's point
+ * (keeping the day-aligned subgraph point) or replaces it if the value differs,
+ * so the series never has two points on the same day. With no live point (e.g.
+ * the on-chain read failed) the history is returned unchanged.
+ *
+ * Shared by the apy-history, share-value-history and total-deposits-history
+ * endpoints so they all append their live point identically.
+ */
+export function appendLivePoint<T extends { timestamp: number }>({
+  getValue,
+  history,
+  livePoint,
+}: {
+  getValue: (point: T) => number | string;
+  history: T[];
+  livePoint: T | null;
+}) {
+  if (!livePoint) {
+    return history;
+  }
+  const last = history[history.length - 1];
+  if (last && sameUtcDay(last.timestamp, livePoint.timestamp)) {
+    return getValue(last) === getValue(livePoint)
+      ? history
+      : [...history.slice(0, -1), livePoint];
+  }
+  return [...history, livePoint];
+}

--- a/api/src/apr-wad-to-apy.ts
+++ b/api/src/apr-wad-to-apy.ts
@@ -1,0 +1,12 @@
+const WAD = 10n ** 18n;
+
+/**
+ * Convert a WAD-scaled APR (annualized reward rate) into a continuous-compounding
+ * APY percentage. The vault auto-compounds continuously as yield drips into its
+ * asset balance, so `apy = (e^apr - 1) * 100`. Shared by the live APY endpoint and
+ * the historic APY endpoint so current and stored values use the identical formula.
+ */
+export function aprWadToApy(aprWad: bigint) {
+  const apr = Number(aprWad) / Number(WAD);
+  return Math.expm1(apr) * 100;
+}

--- a/api/src/apy-history.ts
+++ b/api/src/apy-history.ts
@@ -1,0 +1,110 @@
+import { type Address } from "viem";
+
+import { appendLivePoint } from "./append-live-point.ts";
+import { aprWadToApy } from "./apr-wad-to-apy.ts";
+import { createMainnetClient } from "./mainnet-client.ts";
+import { paginateSubgraphQuery } from "./paginate-subgraph-query.ts";
+import { computeVaultApy } from "./variable-stake.ts";
+import { getPeriodStart } from "./vault-history-period.ts";
+
+type Row = { apr: string; timestamp: string };
+
+/**
+ * Read the vault's current APY live from the chain as a synthetic "now" point. The
+ * subgraph only writes a VaultAprHistory entry once per UTC day, so its latest point
+ * can lag the actual APY by up to ~24h; appending a live point keeps the series' last
+ * value in sync with the current rate. Returns null (so the caller falls back to the
+ * subgraph series alone) if the on-chain read fails, keeping the endpoint as available
+ * as a subgraph-only read.
+ */
+async function getLiveApyPoint({
+  rpcUrl,
+  stakingVaultAddress,
+}: {
+  rpcUrl: string | undefined;
+  stakingVaultAddress: Address;
+}) {
+  try {
+    const client = createMainnetClient(rpcUrl);
+    const apy = await computeVaultApy({
+      client,
+      vaultAddress: stakingVaultAddress,
+    });
+    return { apy, timestamp: Date.now() };
+  } catch (error) {
+    console.warn(
+      `Failed to read live APY for ${stakingVaultAddress}: ${error.message}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Query the subgraph for the APY history of a staking vault over the given period.
+ * The subgraph stores the daily-maximum APR (WAD-scaled); each point is converted to
+ * a continuous-compounding APY percentage with the same formula the live endpoint
+ * uses, so historic and current values stay consistent. Paginates over the subgraph's
+ * 100-result page cap so long windows (e.g. "1y", up to ~366 daily entries) are
+ * returned in full. A live on-chain APY read is appended as the final point so the
+ * latest value reflects the current rate rather than the last daily snapshot, unless
+ * the subgraph already has a point for the current UTC day: then the live point is
+ * skipped when the APY matches, or replaces that day's point when it differs, so the
+ * series never has two points on the same day.
+ */
+export async function getApyHistory({
+  period,
+  rpcUrl,
+  stakingVaultAddress,
+  url,
+}: {
+  period: string;
+  rpcUrl: string | undefined;
+  stakingVaultAddress: Address;
+  url: string;
+}): Promise<{ apy: number; timestamp: number }[]> {
+  const stakingVault = stakingVaultAddress.toLowerCase();
+  const start = getPeriodStart(period);
+  const query = `
+    query ($first: Int!, $skip: Int!, $stakingVault: Bytes!, $start: BigInt!) {
+      vaultAprHistories(
+        first: $first
+        orderBy: timestamp
+        orderDirection: asc
+        skip: $skip
+        where: {
+          stakingVaultAddress: $stakingVault
+          timestamp_gte: $start
+        }
+      ) {
+        apr
+        timestamp
+      }
+    }`;
+
+  // The subgraph pagination and the live APY read are independent, so run them
+  // concurrently rather than in sequence.
+  const [all, livePoint] = await Promise.all([
+    paginateSubgraphQuery<Row>({
+      cursor: {
+        getValue: (row) => row.timestamp,
+        variable: "start",
+      },
+      field: "vaultAprHistories",
+      query,
+      url,
+      variables: { stakingVault, start },
+    }),
+    getLiveApyPoint({ rpcUrl, stakingVaultAddress }),
+  ]);
+
+  const history = all.map((h) => ({
+    apy: aprWadToApy(BigInt(h.apr)),
+    timestamp: Number.parseInt(h.timestamp, 10) * 1000,
+  }));
+
+  return appendLivePoint({
+    getValue: (point) => point.apy,
+    history,
+    livePoint,
+  });
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -5,6 +5,7 @@ import { cors } from "hono/cors";
 import type { Address } from "viem";
 
 import * as analytics from "./analytics.ts";
+import { getApyHistory } from "./apy-history.ts";
 import * as borrow from "./borrow.ts";
 import { convertBigIntsToString } from "./convert-bigints-to-string.ts";
 import { getSubgraphUrl } from "./env.ts";
@@ -277,6 +278,32 @@ app.get(
       return c.json(data);
     } catch (error) {
       throw new Error(`Failed to get share value history: ${error.message}`);
+    }
+  },
+);
+
+app.get(
+  "/variable-stake/apy-history/:stakingVaultAddress/:period",
+  validateStakingVaultAddress,
+  validateParam("period", vaultHistoryValidPeriods),
+  cache({
+    cacheControl: "max-age=300",
+    cacheName: "vetro-api",
+  }),
+  async function (c) {
+    try {
+      const stakingVaultAddress = c.get("stakingVaultAddress");
+      const url = getSubgraphUrl(c.env);
+      const period = c.req.param("period");
+      const data = await getApyHistory({
+        period,
+        rpcUrl: c.env.CUSTOM_RPC_URL_MAINNET,
+        stakingVaultAddress,
+        url,
+      });
+      return c.json(data);
+    } catch (error) {
+      throw new Error(`Failed to get APY history: ${error.message}`);
     }
   },
 );

--- a/api/src/share-value-history.ts
+++ b/api/src/share-value-history.ts
@@ -2,6 +2,7 @@ import { type Address, formatUnits } from "viem";
 import { decimals } from "viem-erc20/actions";
 import { asset, convertToAssets } from "viem-erc4626/actions";
 
+import { appendLivePoint } from "./append-live-point.ts";
 import { createMainnetClient } from "./mainnet-client.ts";
 import { paginateSubgraphQuery } from "./paginate-subgraph-query.ts";
 import { getPeriodStart } from "./vault-history-period.ts";
@@ -65,7 +66,8 @@ async function getAssetDecimals({
  * given period. Paginates over the subgraph's 100-result page cap so that long
  * windows (e.g. "1y", up to ~366 daily entries) are returned in full. A live
  * on-chain share value read is appended as the final point so the latest value
- * reflects the current exchange rate rather than the last daily snapshot.
+ * reflects the current exchange rate rather than the last daily snapshot, via
+ * `appendLivePoint` so it never duplicates the current UTC day's subgraph point.
  */
 export async function getShareValueHistory({
   period,
@@ -129,5 +131,9 @@ export async function getShareValueHistory({
           timestamp: Date.now(),
         };
 
-  return livePoint ? [...history, livePoint] : history;
+  return appendLivePoint({
+    getValue: (point) => point.shareValue,
+    history,
+    livePoint,
+  });
 }

--- a/api/src/total-deposits-history.ts
+++ b/api/src/total-deposits-history.ts
@@ -1,6 +1,7 @@
 import { type Address } from "viem";
 import { totalAssets } from "viem-erc4626/actions";
 
+import { appendLivePoint } from "./append-live-point.ts";
 import { createMainnetClient } from "./mainnet-client.ts";
 import { paginateSubgraphQuery } from "./paginate-subgraph-query.ts";
 import { getPeriodStart } from "./vault-history-period.ts";
@@ -42,7 +43,8 @@ async function getLiveTotalDepositsPoint({
  * given period. Paginates over the subgraph's 100-result page cap so that long
  * windows (e.g. "1y", up to ~366 daily entries) are returned in full. A live
  * on-chain totalAssets read is appended as the final point so the latest value
- * reflects current TVL rather than the last daily subgraph snapshot.
+ * reflects current TVL rather than the last daily subgraph snapshot, via
+ * `appendLivePoint` so it never duplicates the current UTC day's subgraph point.
  */
 export async function getTotalDepositsHistory({
   period,
@@ -95,5 +97,9 @@ export async function getTotalDepositsHistory({
     totalDeposits: h.totalAssets,
   }));
 
-  return livePoint ? [...history, livePoint] : history;
+  return appendLivePoint({
+    getValue: (point) => point.totalDeposits,
+    history,
+    livePoint,
+  });
 }

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -9,6 +9,7 @@ import { type Address, checksumAddress, type Hash } from "viem";
 import { mainnet } from "viem/chains";
 import { convertToAssets, totalAssets } from "viem-erc4626/actions";
 
+import { aprWadToApy } from "./apr-wad-to-apy.ts";
 import * as graphql from "./graphql.ts";
 import { createMainnetClient } from "./mainnet-client.ts";
 import * as merkl from "./merkl.ts";
@@ -68,53 +69,59 @@ export async function getCostBasis({
 }
 
 /**
- * Compute a forward-looking APY for each configured staking vault by reading
- * the current `rewardRate` from the vault's `YieldDistributor` contract and
- * annualizing it over the vault's `totalAssets()`. Yield is dripped into the
- * vault's asset balance (raising the ERC4626 share price), so the reward and
- * staked asset are the same token and no price conversion is needed.
- *
- * The vault auto-compounds continuously, so the annualized rate (APR) is turned
- * into a continuous-compounding APY via `e^apr - 1`. Returns a record keyed by
- * checksummed vault address. A vault is included with `{ apy: 0 }` when its
- * reads succeed but no drip is active (period ended, zero rate, or empty vault);
- * a vault whose on-chain reads fail is omitted entirely so the frontend can
- * render "-" for it, distinct from a genuine 0% APY.
+ * Read a single staking vault's current forward-looking APY from chain: read the
+ * `rewardRate` from the vault's `YieldDistributor` and annualize it over the vault's
+ * `totalAssets()`. Yield is dripped into the vault's asset balance (raising the
+ * ERC4626 share price), so the reward and staked asset are the same token and no
+ * price conversion is needed. Returns 0 when the reads succeed but no drip is active
+ * (period ended, zero rate, or empty vault). Throws if any on-chain read fails, so
+ * callers decide how to surface that (omit the vault, or fall back to history).
+ */
+export async function computeVaultApy({
+  client,
+  vaultAddress,
+}: {
+  client: ReturnType<typeof createMainnetClient>;
+  vaultAddress: Address;
+}) {
+  const now = BigInt(Math.floor(Date.now() / 1000));
+  const totalAssetsPromise = totalAssets(client, { address: vaultAddress });
+  const distributorReadsPromise = getYieldDistributor(client, {
+    address: vaultAddress,
+  }).then((distributorAddress) =>
+    Promise.all([
+      getPeriodFinish(client, { address: distributorAddress }),
+      getRewardRate(client, { address: distributorAddress }),
+    ]),
+  );
+  const [[periodFinish, rewardRate], assets] = await Promise.all([
+    distributorReadsPromise,
+    totalAssetsPromise,
+  ]);
+
+  if (periodFinish >= now && rewardRate > 0n && assets > 0n) {
+    // rewardRate is WAD-scaled reward per second. The WAD scale cancels the
+    // rewardRate's own WAD scaling, so aprWad = (rewardRate * SECONDS_PER_YEAR) /
+    // assets.
+    return aprWadToApy((rewardRate * SECONDS_PER_YEAR) / assets);
+  }
+  return 0;
+}
+
+/**
+ * Compute a forward-looking APY for each configured staking vault via
+ * `computeVaultApy`. Returns a record keyed by checksummed vault address. A vault is
+ * included with `{ apy: 0 }` when its reads succeed but no drip is active; a vault
+ * whose on-chain reads fail is omitted entirely so the frontend can render "-" for
+ * it, distinct from a genuine 0% APY.
  */
 export async function getApy({ rpcUrl }: { rpcUrl: string | undefined }) {
   const client = createMainnetClient(rpcUrl);
-  const now = BigInt(Math.floor(Date.now() / 1000));
 
   const entries = await Promise.all(
     stakingVaultAddresses.map(async function (vaultAddress) {
       try {
-        const totalAssetsPromise = totalAssets(client, {
-          address: vaultAddress,
-        });
-        const distributorReadsPromise = getYieldDistributor(client, {
-          address: vaultAddress,
-        }).then((distributorAddress) =>
-          Promise.all([
-            getPeriodFinish(client, { address: distributorAddress }),
-            getRewardRate(client, { address: distributorAddress }),
-          ]),
-        );
-        const [[periodFinish, rewardRate], assets] = await Promise.all([
-          distributorReadsPromise,
-          totalAssetsPromise,
-        ]);
-
-        let apy = 0;
-        if (periodFinish >= now && rewardRate > 0n && assets > 0n) {
-          // rewardRate is WAD-scaled reward per second. Annualize it and
-          // divide by assets, keeping a WAD fixed-point scale.
-          // The WAD scale cancels the rewardRate's own WAD scaling, so
-          // aprWad = apr * WAD = (rewardRate * SECONDS_PER_YEAR) / assets.
-          const aprWad = (rewardRate * SECONDS_PER_YEAR) / assets;
-          const apr = Number(aprWad) / Number(WAD);
-          // continuous compounding
-          apy = Math.expm1(apr) * 100;
-        }
+        const apy = await computeVaultApy({ client, vaultAddress });
         return [vaultAddress, { apy }] as const;
       } catch (error) {
         // Omit this vault from the response so the frontend shows "-" rather

--- a/api/test/append-live-point.test.ts
+++ b/api/test/append-live-point.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { appendLivePoint } from "../src/append-live-point.ts";
+
+// 2024-02-14 and 2024-02-15 00:00 UTC; the live point sits 1h into 2024-02-15,
+// i.e. the same UTC day as the day-aligned 1_707_955_200_000 subgraph point.
+const previousDay = { timestamp: 1_707_868_800_000, value: 1 };
+const currentDayStart = 1_707_955_200_000;
+const livePoint = { timestamp: currentDayStart + 3_600_000, value: 9 };
+
+describe("append-live-point/appendLivePoint", function () {
+  it("returns the history unchanged when there is no live point", function () {
+    const history = [previousDay];
+
+    expect(
+      appendLivePoint({
+        getValue: (point) => point.value,
+        history,
+        livePoint: null,
+      }),
+    ).toBe(history);
+  });
+
+  it("appends the live point when no subgraph point shares its UTC day", function () {
+    expect(
+      appendLivePoint({
+        getValue: (point) => point.value,
+        history: [previousDay],
+        livePoint,
+      }),
+    ).toEqual([previousDay, livePoint]);
+  });
+
+  it("returns only the live point when the history is empty", function () {
+    expect(
+      appendLivePoint({
+        getValue: (point) => point.value,
+        history: [],
+        livePoint,
+      }),
+    ).toEqual([livePoint]);
+  });
+
+  it("keeps the day-aligned subgraph point when its value matches the live point", function () {
+    const history = [
+      previousDay,
+      { timestamp: currentDayStart, value: livePoint.value },
+    ];
+
+    // Same UTC day and equal value: the live point is dropped as a duplicate and
+    // the day-aligned subgraph point is returned untouched.
+    expect(
+      appendLivePoint({ getValue: (point) => point.value, history, livePoint }),
+    ).toBe(history);
+  });
+
+  it("replaces the day-aligned subgraph point when its value differs from the live point", function () {
+    expect(
+      appendLivePoint({
+        getValue: (point) => point.value,
+        history: [previousDay, { timestamp: currentDayStart, value: 2 }],
+        livePoint,
+      }),
+    ).toEqual([previousDay, livePoint]);
+  });
+
+  it("compares string values for endpoints whose points are base-units strings", function () {
+    const history = [{ deposits: "100", timestamp: currentDayStart }];
+
+    // totalDeposits points compare as strings; equal strings drop the live point.
+    expect(
+      appendLivePoint({
+        getValue: (point) => point.deposits,
+        history,
+        livePoint: { deposits: "100", timestamp: livePoint.timestamp },
+      }),
+    ).toBe(history);
+  });
+});

--- a/api/test/apr-wad-to-apy.test.ts
+++ b/api/test/apr-wad-to-apy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { aprWadToApy } from "../src/apr-wad-to-apy.ts";
+
+describe("apr-wad-to-apy/aprWadToApy", function () {
+  it("returns 0 for a zero APR", function () {
+    expect(aprWadToApy(0n)).toBe(0);
+  });
+
+  it("converts a WAD-scaled APR to a continuous-compounding APY percentage", function () {
+    // 0.1 WAD -> (e^0.1 - 1) * 100
+    expect(aprWadToApy(100_000_000_000_000_000n)).toBeCloseTo(10.5170918, 6);
+    // 0.05 WAD -> (e^0.05 - 1) * 100
+    expect(aprWadToApy(50_000_000_000_000_000n)).toBeCloseTo(5.1271096, 6);
+  });
+
+  it("compounds continuously, so the APY exceeds the raw APR", function () {
+    // 1.0 WAD (100% APR) -> (e^1 - 1) * 100 ≈ 171.83%, well above 100%.
+    const apy = aprWadToApy(10n ** 18n);
+    expect(apy).toBeCloseTo(171.8281828, 6);
+    expect(apy).toBeGreaterThan(100);
+  });
+});

--- a/api/test/apy-history.test.ts
+++ b/api/test/apy-history.test.ts
@@ -1,0 +1,190 @@
+import { sVusdAddress } from "@vetro-protocol/earn";
+import {
+  getPeriodFinish,
+  getRewardRate,
+  getYieldDistributor,
+} from "@vetro-protocol/earn/actions";
+import { type Address } from "viem";
+import { totalAssets } from "viem-erc4626/actions";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { aprWadToApy } from "../src/apr-wad-to-apy.ts";
+import { getApyHistory } from "../src/apy-history.ts";
+import * as graphql from "../src/graphql.ts";
+
+vi.mock("../src/graphql.ts", () => ({
+  runQuery: vi.fn(),
+}));
+
+vi.mock("../src/mainnet-client.ts", () => ({
+  createMainnetClient: vi.fn(() => ({})),
+}));
+
+vi.mock("@vetro-protocol/earn/actions", () => ({
+  getPeriodFinish: vi.fn(),
+  getRewardRate: vi.fn(),
+  getYieldDistributor: vi.fn(),
+}));
+
+vi.mock("viem-erc4626/actions", () => ({
+  totalAssets: vi.fn(),
+}));
+
+const url = "https://subgraph.example/v1";
+const rpcUrl = "https://rpc.example";
+const distributor: Address = "0x55745265Ba172378cf45d224F09F0673cB470cef";
+
+// Fixed "now" so the appended live point's timestamp is deterministic.
+const now = 1_708_000_000_000;
+
+// Mainnet sVUSD example from the issue (80 VUSD over a 7-day drip): these reward
+// rate / total assets produce a forward APY of ~9.95%, matching variable-stake's
+// getApy tests. The live point reuses this so its value is a known quantity.
+const activeRewardRate = 132275132275132275132275132275132n;
+const activeTotalAssets = 43983990448825662118175n;
+const activePeriodFinish = BigInt(Math.floor(now / 1000)) + 86_400n;
+const liveApy = 9.95;
+
+const fetchHistory = (period = "1w") =>
+  getApyHistory({
+    period,
+    rpcUrl,
+    stakingVaultAddress: sVusdAddress,
+    url,
+  });
+
+const lastCallVariables = <T>() =>
+  vi.mocked(graphql.runQuery).mock.calls.at(-1)?.[2] as T | undefined;
+
+describe("apy-history/getApyHistory", function () {
+  beforeEach(function () {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    // Default: an active drip, so the live point resolves to ~9.95% APY.
+    vi.mocked(getYieldDistributor).mockResolvedValue(distributor);
+    vi.mocked(getPeriodFinish).mockResolvedValue(activePeriodFinish);
+    vi.mocked(getRewardRate).mockResolvedValue(activeRewardRate);
+    vi.mocked(totalAssets).mockResolvedValue(activeTotalAssets);
+  });
+
+  afterEach(function () {
+    vi.useRealTimers();
+  });
+
+  it("converts apr to apy and timestamp to ms, with a live point appended", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultAprHistories: [
+        { apr: "100000000000000000", timestamp: "1707782400" }, // 0.1 -> ~10.52%
+        { apr: "50000000000000000", timestamp: "1707868800" }, // 0.05 -> ~5.13%
+      ],
+    });
+
+    const result = await fetchHistory();
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({
+      apy: aprWadToApy(100000000000000000n),
+      timestamp: 1_707_782_400_000,
+    });
+    expect(result[1]).toEqual({
+      apy: aprWadToApy(50000000000000000n),
+      timestamp: 1_707_868_800_000,
+    });
+    // Final point is the live on-chain APY at the current time.
+    expect(result[2].timestamp).toBe(now);
+    expect(result[2].apy).toBeCloseTo(liveApy, 1);
+  });
+
+  it("skips the live point when the subgraph already has the current day with the same APY", async function () {
+    // The exact WAD apr the live read produces from the active fixtures; a subgraph
+    // point with this apr on today's UTC day yields an APY equal to the live read.
+    const liveAprWad = (activeRewardRate * 31_536_000n) / activeTotalAssets;
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultAprHistories: [
+        { apr: "100000000000000000", timestamp: "1707782400" },
+        // 2024-02-15: same UTC day as `now`.
+        { apr: liveAprWad.toString(), timestamp: "1707955200" },
+      ],
+    });
+
+    const result = await fetchHistory();
+
+    expect(result).toHaveLength(2);
+    // The day-aligned subgraph point is kept; the live point is not appended.
+    expect(result.at(-1)).toEqual({
+      apy: aprWadToApy(liveAprWad),
+      timestamp: 1_707_955_200_000,
+    });
+    expect(result.some((point) => point.timestamp === now)).toBe(false);
+  });
+
+  it("replaces the current day's subgraph point with the live point when the APY differs", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultAprHistories: [
+        // 2024-02-13: an earlier day, retained as-is.
+        { apr: "100000000000000000", timestamp: "1707782400" },
+        // 2024-02-15: same UTC day as `now`, with an APY unlike the live read.
+        { apr: "50000000000000000", timestamp: "1707955200" },
+      ],
+    });
+
+    const result = await fetchHistory();
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      apy: aprWadToApy(100000000000000000n),
+      timestamp: 1_707_782_400_000,
+    });
+    // The stale same-day subgraph point is dropped in favor of the live reading.
+    expect(result.some((point) => point.timestamp === 1_707_955_200_000)).toBe(
+      false,
+    );
+    expect(result.at(-1)?.timestamp).toBe(now);
+    expect(result.at(-1)?.apy).toBeCloseTo(liveApy, 1);
+  });
+
+  it("returns only the live point when the subgraph returns no entries", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({ vaultAprHistories: [] });
+
+    const result = await fetchHistory();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].timestamp).toBe(now);
+    expect(result[0].apy).toBeCloseTo(liveApy, 1);
+  });
+
+  it("appends a live point of 0 when no drip is active", async function () {
+    // periodFinish in the past -> computeVaultApy returns 0.
+    vi.mocked(getPeriodFinish).mockResolvedValue(
+      BigInt(Math.floor(now / 1000)) - 86_400n,
+    );
+    vi.mocked(graphql.runQuery).mockResolvedValue({ vaultAprHistories: [] });
+
+    expect(await fetchHistory()).toEqual([{ apy: 0, timestamp: now }]);
+  });
+
+  it("falls back to the subgraph series when the live APY read fails", async function () {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultAprHistories: [
+        { apr: "100000000000000000", timestamp: "1707782400" },
+      ],
+    });
+    vi.mocked(getYieldDistributor).mockRejectedValue(new Error("rpc down"));
+
+    expect(await fetchHistory()).toEqual([
+      { apy: aprWadToApy(100000000000000000n), timestamp: 1_707_782_400_000 },
+    ]);
+    warn.mockRestore();
+  });
+
+  it("queries the subgraph with the staking vault address lowercased", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({ vaultAprHistories: [] });
+
+    await fetchHistory();
+
+    expect(lastCallVariables<{ stakingVault: string }>()?.stakingVault).toBe(
+      sVusdAddress.toLowerCase(),
+    );
+  });
+});

--- a/api/test/share-value-history.test.ts
+++ b/api/test/share-value-history.test.ts
@@ -80,6 +80,23 @@ describe("share-value-history/getShareValueHistory", function () {
     ]);
   });
 
+  it("replaces the current UTC day's subgraph point with the live point", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultHistories: [
+        { shareValue: "1000412938421000000", timestamp: "1707782400" },
+        // same UTC day as `now`, with a value unlike the live read
+        { shareValue: "1000500000000000000", timestamp: "1707955200" },
+      ],
+    });
+
+    // The stale same-day point is dropped, so the series never has two points on
+    // the same UTC day.
+    expect(await fetchHistory()).toEqual([
+      { shareValue: 1.000412938421, timestamp: 1_707_782_400_000 },
+      livePoint,
+    ]);
+  });
+
   it("scales by the asset decimals while using the share decimals for one share", async function () {
     const assetDecimals = 6;
     const shareDecimals = 18;

--- a/api/test/total-deposits-history.test.ts
+++ b/api/test/total-deposits-history.test.ts
@@ -64,6 +64,23 @@ describe("total-deposits-history/getTotalDepositsHistory", function () {
     ]);
   });
 
+  it("replaces the current UTC day's subgraph point with the live point", async function () {
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      vaultHistories: [
+        { timestamp: "1707782400", totalAssets: "5000000000000000000000" },
+        // same UTC day as `now`, with a value unlike the live read
+        { timestamp: "1707955200", totalAssets: "5900000000000000000000" },
+      ],
+    });
+
+    // The stale same-day point is dropped, so the series never has two points on
+    // the same UTC day.
+    expect(await fetchHistory()).toEqual([
+      { timestamp: 1_707_782_400_000, totalDeposits: "5000000000000000000000" },
+      livePoint,
+    ]);
+  });
+
   it("falls back to the subgraph series when the live totalAssets read fails", async function () {
     vi.mocked(graphql.runQuery).mockResolvedValue({
       vaultHistories: [


### PR DESCRIPTION
### Description

Adds a new API endpoint that serves the historical APY for a staking vault, so the Vetro Analytics page can render an APY-over-time chart.

- New `GET /variable-stake/apy-history/:stakingVaultAddress/:period`, returning the daily APY series from the subgraph plus a live on-chain point so the latest value reflects the current rate (the subgraph snapshot can lag by up to ~24h).
- Extracts the live-point append into a shared `appendLivePoint` helper that keeps at most one point per UTC day, and applies it to the existing `share-value-history` and `total-deposits-history` endpoints too — they appended unconditionally before and could emit two points on the same day, so all three now dedup consistently.
- Extracts `aprWadToApy` into its own module so the live (`/variable-stake/apy`) and historic APY endpoints share one conversion formula.
- `api/README.md` and tests updated; each new piece has its own test file.

This is the first of two PRs: it delivers the **API** half. A follow-up PR will add the **frontend** (the Analytics APY history chart) in the web app.

### Screenshots

N/A — backend/API change only.

### Related issue(s)

Related to hemilabs/ui-monorepo#1967

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
