### PR TITLE
Add token distribution stats to DEX page

### DIFF
--- a/internal-dashboard/package.json
+++ b/internal-dashboard/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@tanstack/react-query": "5.90.19",
-    "@total-typescript/ts-reset": "0.6.1",
     "@vetro-protocol/earn": "workspace:*",
     "@vetro-protocol/gateway": "workspace:*",
     "crypto-shortener": "1.2.0",
@@ -28,6 +27,7 @@
     "@cloudflare/vite-plugin": "1.23.1",
     "@cloudflare/workers-types": "4.20260504.1",
     "@tailwindcss/vite": "4.3.0",
+    "@total-typescript/ts-reset": "0.6.1",
     "@tsconfig/vite-react": "7.0.2",
     "@types/node": "24.1.0",
     "@types/react": "19.2.9",

--- a/internal-dashboard/package.json
+++ b/internal-dashboard/package.json
@@ -6,10 +6,12 @@
     "dev": "vite",
     "prepreview": "pnpm run build",
     "preview": "vite preview",
+    "test": "vitest run",
     "tsc": "tsc"
   },
   "dependencies": {
     "@tanstack/react-query": "5.90.19",
+    "@total-typescript/ts-reset": "0.6.1",
     "@vetro-protocol/earn": "workspace:*",
     "@vetro-protocol/gateway": "workspace:*",
     "crypto-shortener": "1.2.0",
@@ -34,6 +36,7 @@
     "tailwindcss": "4.3.0",
     "typescript": "5.9.3",
     "vite": "8.0.13",
+    "vitest": "4.1.9",
     "wrangler": "4.63.0"
   },
   "private": true,

--- a/internal-dashboard/reset.d.ts
+++ b/internal-dashboard/reset.d.ts
@@ -1,0 +1,2 @@
+import "@total-typescript/ts-reset/array-includes";
+import "@total-typescript/ts-reset/filter-boolean";

--- a/internal-dashboard/src/components/dex/tokenDistribution.tsx
+++ b/internal-dashboard/src/components/dex/tokenDistribution.tsx
@@ -1,0 +1,156 @@
+import { VictoryPie, VictoryTooltip } from "victory";
+import { formatUnits } from "viem";
+
+import { useTokenPrices } from "../../hooks/useTokenPrices";
+import { useTrackedTokens } from "../../hooks/useTrackedTokens";
+import {
+  computeDistributions,
+  type TokenDistribution as TokenDistributionData,
+} from "../../lib/distribution";
+import { formatPercent, formatTokenAmount, formatUsd } from "../../lib/format";
+import { type TrackedPool } from "../../lib/types";
+
+import { TokenIcon } from "./tokenIcon";
+
+type Props = {
+  pools: TrackedPool[];
+};
+
+// Slice colors, reused by the pie and its legend.
+const COLORS = [
+  "#2563eb",
+  "#16a34a",
+  "#f59e0b",
+  "#db2777",
+  "#7c3aed",
+  "#0891b2",
+  "#dc2626",
+  "#65a30d",
+  "#c026d3",
+  "#0d9488",
+  "#ea580c",
+  "#4f46e5",
+];
+
+const DistributionCard = function ({
+  distribution,
+  price,
+}: {
+  distribution: TokenDistributionData;
+  price: number | undefined;
+}) {
+  const { slices, token } = distribution;
+  const totalBalance = Number(
+    formatUnits(distribution.totalBalance, token.decimals),
+  );
+  const totalUsd = price !== undefined ? totalBalance * price : undefined;
+
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-white p-4">
+      <div className="flex items-center gap-x-2">
+        <TokenIcon address={token.address} symbol={token.symbol} />
+        <h4 className="font-semibold text-neutral-950">{token.symbol}</h4>
+      </div>
+
+      {slices.length > 1 ? (
+        <div className="mx-auto w-full max-w-55">
+          <VictoryPie
+            colorScale={COLORS}
+            data={slices.map(function (slice) {
+              const balance = Number(
+                formatUnits(slice.balance, token.decimals),
+              );
+              return {
+                balance,
+                usd: price !== undefined ? balance * price : undefined,
+                x: slice.pool.name,
+                y: slice.share * 100,
+              };
+            })}
+            height={220}
+            innerRadius={55}
+            labelComponent={
+              <VictoryTooltip
+                cornerRadius={6}
+                flyoutStyle={{ fill: "#ffffff", stroke: "#e5e5e5" }}
+                style={{ fontSize: 11 }}
+              />
+            }
+            labels={({ datum }) =>
+              [
+                datum.x,
+                `${formatTokenAmount(datum.balance)} ${token.symbol}`,
+                datum.usd !== undefined ? formatUsd(datum.usd) : undefined,
+              ]
+                .filter(Boolean)
+                .join("\n")
+            }
+            padding={20}
+            width={220}
+          />
+        </div>
+      ) : (
+        <p className="mt-3 text-sm text-neutral-600">100% in a single pool.</p>
+      )}
+
+      <ul className="mt-3 space-y-1 text-xs">
+        {slices.map((slice, index) => (
+          <li
+            className="flex items-center justify-between gap-x-2"
+            key={slice.pool.address}
+          >
+            <span className="flex min-w-0 items-center gap-x-2">
+              <span
+                className="size-2 shrink-0 rounded-full"
+                style={{ backgroundColor: COLORS[index % COLORS.length] }}
+              />
+              <span className="truncate text-neutral-700">
+                {slice.pool.name}
+              </span>
+            </span>
+            <span className="shrink-0 font-medium text-neutral-950">
+              {formatPercent(slice.share * 100)}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <p className="mt-3 border-t border-neutral-100 pt-2 text-xs text-neutral-500">
+        Total tracked:{" "}
+        <span className="font-medium text-neutral-700">
+          {formatTokenAmount(totalBalance)} {token.symbol}
+          {totalUsd !== undefined ? ` (${formatUsd(totalUsd)})` : ""}
+        </span>
+      </p>
+    </div>
+  );
+};
+
+export const TokenDistribution = function ({ pools }: Props) {
+  const { data: tokens } = useTrackedTokens();
+  const { data: prices } = useTokenPrices();
+
+  if (!tokens) {
+    return null;
+  }
+
+  const distributions = computeDistributions({ pools, tokens }).filter(
+    (distribution) => distribution.slices.length > 0,
+  );
+
+  if (distributions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {distributions.map((distribution) => (
+        <DistributionCard
+          distribution={distribution}
+          key={distribution.token.address}
+          price={prices?.[distribution.token.address.toLowerCase()]}
+        />
+      ))}
+    </div>
+  );
+};

--- a/internal-dashboard/src/fetchers/fetchTokenPrices.ts
+++ b/internal-dashboard/src/fetchers/fetchTokenPrices.ts
@@ -70,11 +70,17 @@ export const fetchTokenPrices = async function ({
     queryClient.ensureQueryData(trackedTokensOptions()),
   ]);
 
+  // Price each token independently: a single vault whose on-chain call reverts
+  // shouldn't wipe out every other token's price on this internal dashboard.
   const entries = await Promise.all(
     tokens.map(async function (token) {
-      const usd = await tokenUsdPrice({ portal, queryClient, token });
-      return [token.address.toLowerCase(), usd] as const;
+      try {
+        const usd = await tokenUsdPrice({ portal, queryClient, token });
+        return [token.address.toLowerCase(), usd] as const;
+      } catch {
+        return undefined;
+      }
     }),
   );
-  return Object.fromEntries(entries);
+  return Object.fromEntries(entries.filter(Boolean));
 };

--- a/internal-dashboard/src/fetchers/fetchTokenPrices.ts
+++ b/internal-dashboard/src/fetchers/fetchTokenPrices.ts
@@ -1,0 +1,80 @@
+import { type QueryClient } from "@tanstack/react-query";
+import fetch from "fetch-plus-plus";
+import { asset, convertToAssets } from "viem-erc4626/actions";
+
+import { tokenInfoOptions } from "../hooks/useTokenInfo";
+import { trackedTokensOptions } from "../hooks/useTrackedTokens";
+import { client } from "../lib/client";
+import { type TrackedToken } from "../lib/types";
+
+// Overridable per environment (see .env / .env.local), like web's VITE_PORTAL_API_URL.
+const PORTAL_API_BASE = import.meta.env.VITE_PORTAL_API_URL;
+
+type PortalPrices = Record<string, string>;
+
+const fetchPortalPrices = () =>
+  fetch(`${PORTAL_API_BASE}/prices`).then(
+    (body) => (body as { prices: PortalPrices }).prices,
+  );
+
+// USD per peg unit, mirroring web's pegToUsdRate: "USD" is identity ($1), otherwise
+// the portal spot price for the price symbol.
+const pegToUsd = ({
+  portal,
+  priceSymbol,
+}: {
+  portal: PortalPrices;
+  priceSymbol: string;
+}) => (priceSymbol === "USD" ? 1 : Number(portal[priceSymbol] ?? 0));
+
+const tokenUsdPrice = async function ({
+  portal,
+  queryClient,
+  token,
+}: {
+  portal: PortalPrices;
+  queryClient: QueryClient;
+  token: TrackedToken;
+}) {
+  const baseUsd = pegToUsd({
+    portal,
+    priceSymbol: token.extensions?.priceSymbol ?? token.symbol,
+  });
+  if (!token.extensions?.isVaultShare) {
+    return baseUsd;
+  }
+  // Share token: convert one whole share to underlying assets on-chain, then
+  // price. The underlying's decimals are read on demand (cached) rather than
+  // stored on the token.
+  const assetAddress = await asset(client, { address: token.address });
+  const { decimals: assetDecimals } = await queryClient.ensureQueryData(
+    tokenInfoOptions(assetAddress),
+  );
+  const assetsRaw = await convertToAssets(client, {
+    address: token.address,
+    shares: 10n ** BigInt(token.decimals),
+  });
+  const assetsPerShare = Number(assetsRaw) / 10 ** assetDecimals;
+  return baseUsd * assetsPerShare;
+};
+
+// USD price per whole token, keyed by lowercased address — consumed by the Stats
+// token-distribution. Reads portal spot prices + on-chain share values in-browser.
+export const fetchTokenPrices = async function ({
+  queryClient,
+}: {
+  queryClient: QueryClient;
+}): Promise<Record<string, number>> {
+  const [portal, tokens] = await Promise.all([
+    fetchPortalPrices(),
+    queryClient.ensureQueryData(trackedTokensOptions()),
+  ]);
+
+  const entries = await Promise.all(
+    tokens.map(async function (token) {
+      const usd = await tokenUsdPrice({ portal, queryClient, token });
+      return [token.address.toLowerCase(), usd] as const;
+    }),
+  );
+  return Object.fromEntries(entries);
+};

--- a/internal-dashboard/src/hooks/useTokenPrices.ts
+++ b/internal-dashboard/src/hooks/useTokenPrices.ts
@@ -1,0 +1,12 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+
+import { fetchTokenPrices } from "../fetchers/fetchTokenPrices";
+
+export const tokenPricesOptions = () =>
+  queryOptions({
+    queryFn: ({ client: queryClient }) => fetchTokenPrices({ queryClient }),
+    queryKey: ["token-prices"],
+    staleTime: 60 * 1000,
+  });
+
+export const useTokenPrices = () => useQuery(tokenPricesOptions());

--- a/internal-dashboard/src/lib/distribution.ts
+++ b/internal-dashboard/src/lib/distribution.ts
@@ -2,6 +2,10 @@ import { isAddressEqual } from "viem";
 
 import { type TrackedPool, type TrackedToken } from "./types";
 
+// Fixed-point scale for the bigint share ratio: 6 decimals of share precision,
+// well beyond the 2 decimals of percentage the UI renders.
+const SHARE_SCALE = 1_000_000n;
+
 export type DistributionSlice = {
   balance: bigint; // raw on-chain units
   pool: TrackedPool;
@@ -39,12 +43,17 @@ export const computeDistributions = ({
       0n,
     );
 
-    // Same token across pools shares decimals, so the raw-unit ratio is the share.
+    // Same token across pools shares decimals, so the raw-unit ratio is the
+    // share. The ratio is computed in fixed-point bigint to stay exact for raw
+    // balances above 2^53, then converted to a number only for display.
     const slices = entries
       .map((entry) => ({
         ...entry,
         share:
-          totalBalance > 0n ? Number(entry.balance) / Number(totalBalance) : 0,
+          totalBalance > 0n
+            ? Number((entry.balance * SHARE_SCALE) / totalBalance) /
+              Number(SHARE_SCALE)
+            : 0,
       }))
       .sort((a, b) =>
         a.balance < b.balance ? 1 : a.balance > b.balance ? -1 : 0,

--- a/internal-dashboard/src/lib/distribution.ts
+++ b/internal-dashboard/src/lib/distribution.ts
@@ -1,0 +1,54 @@
+import { isAddressEqual } from "viem";
+
+import { type TrackedPool, type TrackedToken } from "./types";
+
+export type DistributionSlice = {
+  balance: bigint; // raw on-chain units
+  pool: TrackedPool;
+  share: number; // 0..1 of the token's total tracked liquidity
+};
+
+export type TokenDistribution = {
+  slices: DistributionSlice[];
+  token: TrackedToken;
+  totalBalance: bigint; // raw on-chain units
+};
+
+// For each token, how its tracked-pool liquidity is split across the pools that
+// hold it. Tokens that appear in a single pool produce a one-slice
+// distribution, which the UI renders as a plain stat rather than a chart.
+export const computeDistributions = ({
+  pools,
+  tokens,
+}: {
+  pools: TrackedPool[];
+  tokens: TrackedToken[];
+}): TokenDistribution[] =>
+  tokens.map(function (token) {
+    const entries = pools
+      .map(function (pool) {
+        const coin = pool.coins.find((candidate) =>
+          isAddressEqual(candidate.address, token.address),
+        );
+        return coin ? { balance: coin.balance, pool } : undefined;
+      })
+      .filter(Boolean);
+
+    const totalBalance = entries.reduce(
+      (sum, entry) => sum + entry.balance,
+      0n,
+    );
+
+    // Same token across pools shares decimals, so the raw-unit ratio is the share.
+    const slices = entries
+      .map((entry) => ({
+        ...entry,
+        share:
+          totalBalance > 0n ? Number(entry.balance) / Number(totalBalance) : 0,
+      }))
+      .sort((a, b) =>
+        a.balance < b.balance ? 1 : a.balance > b.balance ? -1 : 0,
+      );
+
+    return { slices, token, totalBalance };
+  });

--- a/internal-dashboard/src/pages/dex.tsx
+++ b/internal-dashboard/src/pages/dex.tsx
@@ -1,5 +1,6 @@
 import { PoolsTable } from "../components/dex/poolsTable";
 import { StateMessage } from "../components/dex/stateMessage";
+import { TokenDistribution } from "../components/dex/tokenDistribution";
 import { useTrackedPools } from "../hooks/useTrackedPools";
 
 export const DexPage = function () {
@@ -32,6 +33,19 @@ export const DexPage = function () {
               </h3>
               <PoolsTable
                 pools={[...pools].sort((a, b) => b.tvlUsd - a.tvlUsd)}
+              />
+            </div>
+            <div>
+              <h3 className="mb-1 text-lg font-semibold text-neutral-950">
+                Stats
+              </h3>
+              <p className="mb-4 text-sm text-neutral-600">
+                Share of each token&apos;s tracked liquidity by pool.
+              </p>
+              <TokenDistribution
+                // Exclude concentrated range views so a pool's liquidity isn't
+                // counted twice (the full entry already covers it).
+                pools={pools.filter((pool) => !pool.isRangeView)}
               />
             </div>
           </>

--- a/internal-dashboard/test/distribution.test.ts
+++ b/internal-dashboard/test/distribution.test.ts
@@ -1,0 +1,225 @@
+import { type Address, getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+
+import { computeDistributions } from "../src/lib/distribution.ts";
+import {
+  type PoolCoin,
+  type TrackedPool,
+  type TrackedToken,
+} from "../src/lib/types.ts";
+
+const tokenA: Address = "0x1111111111111111111111111111111111111111";
+const tokenB: Address = "0x2222222222222222222222222222222222222222";
+const tokenC: Address = "0x3333333333333333333333333333333333333333";
+
+const makeToken = ({
+  address,
+  symbol,
+}: {
+  address: Address;
+  symbol: string;
+}): TrackedToken => ({ address, decimals: 18, symbol });
+
+const makeCoin = ({
+  address,
+  balance,
+}: {
+  address: Address;
+  balance: bigint;
+}): PoolCoin => ({ address, balance, decimals: 18, symbol: "X", usdPrice: 1 });
+
+const makePool = ({
+  address,
+  coins,
+}: {
+  address: Address;
+  coins: PoolCoin[];
+}): TrackedPool => ({
+  address,
+  baseApy: 0,
+  coins,
+  dex: "curve",
+  gaugeAddress: undefined,
+  id: address,
+  lpTokenAddress: undefined,
+  name: `pool-${address}`,
+  poolType: "stableswap",
+  rewardApy: 0,
+  rewardApyMax: 0,
+  tvlUsd: 0,
+  url: "https://example.com",
+  virtualPrice: 1,
+  volumeUsd24h: 0,
+});
+
+const poolOne: Address = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const poolTwo: Address = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const poolThree: Address = "0xcccccccccccccccccccccccccccccccccccccccc";
+
+describe("distribution/computeDistributions", function () {
+  it("returns one distribution per token, preserving token order", function () {
+    const tokens = [
+      makeToken({ address: tokenA, symbol: "A" }),
+      makeToken({ address: tokenB, symbol: "B" }),
+    ];
+    const result = computeDistributions({ pools: [], tokens });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].token.symbol).toBe("A");
+    expect(result[1].token.symbol).toBe("B");
+  });
+
+  it("produces an empty distribution for a token held by no pool", function () {
+    const pools = [
+      makePool({
+        address: poolOne,
+        coins: [makeCoin({ address: tokenB, balance: 100n })],
+      }),
+    ];
+    const [distribution] = computeDistributions({
+      pools,
+      tokens: [makeToken({ address: tokenA, symbol: "A" })],
+    });
+
+    expect(distribution.slices).toEqual([]);
+    expect(distribution.totalBalance).toBe(0n);
+  });
+
+  it("produces a single full-share slice when only one pool holds the token", function () {
+    const pools = [
+      makePool({
+        address: poolOne,
+        coins: [makeCoin({ address: tokenA, balance: 500n })],
+      }),
+    ];
+    const [distribution] = computeDistributions({
+      pools,
+      tokens: [makeToken({ address: tokenA, symbol: "A" })],
+    });
+
+    expect(distribution.totalBalance).toBe(500n);
+    expect(distribution.slices).toHaveLength(1);
+    expect(distribution.slices[0].balance).toBe(500n);
+    expect(distribution.slices[0].share).toBe(1);
+  });
+
+  it("splits liquidity across pools as shares that sum to 1", function () {
+    const pools = [
+      makePool({
+        address: poolOne,
+        coins: [makeCoin({ address: tokenA, balance: 30n })],
+      }),
+      makePool({
+        address: poolTwo,
+        coins: [makeCoin({ address: tokenA, balance: 70n })],
+      }),
+    ];
+    const [distribution] = computeDistributions({
+      pools,
+      tokens: [makeToken({ address: tokenA, symbol: "A" })],
+    });
+
+    expect(distribution.totalBalance).toBe(100n);
+    expect(distribution.slices).toHaveLength(2);
+    expect(distribution.slices.map((slice) => slice.share)).toEqual([0.7, 0.3]);
+    const shareSum = distribution.slices.reduce(
+      (sum, slice) => sum + slice.share,
+      0,
+    );
+    expect(shareSum).toBeCloseTo(1, 12);
+  });
+
+  it("sorts slices by balance, largest first", function () {
+    const pools = [
+      makePool({
+        address: poolOne,
+        coins: [makeCoin({ address: tokenA, balance: 10n })],
+      }),
+      makePool({
+        address: poolTwo,
+        coins: [makeCoin({ address: tokenA, balance: 90n })],
+      }),
+      makePool({
+        address: poolThree,
+        coins: [makeCoin({ address: tokenA, balance: 50n })],
+      }),
+    ];
+    const [distribution] = computeDistributions({
+      pools,
+      tokens: [makeToken({ address: tokenA, symbol: "A" })],
+    });
+
+    expect(distribution.slices.map((slice) => slice.balance)).toEqual([
+      90n,
+      50n,
+      10n,
+    ]);
+    expect(distribution.slices.map((slice) => slice.pool.address)).toEqual([
+      poolTwo,
+      poolThree,
+      poolOne,
+    ]);
+  });
+
+  it("matches token and coin addresses case-insensitively", function () {
+    const pools = [
+      makePool({
+        address: poolOne,
+        // Coin recorded in checksummed form; token tracked in lowercase.
+        coins: [makeCoin({ address: getAddress(tokenA), balance: 42n })],
+      }),
+    ];
+    const [distribution] = computeDistributions({
+      pools,
+      tokens: [makeToken({ address: tokenA, symbol: "A" })],
+    });
+
+    expect(distribution.slices).toHaveLength(1);
+    expect(distribution.slices[0].balance).toBe(42n);
+  });
+
+  it("assigns a zero share to every slice when total balance is zero", function () {
+    const pools = [
+      makePool({
+        address: poolOne,
+        coins: [makeCoin({ address: tokenA, balance: 0n })],
+      }),
+      makePool({
+        address: poolTwo,
+        coins: [makeCoin({ address: tokenA, balance: 0n })],
+      }),
+    ];
+    const [distribution] = computeDistributions({
+      pools,
+      tokens: [makeToken({ address: tokenA, symbol: "A" })],
+    });
+
+    expect(distribution.totalBalance).toBe(0n);
+    expect(distribution.slices).toHaveLength(2);
+    expect(distribution.slices.every((slice) => slice.share === 0)).toBe(true);
+  });
+
+  it("considers only the pools that hold the given token", function () {
+    const pools = [
+      makePool({
+        address: poolOne,
+        coins: [
+          makeCoin({ address: tokenA, balance: 100n }),
+          makeCoin({ address: tokenB, balance: 200n }),
+        ],
+      }),
+      makePool({
+        address: poolTwo,
+        coins: [makeCoin({ address: tokenC, balance: 999n })],
+      }),
+    ];
+    const [distribution] = computeDistributions({
+      pools,
+      tokens: [makeToken({ address: tokenA, symbol: "A" })],
+    });
+
+    expect(distribution.totalBalance).toBe(100n);
+    expect(distribution.slices).toHaveLength(1);
+    expect(distribution.slices[0].pool.address).toBe(poolOne);
+  });
+});

--- a/internal-dashboard/tsconfig.json
+++ b/internal-dashboard/tsconfig.json
@@ -5,6 +5,6 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["src", "reset.d.ts"],
+  "include": ["reset.d.ts", "src", "test"],
   "exclude": ["node_modules", "dist"]
 }

--- a/internal-dashboard/tsconfig.json
+++ b/internal-dashboard/tsconfig.json
@@ -5,6 +5,6 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["src"],
+  "include": ["src", "reset.d.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/internal-dashboard/vitest.config.ts
+++ b/internal-dashboard/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    tsconfigPaths: true,
+  },
+  test: {
+    clearMocks: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.90.19
         version: 5.90.19(react@19.2.3)
+      '@total-typescript/ts-reset':
+        specifier: 0.6.1
+        version: 0.6.1
       '@vetro-protocol/earn':
         specifier: workspace:*
         version: link:../packages/earn
@@ -175,6 +178,9 @@ importers:
       vite:
         specifier: 8.0.13
         version: 8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4)
+      vitest:
+        specifier: 4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
       wrangler:
         specifier: 4.63.0
         version: 4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -6901,10 +6907,6 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==, tarball: https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==, tarball: https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==, tarball: https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz}
     engines: {node: '>=12'}
@@ -7821,10 +7823,6 @@ packages:
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==, tarball: https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==, tarball: https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==, tarball: https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz}
@@ -9214,7 +9212,7 @@ snapshots:
       '@commitlint/types': 20.5.0
       git-raw-commits: 5.0.1(conventional-commits-parser@6.4.0)
       minimist: 1.2.8
-      tinyexec: 1.0.2
+      tinyexec: 1.1.2
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
@@ -10310,7 +10308,7 @@ snapshots:
       semver: 7.7.3
       string-width: 4.2.3
       supports-color: 8.1.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
@@ -12202,7 +12200,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
 
   '@vitest/eslint-plugin@1.6.6(eslint@8.57.0)(typescript@6.0.2)(vitest@4.1.9)':
     dependencies:
@@ -14303,14 +14301,13 @@ snapshots:
       esquery: 1.7.0
       jsonc-eslint-parser: 2.4.2
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.53.1(eslint@8.57.0)(typescript@6.0.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14331,7 +14328,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14680,10 +14677,6 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -16392,8 +16385,6 @@ snapshots:
 
   picomatch@2.3.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pify@2.3.0: {}
@@ -17091,7 +17082,7 @@ snapshots:
       detect-newline: 4.0.1
       git-hooks-list: 4.2.1
       is-plain-obj: 4.1.0
-      semver: 7.7.3
+      semver: 7.8.1
       sort-object-keys: 2.1.0
       tinyglobby: 0.2.16
 
@@ -17357,11 +17348,6 @@ snapshots:
   tinyexec@1.0.2: {}
 
   tinyexec@1.1.2: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
 
   tinyglobby@0.2.16:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,9 +108,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.90.19
         version: 5.90.19(react@19.2.3)
-      '@total-typescript/ts-reset':
-        specifier: 0.6.1
-        version: 0.6.1
       '@vetro-protocol/earn':
         specifier: workspace:*
         version: link:../packages/earn
@@ -154,6 +151,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 4.3.0
         version: 4.3.0(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+      '@total-typescript/ts-reset':
+        specifier: 0.6.1
+        version: 0.6.1
       '@tsconfig/vite-react':
         specifier: 7.0.2
         version: 7.0.2


### PR DESCRIPTION
### Description

Adds a "Stats" section to the internal dashboard's DEX page showing how each tracked token's liquidity is split across the pools that hold it. Each token renders as a pie chart with per-pool shares and USD totals, or as a plain stat when a single pool holds it.

- `lib/distribution.ts` computes per-token pool shares from raw on-chain balances (matching addresses case-insensitively, sorted largest-first).
- `fetchTokenPrices` / `useTokenPrices` derive USD prices from portal spot prices and, for ERC-4626 share tokens, on-chain share values.
- Concentrated range views are excluded so banded liquidity isn't double-counted.
- Sets up vitest for `internal-dashboard` (using vite's native tsconfig-paths resolution, no plugin) and covers the distribution math with tests.

### Screenshots

<img width="2988" height="1404" alt="image" src="https://github.com/user-attachments/assets/f2768669-13d2-4601-95cd-53ef5a866985" />


A chart showing how VUSD, VetBTC, and other tokens are distributed in % per different pools. Note that no chart is rendered if everything is in just one pool

It should update automatically as new pools are added

### Related issue(s)

Related to #474

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.