### PR TITLE
Add Input component to design system

### DIFF
--- a/web/src/components/base/input/index.tsx
+++ b/web/src/components/base/input/index.tsx
@@ -29,7 +29,11 @@ export const Input = function ({
       ) : null}
       <input
         {...props}
-        aria-describedby={errorMessage ? errorId : undefined}
+        aria-describedby={
+          [props["aria-describedby"], errorMessage ? errorId : null]
+            .filter(Boolean)
+            .join(" ") || undefined
+        }
         aria-invalid={invalid || undefined}
         className="input--base"
         id={inputId}

--- a/web/src/components/base/input/index.tsx
+++ b/web/src/components/base/input/index.tsx
@@ -42,6 +42,7 @@ export const Input = function ({
         <p
           className="text-b-regular text-rose-600 transition-colors group-focus-within/input:text-gray-500"
           id={errorId}
+          role="alert"
         >
           {errorMessage}
         </p>

--- a/web/src/components/base/input/index.tsx
+++ b/web/src/components/base/input/index.tsx
@@ -1,0 +1,47 @@
+import { type ComponentProps, useId } from "react";
+
+import "./input.css";
+
+type Props = Omit<ComponentProps<"input">, "className"> & {
+  error?: boolean;
+  errorMessage?: string;
+  label?: string;
+};
+
+export const Input = function ({
+  error,
+  errorMessage,
+  id,
+  label,
+  ...props
+}: Props) {
+  const fallbackId = useId();
+  const inputId = id ?? fallbackId;
+  const errorId = `${inputId}-error`;
+  const invalid = error || Boolean(errorMessage);
+
+  return (
+    <div className="group/input flex flex-col gap-2">
+      {label ? (
+        <label className="text-b-medium text-gray-900" htmlFor={inputId}>
+          {label}
+        </label>
+      ) : null}
+      <input
+        {...props}
+        aria-describedby={errorMessage ? errorId : undefined}
+        aria-invalid={invalid || undefined}
+        className="input--base"
+        id={inputId}
+      />
+      {errorMessage ? (
+        <p
+          className="text-b-regular text-rose-600 transition-colors group-focus-within/input:text-gray-500"
+          id={errorId}
+        >
+          {errorMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+};

--- a/web/src/components/base/input/input.css
+++ b/web/src/components/base/input/input.css
@@ -1,0 +1,33 @@
+@reference "../../../index.css";
+
+.input--base {
+  @apply text-b-regular h-7 w-full rounded-full bg-white pr-1.5 pl-3 text-gray-900 shadow-sm transition-shadow outline-none placeholder:text-gray-500;
+}
+
+.input--base:hover:not(:focus, [aria-invalid="true"]) {
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    0 1px 2px 0 rgba(0, 0, 0, 0.08),
+    0 7px 11px -6px rgba(0, 0, 0, 0.08);
+}
+
+.input--base:focus {
+  box-shadow:
+    var(--shadow-sm),
+    0 0 0 4px rgba(0, 0, 0, 0.12);
+}
+
+.input--base[aria-invalid="true"] {
+  box-shadow:
+    var(--shadow-sm),
+    0 0 0 1px rgba(255, 32, 86, 0.53),
+    0 0 1px 0 rgba(255, 32, 86, 0.48);
+}
+
+.input--base[aria-invalid="true"]:focus {
+  box-shadow:
+    0 0 0 4px rgba(255, 32, 86, 0.16),
+    0 0 1px 0 rgba(255, 32, 86, 0.48),
+    0 0 0 1px rgba(255, 32, 86, 0.53),
+    var(--shadow-sm);
+}

--- a/web/stories/input.stories.tsx
+++ b/web/stories/input.stories.tsx
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+import { Input } from "../src/components/base/input";
+
+const meta = {
+  argTypes: {
+    error: {
+      control: "boolean",
+    },
+    errorMessage: {
+      control: "text",
+    },
+  },
+  component: Input,
+  title: "Components/Input",
+} satisfies Meta<typeof Input>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const label = "Your email address";
+const placeholder = "john@email.com";
+
+export const Default: Story = {
+  args: {
+    label,
+    placeholder,
+  },
+  render: function Render(args) {
+    const [value, setValue] = useState("");
+
+    return (
+      <div className="w-[352px]">
+        <Input
+          {...args}
+          onChange={(event) => setValue(event.target.value)}
+          value={value}
+        />
+      </div>
+    );
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    label,
+    placeholder,
+  },
+  render: function Render(args) {
+    const [value, setValue] = useState("john@email.com");
+
+    return (
+      <div className="w-[352px]">
+        <Input
+          {...args}
+          onChange={(event) => setValue(event.target.value)}
+          value={value}
+        />
+      </div>
+    );
+  },
+};
+
+export const Error: Story = {
+  args: {
+    errorMessage: "Please enter a valid email address",
+    label,
+    placeholder,
+  },
+  render: function Render(args) {
+    const [value, setValue] = useState("");
+
+    return (
+      <div className="w-[352px]">
+        <Input
+          {...args}
+          onChange={(event) => setValue(event.target.value)}
+          value={value}
+        />
+      </div>
+    );
+  },
+};
+
+export const States: Story = {
+  render: function Render() {
+    const [empty, setEmpty] = useState("");
+    const [filled, setFilled] = useState("john@email.com");
+    const [invalid, setInvalid] = useState("");
+
+    return (
+      <div className="flex w-[352px] flex-col gap-6">
+        <div>
+          <p className="text-xsm mb-2 font-medium text-gray-500">
+            Default (hover and focus to see other states)
+          </p>
+          <Input
+            label={label}
+            onChange={(event) => setEmpty(event.target.value)}
+            placeholder={placeholder}
+            value={empty}
+          />
+        </div>
+        <div>
+          <p className="text-xsm mb-2 font-medium text-gray-500">
+            Filled (with value)
+          </p>
+          <Input
+            label={label}
+            onChange={(event) => setFilled(event.target.value)}
+            placeholder={placeholder}
+            value={filled}
+          />
+        </div>
+        <div>
+          <p className="text-xsm mb-2 font-medium text-gray-500">
+            Error (focus to see error + focus state)
+          </p>
+          <Input
+            errorMessage="Please enter a valid email address"
+            label={label}
+            onChange={(event) => setInvalid(event.target.value)}
+            placeholder={placeholder}
+            value={invalid}
+          />
+        </div>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
### Description

Adds a labeled, pill-shaped text `Input` to the base design system (`web/src/components/base/input/`), built from the Figma spec. It's an all-in-one component that renders the label, field, and an optional error message, associating the label and error with the input for accessibility.

Supported states: default, hover, focus, and error. Error shows a red ring (driven by `error` or `errorMessage`) plus an optional message that renders in `rose-600` and turns gray while the field is focused, matching the design.

This is groundwork for #550 — the feedback form will be the first consumer of this input.

### Screenshots

https://github.com/user-attachments/assets/2ca8c6d9-d474-4326-8f96-2aebcb7c005a

### Related issue(s)

Related to #550

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A. — N/A (presentational design-system component; Storybook stories serve as the visual harness)
- [ ] Documentation updated, or N/A. — N/A
- [ ] Environment variables set in CI, or N/A. — N/A
