### PR TITLE
Guard parseTokenUnits against undefined amount

### DIFF
--- a/web/src/components/swapForm/redeemQueue.tsx
+++ b/web/src/components/swapForm/redeemQueue.tsx
@@ -71,9 +71,7 @@ function ActiveRedeemDrawer({
   const [flowStatus, setFlowStatus] = useState<ClaimRedeemFlowStatus>("idle");
   const [fromInputValue, setFromInputValue] = useState("0");
 
-  const amountBigInt = fromInputValue
-    ? parseTokenUnits(fromInputValue, peggedToken)
-    : 0n;
+  const amountBigInt = parseTokenUnits(fromInputValue, peggedToken);
 
   const { data: maxWithdraw } = useMaxWithdraw({
     gatewayAddress: peggedToken.gatewayAddress,

--- a/web/src/utils/token.ts
+++ b/web/src/utils/token.ts
@@ -20,6 +20,9 @@ export const getTokenPrice = function (
  * @returns The parsed token amount in the smallest unit.
  */
 export const parseTokenUnits = function (amount: string, token: Token) {
+  if (!amount) {
+    return 0n;
+  }
   const [whole, fraction] = amount.split(".");
   const truncatedFraction = fraction?.slice(0, token.decimals);
   const normalizedAmount = truncatedFraction

--- a/web/test/utils/token.test.ts
+++ b/web/test/utils/token.test.ts
@@ -234,6 +234,17 @@ describe("utils/token", function () {
       );
       expect(parseTokenUnits(largeDecimalAmount, token)).toEqual(expected);
     });
+
+    it("returns 0n when the amount is undefined", function () {
+      const token = { ...parseBaseToken, decimals: 6 };
+      // @ts-expect-error testing invalid input
+      expect(parseTokenUnits(undefined, token)).toEqual(0n);
+    });
+
+    it("returns 0n when the amount is an empty string", function () {
+      const token = { ...parseBaseToken, decimals: 6 };
+      expect(parseTokenUnits("", token)).toEqual(0n);
+    });
   });
 
   describe("removeOftDust", function () {


### PR DESCRIPTION
### Description

The Swap page crashed with `TypeError: Cannot read properties of undefined (reading 'split')` (Sentry VETRO-APP-6) when `parseTokenUnits` received an `undefined` amount. The debounced input value can momentarily be `undefined` and was passed straight into `parseTokenUnits`, which calls `.split` on it with no guard. The same unguarded pattern exists in the bridge form.

This adds a `!amount` guard inside `parseTokenUnits` that returns `0n` for a falsy amount, so every caller is protected (swap, bridge, and any future one). It also drops the now-redundant `fromInputValue ? … : 0n` guard in `redeemQueue`, which was the only call site that had worked around the issue locally.

### Screenshots

N/A — non-visual crash fix.

### Related issue(s)

Closes #543

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)