### PR TITLE
Test for orphaned locale keys, drop unused ones

### DIFF
--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -29,9 +29,6 @@
     "try-different-search": "Try searching with a different term",
     "wallet-disclaimer": "By connecting a wallet, you agree to Vetro <terms>Terms of Use</terms> and consent to its <privacy>Privacy Policy</privacy>."
   },
-  "language": {
-    "switch-to": "Switch to Spanish"
-  },
   "nav": {
     "analytics": "Analytics",
     "borrow": "Borrow",
@@ -105,7 +102,6 @@
       "drop-from-price": "{{percentage}} from ${{price}}",
       "effective-interest": "Effective Interest",
       "effective-interest-tooltip": "The actual annual rate you pay after discounts. It's the base rate minus any rebates you qualify for.",
-      "enter-amount": "Enter amount",
       "has-position-description": "This address already has an active borrow position. Switch wallet or manage your existing position.",
       "has-position-title": "You have a position already open",
       "health-factor": "Health factor",
@@ -153,7 +149,6 @@
         "title": "Repay loan",
         "toast-description": "{{amount}} {{symbol}} repaid.",
         "toast-title": "Loan repaid",
-        "total-loan": "Total loan",
         "you-will-repay": "You will repay"
       },
       "supply-collateral-and-borrow": "Supply collateral and borrow",
@@ -165,7 +160,6 @@
         "supply-description": "Confirm the collateral deposit to your borrow position.",
         "supply-progress": "Supply progress",
         "supply-title": "Supply collateral",
-        "title": "Supply in progress",
         "toast-description": "{{amount}} {{symbol}} supplied as collateral.",
         "toast-title": "Collateral supplied",
         "you-will-supply": "You will supply"
@@ -219,7 +213,6 @@
         "waiting-description": "We're waiting for funds to arrive from the source chain — this can take a few minutes.",
         "waiting-title": "Waiting for funds to arrive"
       },
-      "select-chain": "Select chain",
       "select-from-chain": "Select source chain",
       "select-to-chain": "Select destination chain",
       "title": "Bridge assets across chains",
@@ -314,7 +307,6 @@
         "deposit-toast-title": "Stake deposit confirmed",
         "depositing": "Depositing...",
         "fees-label": "Staking {{amount}} {{token}}",
-        "how-withdrawals-work": "How withdrawals work",
         "instant-withdraw": "Withdraw",
         "instant-withdraw-step-description": "Review the details and confirm the withdrawal in your wallet.",
         "instant-withdraw-step-title": "Confirm withdrawal",
@@ -325,7 +317,6 @@
         "request-withdrawal": "Request withdrawal",
         "requesting": "Requesting...",
         "withdraw": "Withdraw",
-        "withdraw-coming-soon": "Withdraw coming soon",
         "withdraw-progress": "Withdraw progress",
         "withdraw-step-1-description": "Start the withdrawal process. Your funds will be locked in a cooldown and will no longer earn yield.",
         "withdraw-step-1-title": "Request withdrawal",
@@ -368,8 +359,7 @@
         "swap-text": "{{fromAmount}} {{fromSymbol}} to {{toAmount}} {{toSymbol}}"
       },
       "fees": {
-        "fixed-protocol-fee": "Fixed Protocol Fee",
-        "oracle-deviation-fee": "Oracle Deviation Fee"
+        "fixed-protocol-fee": "Fixed Protocol Fee"
       },
       "form": {
         "allowance-error": "Error loading allowance",
@@ -417,7 +407,6 @@
         "ready-to-redeem": "Ready to redeem",
         "redeem": "Redeem",
         "redeem-confirmed": "Redeem confirmed",
-        "redeem-progress": "Redeem progress",
         "redeemable-balance": "Redeemable balance",
         "status": "Status",
         "swap-confirmed-description": "Your {{symbol}} is now available in your wallet",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -29,9 +29,6 @@
     "try-different-search": "Intente con un término de búsqueda diferente",
     "wallet-disclaimer": "Al conectar una billetera, usted acepta los <terms>Términos de uso</terms> de Vetro y consiente su <privacy>Política de privacidad</privacy>."
   },
-  "language": {
-    "switch-to": "Cambiar a Inglés"
-  },
   "nav": {
     "analytics": "Analíticas",
     "borrow": "Préstamos",
@@ -105,7 +102,6 @@
       "drop-from-price": "{{percentage}} desde ${{price}}",
       "effective-interest": "Interés efectivo",
       "effective-interest-tooltip": "La tasa anual real que paga después de descuentos. Es la tasa base menos cualquier reembolso al que califique.",
-      "enter-amount": "Ingrese un monto",
       "has-position-description": "Esta dirección ya tiene una posición de préstamo activa. Cambie de billetera o gestione su posición existente.",
       "has-position-title": "Ya tiene una posición abierta",
       "health-factor": "Factor de salud",
@@ -153,7 +149,6 @@
         "title": "Pagar préstamo",
         "toast-description": "{{amount}} {{symbol}} pagados.",
         "toast-title": "Préstamo pagado",
-        "total-loan": "Préstamo total",
         "you-will-repay": "Pagará"
       },
       "supply-collateral-and-borrow": "Depositar garantía y pedir prestado",
@@ -165,7 +160,6 @@
         "supply-description": "Confirme el depósito de garantía a su posición de préstamo.",
         "supply-progress": "Progreso del depósito",
         "supply-title": "Depositar garantía",
-        "title": "Depósito en progreso",
         "toast-description": "{{amount}} {{symbol}} depositados como garantía.",
         "toast-title": "Garantía depositada",
         "you-will-supply": "Depositará"
@@ -220,7 +214,6 @@
         "waiting-description": "Estamos esperando que los fondos lleguen desde la red de origen — esto puede tardar unos minutos.",
         "waiting-title": "Esperando que lleguen los fondos"
       },
-      "select-chain": "Seleccionar red",
       "select-from-chain": "Seleccionar red de origen",
       "select-to-chain": "Seleccionar red de destino",
       "title": "Transfiera activos entre redes",
@@ -317,7 +310,6 @@
         "deposit-toast-title": "Depósito de stake confirmado",
         "depositing": "Depositando...",
         "fees-label": "Haciendo stake de {{amount}} {{token}}",
-        "how-withdrawals-work": "Cómo funcionan los retiros",
         "instant-withdraw": "Retirar",
         "instant-withdraw-step-description": "Revise los detalles y confirme el retiro en su billetera.",
         "instant-withdraw-step-title": "Confirmar retiro",
@@ -328,7 +320,6 @@
         "request-withdrawal": "Solicitar retiro",
         "requesting": "Solicitando...",
         "withdraw": "Retirar",
-        "withdraw-coming-soon": "Retiro próximamente",
         "withdraw-progress": "Progreso del retiro",
         "withdraw-step-1-description": "Inicie el proceso de retiro. Sus fondos estarán bloqueados en un período de espera y ya no generarán rendimiento.",
         "withdraw-step-1-title": "Solicitar retiro",
@@ -374,8 +365,7 @@
         "swap-text": "{{fromAmount}} {{fromSymbol}} a {{toAmount}} {{toSymbol}}"
       },
       "fees": {
-        "fixed-protocol-fee": "Tarifa de Protocolo Fija",
-        "oracle-deviation-fee": "Tarifa de Desviación del Oráculo"
+        "fixed-protocol-fee": "Tarifa de Protocolo Fija"
       },
       "form": {
         "allowance-error": "No se pudo cargar el monto autorizado",
@@ -424,7 +414,6 @@
         "ready-to-redeem": "Listo para canjear",
         "redeem": "Canjear",
         "redeem-confirmed": "Canje confirmado",
-        "redeem-progress": "Progreso del canje",
         "redeemable-balance": "Saldo canjeable",
         "status": "Estado",
         "swap-confirmed-description": "Su {{symbol}} ahora está disponible en su billetera",

--- a/web/test/locale.test.ts
+++ b/web/test/locale.test.ts
@@ -40,6 +40,60 @@ const getBaseKeys = (keys: string[]) => [
   ...new Set(keys.map(stripPluralSuffix)),
 ];
 
+const sourceFileExtensions = /\.(cjs|js|jsx|mjs|ts|tsx)$/;
+
+// Keys assembled at runtime — e.g. t(`common.${inputError}`) for the InputError
+// union in src/components/tokenInput/utils.ts — can't be found by a static
+// string search, so they are listed here to avoid being reported as orphaned.
+const dynamicallyReferencedKeys = [
+  "common.amount-too-small-to-bridge",
+  "common.enter-amount",
+  "common.exceeds-debt",
+  "common.insufficient-balance",
+  "common.insufficient-collateral",
+  "common.insufficient-gas",
+  "common.insufficient-liquidity",
+  "common.insufficient-treasury",
+];
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// A key only counts as referenced when it is not immediately preceded or
+// followed by another key character, so a key that is merely a fragment of a
+// longer one — whether a prefix ("pages.borrow.borrow-more" inside
+// "pages.borrow.borrow-more-progress") or a dot-boundary suffix ("enter-amount"
+// inside "common.enter-amount") — is not mistaken for a match.
+const isReferenced = ({ corpus, key }: { corpus: string; key: string }) =>
+  new RegExp(`(?<![\\w.-])${escapeRegExp(key)}(?![\\w.-])`).test(corpus);
+
+const readEnglishBaseKeys = async function () {
+  const filePath = path.resolve(
+    __dirname,
+    "../src/i18n/locales/en/translation.json",
+  );
+  const content = JSON.parse(await readFile(filePath, "utf-8")) as LocaleObject;
+  return getBaseKeys(getFullKeys(content));
+};
+
+// Concatenate every source file (excluding the locale JSON files themselves) so
+// translation keys can be searched for as literals.
+const readSourceCorpus = async function () {
+  const srcDir = path.resolve(__dirname, "../src");
+  const localesPath = path.join("i18n", "locales");
+  const entries = await readdir(srcDir, { recursive: true });
+  const sourceFiles = entries.filter(
+    (entry: string) =>
+      sourceFileExtensions.test(entry) && !entry.includes(localesPath),
+  );
+  const contents = await Promise.all(
+    sourceFiles.map((file: string) =>
+      readFile(path.join(srcDir, file), "utf-8"),
+    ),
+  );
+  return contents.join("\n");
+};
+
 describe("locale messages", function () {
   describe("All locale resource files should have the same keys in the same order", function () {
     it("should have the same keys in the same order", async function () {
@@ -77,6 +131,33 @@ describe("locale messages", function () {
       const sortedKeys = [...keys].sort();
 
       expect(keys).toEqual(sortedKeys);
+    });
+  });
+
+  describe("English locale keys should all be referenced in the source code", function () {
+    it("should not have unused (orphaned) keys", async function () {
+      const baseKeys = await readEnglishBaseKeys();
+      const corpus = await readSourceCorpus();
+
+      const unusedKeys = baseKeys.filter(
+        (key: string) =>
+          !isReferenced({ corpus, key }) &&
+          !dynamicallyReferencedKeys.includes(key),
+      );
+
+      expect(unusedKeys).toEqual([]);
+    });
+
+    // Guards the allow-list above from going stale: if a dynamically referenced
+    // key is deleted from the translations, its allow-list entry must go too.
+    it("should not allow-list keys that no longer exist", async function () {
+      const baseKeys = await readEnglishBaseKeys();
+
+      const staleAllowList = dynamicallyReferencedKeys.filter(
+        (key: string) => !baseKeys.includes(key),
+      );
+
+      expect(staleAllowList).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
### Description

Adds a vitest check that fails when an English translation key is never referenced anywhere in the source, so dead keys don't accumulate over time. Keys assembled at runtime (e.g. `t(`common.${inputError}`)`) are allow-listed, and a companion test guards that allow-list from going stale (if an allow-listed key is deleted from the translations, its entry must go too).

Running the new test surfaced 9 orphaned keys, removed here from both the `en` and `es` locales:

- `language.switch-to`
- `pages.borrow.enter-amount`
- `pages.borrow.repay-loan-progress.total-loan`
- `pages.borrow.supply-collateral-progress.title`
- `pages.bridge.select-chain`
- `pages.earn.stake.how-withdrawals-work`
- `pages.earn.stake.withdraw-coming-soon`
- `pages.swap.fees.oracle-deviation-fee`
- `pages.swap.redeem-queue.redeem-progress`

> **Note on the heuristic:** the orphaned-key check is a static string search over the source, so it's a heuristic rather than a precise reference resolver. The risk it introduces is a false negative — failing to detect that a key is actually used and reporting it as orphaned. That's safe in practice: translation keys are typed, so if we ever delete a key that's genuinely referenced, `tsc` catches it and fails the build. The test can over-report, but it can't cause a silently broken removal to slip through.

### Screenshots

N/A — no UI changes.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.