### PR TITLE
Validate borrow market only on cache miss

### DIFF
--- a/api/src/borrow.ts
+++ b/api/src/borrow.ts
@@ -87,11 +87,9 @@ export async function getAprHistory({
 /**
  * Gets the amount of collateral assets in a given Morpho market.
  */
-export async function getCollateralAssets({
-  marketId,
-}: {
-  marketId: string;
-}): Promise<{ collateralAssets: number }> {
+export async function getCollateralAssets(
+  marketId: string,
+): Promise<{ collateralAssets: number }> {
   const collateralAssets = await morpho.getCollateralAssets({ marketId });
   return { collateralAssets };
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/cloudflare";
 import { sVetBtcAddress, sVusdAddress } from "@vetro-protocol/earn";
-import { Hono } from "hono";
+import { type Context, Hono, type Next } from "hono";
 import { cache } from "hono/cache";
 import { cors } from "hono/cors";
 import type { Address } from "viem";
@@ -139,28 +139,44 @@ app.get(
   },
 );
 
+// Cheap, local check on the market id shape. Kept ahead of `cache()` so
+// malformed ids are rejected without a cache lookup or a network call.
+function validateMarketIdFormat(c: Context, next: Next) {
+  const marketId = c.req.param("marketId")?.toLowerCase();
+  if (!marketId || !/^0x[a-f0-9]{64}$/.test(marketId)) {
+    return c.json({ error: "Malformed market id" }, 400);
+  }
+  return next();
+}
+
+// Expensive check: confirms the market exists and is supported via a Morpho
+// API call. Placed *after* `cache()` so it only runs on a cache miss, not on
+// every cached request.
+async function validateMarketIdSupported(c: Context, next: Next) {
+  try {
+    const marketId = c.req.param("marketId")?.toLowerCase();
+    if (!marketId) {
+      return c.json({ error: "Malformed market id" }, 400);
+    }
+    const isValid = await borrow.validateMarketId({ marketId });
+    if (!isValid) {
+      return c.json({ error: "Unsupported market" }, 404);
+    }
+    return next();
+  } catch (error) {
+    return c.json({ error: `Invalid market id: ${error.message}` }, 404);
+  }
+}
+
 app.get(
   "/borrow/:marketId/apr-history/:period",
-  async function (c, next) {
-    try {
-      const marketId = c.req.param("marketId").toLowerCase();
-      if (!/^0x[a-f0-9]{64}$/.test(marketId)) {
-        return c.json({ error: "Malformed market id" }, 400);
-      }
-      const isValid = await borrow.validateMarketId({ marketId });
-      if (!isValid) {
-        return c.json({ error: "Unsupported market" }, 404);
-      }
-      return next();
-    } catch (error) {
-      return c.json({ error: `Invalid market id: ${error.message}` }, 404);
-    }
-  },
+  validateMarketIdFormat,
   validateParam("period", borrow.validPeriods),
   cache({
     cacheControl: "max-age=3600",
     cacheName: "vetro-api",
   }),
+  validateMarketIdSupported,
   async function (c) {
     try {
       const marketId = c.req.param("marketId").toLowerCase();
@@ -175,29 +191,16 @@ app.get(
 
 app.get(
   "/borrow/:marketId/collateral-assets",
-  async function (c, next) {
-    try {
-      const marketId = c.req.param("marketId").toLowerCase();
-      if (!/^0x[a-f0-9]{64}$/.test(marketId)) {
-        return c.json({ error: "Malformed market id" }, 400);
-      }
-      const isValid = await borrow.validateMarketId({ marketId });
-      if (!isValid) {
-        return c.json({ error: "Unsupported market" }, 404);
-      }
-      return next();
-    } catch (error) {
-      return c.json({ error: `Invalid market id: ${error.message}` }, 404);
-    }
-  },
+  validateMarketIdFormat,
   cache({
-    cacheControl: "max-age=3600",
+    cacheControl: "max-age=300",
     cacheName: "vetro-api",
   }),
+  validateMarketIdSupported,
   async function (c) {
     try {
       const marketId = c.req.param("marketId").toLowerCase();
-      const collateralAssets = await borrow.getCollateralAssets({ marketId });
+      const collateralAssets = await borrow.getCollateralAssets(marketId);
       return c.json(collateralAssets);
     } catch (error) {
       throw new Error(`Failed to get collateral assets: ${error.message}`);


### PR DESCRIPTION
### Description

The `/borrow/:marketId/*` endpoints validated the market id by calling the Morpho GraphQL API, and that validation ran as middleware *before* the `cache()` middleware. As a result the Morpho call fired on **every** request — including cache hits — so even a cached response paid the validation cost.

Measured before the fix (production `api.vetro.org`):

- `GET /borrow/:marketId/collateral-assets` — cache miss ~600–700 ms, **cache hit ~300–390 ms**
- `GET /borrow/:marketId/apr-history/1m` — cache miss ~690 ms, **cache hit ~335–375 ms**

The ~300 ms on a cache hit was purely the Morpho validation call that the cache should have skipped.

The fix splits validation in two: a cheap, local market-id format check stays ahead of `cache()`, while the Morpho existence/support check moves *after* it, so the network call only runs on a cache miss. Both borrow routes share the extracted middleware, so both get the improvement. It also shortens the `collateral-assets` cache TTL to 5 minutes and simplifies `getCollateralAssets` to take `marketId` as a single positional argument.

After the fix, the cache miss is unchanged (as expected — the first compute still validates and queries), but a **cache hit now takes under 50 ms**, both locally and on staging.

### Screenshots

N/A

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A. — N/A (existing suite passes; behavior verified via curl)
- [ ] Documentation updated, or N/A. — N/A (no external contract change)
- [ ] Environment variables set in CI, or N/A. — N/A