### PR TITLE
Add staked amount to earn pool info bar

### DIFF
--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -295,6 +295,7 @@
         "deposit": "Deposit",
         "pool-contract": "Pool contract",
         "pool-deposits": "Pool deposits",
+        "staked-amount": "Your staked amount",
         "withdraw": "Withdraw"
       },
       "stake": {

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -298,6 +298,7 @@
         "deposit": "Depositar",
         "pool-contract": "Contrato del fondo",
         "pool-deposits": "Depósitos del fondo",
+        "staked-amount": "Su monto stakeado",
         "withdraw": "Retirar"
       },
       "stake": {

--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -13,6 +13,7 @@ import type { Address } from "viem";
 
 import { PoolInfoButtons } from "./poolInfoButtons";
 import { PoolInfoItem } from "./poolInfoItem";
+import { PoolInfoStakedAmount } from "./poolInfoStakedAmount";
 
 type Props = {
   stakingVaultAddress: Address;
@@ -92,6 +93,7 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
             </span>
           </div>
         </PoolInfoItem>
+        <PoolInfoStakedAmount stakingVaultAddress={stakingVaultAddress} />
       </div>
       <PoolInfoButtons stakingVaultAddress={stakingVaultAddress} />
     </div>

--- a/web/src/pages/earn/components/poolInfoBar/poolInfoStakedAmount.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/poolInfoStakedAmount.tsx
@@ -1,0 +1,39 @@
+import { RenderFiatValue } from "components/base/fiatValue";
+import { useStakedBalance } from "hooks/useStakedBalance";
+import { useVaultPeggedToken } from "hooks/useVaultPeggedToken";
+import { useTranslation } from "react-i18next";
+import type { Address } from "viem";
+import { useAccount } from "wagmi";
+
+import { PoolInfoItem } from "./poolInfoItem";
+
+type Props = {
+  stakingVaultAddress: Address;
+};
+
+export function PoolInfoStakedAmount({ stakingVaultAddress }: Props) {
+  const { t } = useTranslation();
+  const { address: account } = useAccount();
+  const { data: peggedToken } = useVaultPeggedToken(stakingVaultAddress);
+  const { data: stakedBalance, status: stakedStatus } =
+    useStakedBalance(stakingVaultAddress);
+
+  return (
+    <PoolInfoItem label={t("pages.earn.pool-info.staked-amount")}>
+      <span className="text-xsm flex items-center gap-x-1 font-semibold text-gray-900">
+        {account ? (
+          <>
+            $
+            <RenderFiatValue
+              queryStatus={stakedStatus}
+              token={peggedToken}
+              value={stakedBalance}
+            />
+          </>
+        ) : (
+          "-"
+        )}
+      </span>
+    </PoolInfoItem>
+  );
+}


### PR DESCRIPTION
### Description

Each Earn pool info bar now shows the connected user's staked position in USD, placed between the APY and the Deposit/Withdraw action buttons, so users can see what they have staked in a given vault directly from the pool list.

The value is rendered with full precision (e.g. `$1,000.00`) via the shared `RenderFiatValue` component, matching how per-vault staked balances are shown elsewhere on the Earn page. It's implemented as a self-contained `PoolInfoStakedAmount` component that fetches its own data, keeping `PoolInfoBar` simple. A disconnected wallet shows `-`; a connected wallet with no stake in a vault shows `$0.00`. Added the `pages.earn.pool-info.staked-amount` translation key in both `en` and `es`.

### Screenshots

<img width="1319" height="456" alt="image" src="https://github.com/user-attachments/assets/01c8d814-22e4-4ca3-9bc4-d36fa520b352" />

Staked amount column added

### Related issue(s)

Closes #541

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
