### PR TITLE
Add DEX per-pool detail page to dashboard

### DIFF
--- a/internal-dashboard/src/app.tsx
+++ b/internal-dashboard/src/app.tsx
@@ -15,7 +15,7 @@ export const App = () => (
       <BrowserRouter>
         <Layout>
           <Routes>
-            <Route element={<DexPoolPage />} path="/dex/:poolAddress" />
+            <Route element={<DexPoolPage />} path="/dex/:poolId" />
             <Route element={<Navigate replace to="/dex" />} path="/" />
             <Route element={<DexPage />} path="/dex" />
             <Route element={<Navigate replace to="/dex" />} path="*" />

--- a/internal-dashboard/src/app.tsx
+++ b/internal-dashboard/src/app.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 import { Header } from "./components/header";
 import { Layout } from "./components/layout";
 import { DexPage } from "./pages/dex";
+import { DexPoolPage } from "./pages/dexPool";
 
 const queryClient = new QueryClient();
 
@@ -14,6 +15,7 @@ export const App = () => (
       <BrowserRouter>
         <Layout>
           <Routes>
+            <Route element={<DexPoolPage />} path="/dex/:poolAddress" />
             <Route element={<Navigate replace to="/dex" />} path="/" />
             <Route element={<DexPage />} path="/dex" />
             <Route element={<Navigate replace to="/dex" />} path="*" />

--- a/internal-dashboard/src/components/dex/explorerLink.tsx
+++ b/internal-dashboard/src/components/dex/explorerLink.tsx
@@ -1,0 +1,22 @@
+import { type Address } from "viem";
+import { mainnet } from "viem/chains";
+
+import { shortenAddress } from "../../lib/format";
+
+type Props = {
+  address: Address;
+};
+
+const explorerAddressUrl = (address: Address) =>
+  `${mainnet.blockExplorers.default.url}/address/${address}`;
+
+export const ExplorerLink = ({ address }: Props) => (
+  <a
+    className="font-medium text-blue-600 hover:underline"
+    href={explorerAddressUrl(address)}
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    {shortenAddress(address)}
+  </a>
+);

--- a/internal-dashboard/src/components/dex/statCard.tsx
+++ b/internal-dashboard/src/components/dex/statCard.tsx
@@ -1,0 +1,15 @@
+import { type ReactNode } from "react";
+
+type Props = {
+  hint?: ReactNode;
+  label: string;
+  value: ReactNode;
+};
+
+export const StatCard = ({ hint, label, value }: Props) => (
+  <div className="rounded-lg border border-neutral-200 bg-white p-4">
+    <p className="text-xs font-medium text-neutral-500">{label}</p>
+    <p className="mt-1 text-lg font-semibold text-neutral-950">{value}</p>
+    {hint ? <div className="mt-1 text-xs text-neutral-500">{hint}</div> : null}
+  </div>
+);

--- a/internal-dashboard/src/fetchers/fetchGaugeEmissions.ts
+++ b/internal-dashboard/src/fetchers/fetchGaugeEmissions.ts
@@ -17,7 +17,14 @@ export const fetchGaugeEmissions = async function (): Promise<
     }
     const inflationRate = Number(gauge.inflationRate) / 1e18;
     const relativeWeight = Number(gauge.relativeWeight) / 1e18;
-    emissions[gauge.pool.toLowerCase()] = {
+    const key = gauge.pool.toLowerCase();
+    // A pool can expose several gauges (old/killed ones linger). Keep the one
+    // emitting the most CRV so a dead gauge can't zero out an active pool.
+    const existing = emissions[key];
+    if (existing && existing.inflationRate >= inflationRate) {
+      continue;
+    }
+    emissions[key] = {
       estCrvPerDay: inflationRate * relativeWeight * SECONDS_PER_DAY,
       inflationRate,
       relativeWeight,

--- a/internal-dashboard/src/fetchers/fetchGaugeEmissions.ts
+++ b/internal-dashboard/src/fetchers/fetchGaugeEmissions.ts
@@ -1,0 +1,27 @@
+import { fetchGauges } from "../lib/curveApi";
+import { type GaugeEmission } from "../lib/types";
+
+const SECONDS_PER_DAY = 86_400;
+
+// Normalizes every gauge's emission data, keyed by its pool address (lowercased)
+// for cheap lookup from a pool detail view.
+export const fetchGaugeEmissions = async function (): Promise<
+  Record<string, GaugeEmission>
+> {
+  const gauges = await fetchGauges();
+
+  const emissions: Record<string, GaugeEmission> = {};
+  for (const gauge of gauges) {
+    if (!gauge.pool) {
+      continue;
+    }
+    const inflationRate = Number(gauge.inflationRate) / 1e18;
+    const relativeWeight = Number(gauge.relativeWeight) / 1e18;
+    emissions[gauge.pool.toLowerCase()] = {
+      estCrvPerDay: inflationRate * relativeWeight * SECONDS_PER_DAY,
+      inflationRate,
+      relativeWeight,
+    };
+  }
+  return emissions;
+};

--- a/internal-dashboard/src/hooks/useCurvePoolStats.ts
+++ b/internal-dashboard/src/hooks/useCurvePoolStats.ts
@@ -1,0 +1,22 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { type Address } from "viem";
+
+import { fetchPoolStats } from "../lib/curveApi";
+
+const curvePoolStatsOptions = ({
+  poolAddress,
+}: {
+  poolAddress: Address | undefined;
+}) =>
+  queryOptions({
+    enabled: !!poolAddress,
+    queryFn: () => fetchPoolStats(poolAddress!),
+    queryKey: ["curve-pool-stats", poolAddress?.toLowerCase()],
+    staleTime: 60 * 1000,
+  });
+
+export const useCurvePoolStats = ({
+  poolAddress,
+}: {
+  poolAddress: Address | undefined;
+}) => useQuery(curvePoolStatsOptions({ poolAddress }));

--- a/internal-dashboard/src/hooks/useGaugeEmissions.ts
+++ b/internal-dashboard/src/hooks/useGaugeEmissions.ts
@@ -1,0 +1,26 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { type Address } from "viem";
+
+import { fetchGaugeEmissions } from "../fetchers/fetchGaugeEmissions";
+
+// The gauge payload is large, so it lives behind its own query (the summary view
+// never needs it) and stays under a single cache entry — pool detail views
+// select their gauge from it client-side instead of refetching per pool.
+const gaugeEmissionsOptions = () =>
+  queryOptions({
+    queryFn: fetchGaugeEmissions,
+    queryKey: ["gauge-emissions"],
+    staleTime: 60 * 1000,
+  });
+
+export const useGaugeEmissions = ({
+  poolAddress,
+}: {
+  poolAddress: Address | undefined;
+}) =>
+  useQuery({
+    ...gaugeEmissionsOptions(),
+    enabled: !!poolAddress,
+    select: (emissions) =>
+      poolAddress ? emissions[poolAddress.toLowerCase()] : undefined,
+  });

--- a/internal-dashboard/src/hooks/useTokenPrices.ts
+++ b/internal-dashboard/src/hooks/useTokenPrices.ts
@@ -2,7 +2,7 @@ import { queryOptions, useQuery } from "@tanstack/react-query";
 
 import { fetchTokenPrices } from "../fetchers/fetchTokenPrices";
 
-export const tokenPricesOptions = () =>
+const tokenPricesOptions = () =>
   queryOptions({
     queryFn: ({ client: queryClient }) => fetchTokenPrices({ queryClient }),
     queryKey: ["token-prices"],

--- a/internal-dashboard/src/lib/curveApi.ts
+++ b/internal-dashboard/src/lib/curveApi.ts
@@ -7,7 +7,7 @@ const CURVE_API_BASE = "https://api.curve.finance/api";
 const PRICES_API_BASE = "https://prices.curve.finance/v1";
 const NETWORK = "ethereum";
 
-export type CurveCoin = {
+type CurveCoin = {
   address: string;
   decimals: string;
   poolBalance: string;
@@ -15,7 +15,7 @@ export type CurveCoin = {
   usdPrice: number;
 };
 
-export type CurvePool = {
+type CurvePool = {
   address: string;
   coins: CurveCoin[];
   gaugeAddress?: string;
@@ -28,7 +28,7 @@ export type CurvePool = {
   virtualPrice: string;
 };
 
-export type CurveVolume = {
+type CurveVolume = {
   address: string;
   latestDailyApyPcent: number;
   latestWeeklyApyPcent: number;
@@ -36,7 +36,7 @@ export type CurveVolume = {
 };
 
 // Already converted out of the API's snake_case gauge fields.
-export type CurveGaugeInfo = {
+type CurveGaugeInfo = {
   gauge: string;
   inflationRate: string;
   pool: string;

--- a/internal-dashboard/src/pages/dexPool.tsx
+++ b/internal-dashboard/src/pages/dexPool.tsx
@@ -231,7 +231,7 @@ const AddressesSection = ({ pool }: { pool: TrackedPool }) => (
 );
 
 export const DexPoolPage = function () {
-  const { poolAddress } = useParams();
+  const { poolId } = useParams();
   const { data: pools, isError, isPending } = useTrackedPools();
 
   if (isPending) {
@@ -246,7 +246,7 @@ export const DexPoolPage = function () {
   }
 
   const pool = pools?.find(
-    (candidate) => candidate.id.toLowerCase() === poolAddress?.toLowerCase(),
+    (candidate) => candidate.id.toLowerCase() === poolId?.toLowerCase(),
   );
 
   if (!pool) {

--- a/internal-dashboard/src/pages/dexPool.tsx
+++ b/internal-dashboard/src/pages/dexPool.tsx
@@ -1,0 +1,352 @@
+import { type ReactNode } from "react";
+import { Link, useParams } from "react-router";
+import { type Address, formatUnits, isAddressEqual } from "viem";
+
+import { ExplorerLink } from "../components/dex/explorerLink";
+import { RangeBadge } from "../components/dex/rangeBadge";
+import { StatCard } from "../components/dex/statCard";
+import { StateMessage } from "../components/dex/stateMessage";
+import { TokenIcon } from "../components/dex/tokenIcon";
+import { TokenPair } from "../components/dex/tokenPair";
+import { VenueBadge } from "../components/dex/venueBadge";
+import { type Dex } from "../config/dexes";
+import { useCurvePoolStats } from "../hooks/useCurvePoolStats";
+import { useGaugeEmissions } from "../hooks/useGaugeEmissions";
+import { useTrackedPools } from "../hooks/useTrackedPools";
+import {
+  formatPercent,
+  formatPrice,
+  formatRate,
+  formatTokenAmount,
+  formatUsd,
+} from "../lib/format";
+import { type PoolCoin, type TrackedPool } from "../lib/types";
+
+// Within 10% of equal value: treat the pair as a peg and surface drift from 1.
+const PEG_THRESHOLD = 1.1;
+
+const ExternalLink = ({
+  children,
+  className,
+  href,
+}: {
+  children: ReactNode;
+  className: string;
+  href: string;
+}) => (
+  <a
+    className={className}
+    href={href}
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    {children}
+  </a>
+);
+
+// Rolling-24h fees come from Curve's analytics API, fetched per pool on demand.
+const FeesCard = function ({ pool }: { pool: TrackedPool }) {
+  const { data: stats } = useCurvePoolStats({ poolAddress: pool.address });
+
+  return (
+    <StatCard
+      hint={
+        stats && stats.liquidityFee24h > 0
+          ? `+ ${formatPrice(stats.liquidityFee24h)} liquidity fees`
+          : undefined
+      }
+      label="24h Fees"
+      value={
+        stats?.tradingFee24h != null ? formatPrice(stats.tradingFee24h) : "—"
+      }
+    />
+  );
+};
+
+const ExchangeRateCard = function ({ pool }: { pool: TrackedPool }) {
+  if (pool.coins.length !== 2) {
+    return null;
+  }
+  const [base, quote] = pool.coins;
+  // Without a price for both legs the rate is Infinity/NaN; skip the card.
+  if (!base.usdPrice || !quote.usdPrice) {
+    return null;
+  }
+  const rate = base.usdPrice / quote.usdPrice;
+  const isPeg = Math.max(rate, 1 / rate) < PEG_THRESHOLD;
+  const deviation = (rate - 1) * 100;
+
+  return (
+    <StatCard
+      hint={
+        isPeg ? (
+          <span
+            className={
+              Math.abs(deviation) >= 0.5 ? "text-amber-600" : "text-emerald-600"
+            }
+          >
+            {deviation >= 0 ? "+" : ""}
+            {deviation.toFixed(3)}% vs. peg
+          </span>
+        ) : (
+          `1 ${quote.symbol} = ${formatRate(1 / rate)} ${base.symbol}`
+        )
+      }
+      label="Exchange rate"
+      value={`1 ${base.symbol} = ${formatRate(rate)} ${quote.symbol}`}
+    />
+  );
+};
+
+const CoinBreakdown = function ({
+  coin,
+  dex,
+  tvlUsd,
+}: {
+  coin: PoolCoin;
+  dex: Dex;
+  tvlUsd: number;
+}) {
+  const balance = Number(formatUnits(coin.balance, coin.decimals));
+  const balanceUsd = balance * coin.usdPrice;
+  const share = tvlUsd > 0 ? (balanceUsd / tvlUsd) * 100 : 0;
+
+  return (
+    <div className="rounded-lg border border-neutral-200 p-4">
+      <div className="flex items-center gap-x-2">
+        <TokenIcon address={coin.address} dex={dex} symbol={coin.symbol} />
+        <span className="font-medium text-neutral-950">{coin.symbol}</span>
+        <span className="ml-auto text-xs text-neutral-500">
+          {formatPercent(share)}
+        </span>
+      </div>
+      <dl className="mt-3 grid grid-cols-3 gap-2 text-sm">
+        <div>
+          <dt className="text-xs text-neutral-500">Balance</dt>
+          <dd className="font-medium text-neutral-950">
+            {formatTokenAmount(balance)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-neutral-500">Value</dt>
+          <dd className="font-medium text-neutral-950">
+            {formatUsd(balanceUsd)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-neutral-500">Price</dt>
+          <dd className="font-medium text-neutral-950">
+            {formatPrice(coin.usdPrice)}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+};
+
+const GaugeSection = function ({ pool }: { pool: TrackedPool }) {
+  const { data: emission } = useGaugeEmissions({ poolAddress: pool.address });
+
+  if (!pool.gaugeAddress) {
+    return <p className="text-sm text-neutral-600">This pool has no gauge.</p>;
+  }
+
+  const hasEmissions = emission ? emission.estCrvPerDay > 0 : false;
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      <StatCard
+        hint="Share of CRV emissions"
+        label="Gauge weight"
+        value={emission ? formatPercent(emission.relativeWeight * 100) : "—"}
+      />
+      <StatCard
+        label="Est. CRV / day"
+        value={emission ? formatTokenAmount(emission.estCrvPerDay) : "—"}
+      />
+      <StatCard
+        label="CRV APY"
+        value={
+          pool.rewardApyMax > pool.rewardApy
+            ? `${formatPercent(pool.rewardApy)} – ${formatPercent(pool.rewardApyMax)}`
+            : formatPercent(pool.rewardApy)
+        }
+      />
+      {!hasEmissions && emission ? (
+        <p className="col-span-full text-xs text-neutral-500">
+          No active CRV emissions are currently directed to this gauge.
+        </p>
+      ) : null}
+    </div>
+  );
+};
+
+const AddressRow = ({
+  address,
+  label,
+}: {
+  address: Address;
+  label: string;
+}) => (
+  <div className="flex items-center justify-between gap-x-4 py-2 text-sm">
+    <span className="text-neutral-600">{label}</span>
+    <ExplorerLink address={address} />
+  </div>
+);
+
+const AddressesSection = ({ pool }: { pool: TrackedPool }) => (
+  <div>
+    <h3 className="mb-1 text-lg font-semibold text-neutral-950">Addresses</h3>
+    <div className="divide-y divide-neutral-100">
+      <div className="flex items-center justify-between gap-x-4 py-2 text-sm">
+        <span className="text-neutral-600">Pool</span>
+        <span className="flex items-center gap-x-3">
+          <ExplorerLink address={pool.address} />
+          {pool.url ? (
+            <ExternalLink
+              className="font-medium text-blue-600 capitalize hover:underline"
+              href={pool.url}
+            >
+              {pool.dex} ↗
+            </ExternalLink>
+          ) : null}
+        </span>
+      </div>
+      {pool.gaugeAddress ? (
+        <AddressRow address={pool.gaugeAddress} label="Gauge" />
+      ) : null}
+      {pool.lpTokenAddress &&
+      !isAddressEqual(pool.lpTokenAddress, pool.address) ? (
+        <AddressRow address={pool.lpTokenAddress} label="LP token" />
+      ) : null}
+      {pool.coins.map((coin) => (
+        <AddressRow
+          address={coin.address}
+          key={coin.address}
+          label={coin.symbol}
+        />
+      ))}
+    </div>
+  </div>
+);
+
+export const DexPoolPage = function () {
+  const { poolAddress } = useParams();
+  const { data: pools, isError, isPending } = useTrackedPools();
+
+  if (isPending) {
+    return <StateMessage>Loading pool…</StateMessage>;
+  }
+  if (isError) {
+    return (
+      <StateMessage>
+        Couldn&apos;t load pool data. Try again later.
+      </StateMessage>
+    );
+  }
+
+  const pool = pools?.find(
+    (candidate) => candidate.id.toLowerCase() === poolAddress?.toLowerCase(),
+  );
+
+  if (!pool) {
+    return (
+      <section className="flex flex-col gap-y-4">
+        <StateMessage>Pool not found.</StateMessage>
+        <Link
+          className="mx-auto text-sm text-blue-600 hover:underline"
+          to="/dex"
+        >
+          ← Back to DEX
+        </Link>
+      </section>
+    );
+  }
+
+  // Curve exposes volume / fees / APY / gauge; Sushi pools are read on-chain for
+  // liquidity only, so those sections are Curve-only.
+  const isCurve = pool.dex === "curve";
+
+  return (
+    <section className="flex flex-col gap-y-8">
+      <div className="flex flex-col gap-y-4">
+        <Link className="text-sm text-blue-600 hover:underline" to="/dex">
+          ← Back to DEX
+        </Link>
+        <div className="flex flex-col gap-y-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <div className="flex items-center gap-x-2">
+              <TokenPair
+                coins={pool.coins}
+                dex={pool.dex}
+                name={pool.name}
+                size={32}
+              />
+              <VenueBadge dex={pool.dex} />
+              {pool.rangeLabel ? <RangeBadge label={pool.rangeLabel} /> : null}
+            </div>
+            <p className="mt-1 text-xs text-neutral-500">{pool.poolType}</p>
+          </div>
+          {pool.url ? (
+            <ExternalLink
+              className="self-start rounded-md border border-neutral-300 px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+              href={pool.url}
+            >
+              View on <span className="capitalize">{pool.dex}</span> ↗
+            </ExternalLink>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        <StatCard label="TVL" value={formatUsd(pool.tvlUsd)} />
+        {isCurve ? (
+          <>
+            <StatCard label="24h Volume" value={formatUsd(pool.volumeUsd24h)} />
+            <FeesCard pool={pool} />
+            <StatCard
+              hint={`${formatPercent(pool.baseApy)} base + ${formatPercent(pool.rewardApy)} rewards`}
+              label="APY"
+              value={formatPercent(pool.baseApy + pool.rewardApy)}
+            />
+            <StatCard
+              hint="24h volume / TVL"
+              label="Liquidity utilization"
+              value={
+                pool.tvlUsd > 0
+                  ? formatPercent((pool.volumeUsd24h / pool.tvlUsd) * 100)
+                  : "—"
+              }
+            />
+          </>
+        ) : null}
+        <ExchangeRateCard pool={pool} />
+      </div>
+
+      <div>
+        <h3 className="mb-3 text-lg font-semibold text-neutral-950">
+          Liquidity
+        </h3>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {pool.coins.map((coin) => (
+            <CoinBreakdown
+              coin={coin}
+              dex={pool.dex}
+              key={coin.address}
+              tvlUsd={pool.tvlUsd}
+            />
+          ))}
+        </div>
+      </div>
+
+      {isCurve ? (
+        <div>
+          <h3 className="mb-3 text-lg font-semibold text-neutral-950">Gauge</h3>
+          <GaugeSection pool={pool} />
+        </div>
+      ) : null}
+
+      <AddressesSection pool={pool} />
+    </section>
+  );
+};


### PR DESCRIPTION
### Description

Adds a per-pool detail page to the internal dashboard at `/dex/:poolAddress`, reachable from the DEX list. It shows TVL for any pool and, for Curve pools, 24h volume, fees, APY and liquidity utilization (24h volume / TVL). Every pool also gets a per-coin liquidity breakdown (balance, value, price, share), an exchange-rate card that surfaces peg drift for stable pairs, Curve gauge emissions (gauge weight, est. CRV/day, CRV APY), and the pool/gauge/LP-token/coin addresses with explorer links.

Also drops a few now-unused type/option exports flagged by knip (`curveApi` `Curve*` types and web's `tokenPricesOptions`).

### Screenshots

https://github.com/user-attachments/assets/cb5286fa-f48f-4e9f-8e01-14a6a4cc61a7

### Related issue(s)

Related to #474

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
