### PR TITLE
Make analytics token filter sticky on scroll

### DIFF
--- a/web/src/pages/analytics/components/allocationCard/allocationChart.tsx
+++ b/web/src/pages/analytics/components/allocationCard/allocationChart.tsx
@@ -20,7 +20,7 @@ export const AllocationChart = ({
   items,
   onHover,
 }: Props) => (
-  <div className="h-16 overflow-clip border-y border-gray-200 bg-gray-200/24">
+  <div className="h-16 overflow-clip border-y border-gray-200 bg-gray-200/25">
     <div className="mx-6 flex h-full gap-1 border-x border-gray-200 bg-white p-1 md:mx-14">
       {!isLoading &&
         !isError &&

--- a/web/src/pages/analytics/index.tsx
+++ b/web/src/pages/analytics/index.tsx
@@ -71,12 +71,16 @@ export const Analytics = function () {
     (token) => token.gatewayAddress === selectedGatewayAddress,
   );
 
+  // only show the filter if there are 2 or more tokens to filter from
+  const showTokenFilter = gatewayAddresses.length > 1 && !isPeggedTokensError;
+
   return (
     <div className="flex flex-col">
-      <PageTitle value={t("pages.analytics.title")} />
-      {/* only show the filter if there are 2 or more tokens to filter from */}
-      {gatewayAddresses.length > 1 && !isPeggedTokensError && (
-        <div className="border-y border-gray-200 bg-white px-3 py-4 md:px-6">
+      <div className={showTokenFilter ? "border-b border-gray-200" : undefined}>
+        <PageTitle value={t("pages.analytics.title")} />
+      </div>
+      {showTokenFilter && (
+        <div className="sticky top-0 z-10 border-b border-gray-200 bg-white px-3 py-4 md:px-6">
           <div className="mx-auto w-fit">
             {tokens && selectedToken ? (
               <TokenFilter


### PR DESCRIPTION
### Description

On the Analytics page, the VUSD/vetBTC token segmented control now pins directly below the app header once the user scrolls past it, so the selected token stays visible while scrolling through the metric cards. Before that point it scrolls normally.

Also bumps the allocation chart background opacity from 24% to 25%.

### Screenshots

https://github.com/user-attachments/assets/fb3c3213-12e9-4692-8bb2-128041c8f29a

### Related issue(s)

Closes #511

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
