### PR TITLE
Remove unused pegged-token-backing endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -4,20 +4,6 @@ Service that provides data to the Vetro web application.
 
 ## Data endpoints
 
-### `GET /analytics/pegged-token-backing/:gatewayAddress`
-
-Get the total strategic reserves and the total surplus for a given gateway's pegged token.
-`:gatewayAddress` must be a known gateway address. Returns `400` if malformed and `404` if the address is not a whitelisted gateway.
-
-#### Sample response
-
-```json
-{
-  "strategicReserves": "10000000000000000000",
-  "surplus": "1424707358963452827"
-}
-```
-
 ### `GET /analytics/collateralization-ratio/:gatewayAddress`
 
 Get the collateralization ratio for a given gateway's pegged token: the total backing value divided by the circulating supply. The backing is the sum of the strategic reserves, the protocol surplus and the liquid Treasury reserves (whitelisted holdings valued in the pegged token). Cached for 5 minutes.

--- a/api/src/analytics.ts
+++ b/api/src/analytics.ts
@@ -187,35 +187,6 @@ async function getBacking({
   };
 }
 
-/**
- * The strategic reserves are the mark-to-market value of yield-bearing
- * receipts held by the Treasury, the UMM role and the Operator (multisig).
- * The protocol surplus is any pegged token held in the Treasury, UMM or
- * YieldDistributor.
- *
- * This is useful to understand the health of the protocol and its ability to
- * cover redemptions for the given gateway's pegged token.
- */
-export async function getPeggedTokenBacking({
-  gatewayAddress,
-  url,
-}: {
-  gatewayAddress: Address;
-  url: string | undefined;
-}) {
-  const client = createMainnetClient(url);
-  const [peggedTokenAddress, treasuryAddress] = await Promise.all([
-    getPeggedToken(client, { address: gatewayAddress }),
-    getTreasury(client, { address: gatewayAddress }),
-  ]);
-  return getBacking({
-    client,
-    gatewayAddress,
-    peggedTokenAddress,
-    treasuryAddress,
-  });
-}
-
 // Converts the Treasury's whitelisted-token holdings into their pegged-token
 // equivalent using the gateway's on-chain previewRedeem rate, mirroring the
 // frontend's previous client-side calculation. A token whose redeem rate is

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -34,28 +34,6 @@ app.use("*", async function (c, next) {
 app.use("*", securityHeaders);
 
 app.get(
-  "/analytics/pegged-token-backing/:gatewayAddress",
-  validateGatewayAddress,
-  cache({
-    cacheControl: "max-age=15, stale-while-revalidate=45",
-    cacheName: "vetro-api",
-  }),
-  async function (c) {
-    try {
-      const url = c.env.CUSTOM_RPC_URL_MAINNET;
-      const gatewayAddress = c.get("gatewayAddress");
-      const data = await analytics.getPeggedTokenBacking({
-        gatewayAddress,
-        url,
-      });
-      return c.json(convertBigIntsToString(data));
-    } catch (error) {
-      throw new Error(`Failed to get pegged token backing: ${error.message}`);
-    }
-  },
-);
-
-app.get(
   "/analytics/collateralization-ratio/:gatewayAddress",
   validateGatewayAddress,
   cache({


### PR DESCRIPTION
### Description

Removes the `GET /analytics/pegged-token-backing/:gatewayAddress` endpoint. It has no consumer in the repo and is redundant: its `{ strategicReserves, surplus }` payload is a strict subset of `collateralization-ratio`, which returns the same two fields (from the same internal `getBacking` helper) plus `supply`, `treasuryTotal`, `total`, and `ratio`. This drops API surface to maintain and one fewer endpoint to cover in the upcoming cron + KV migration.

Drops the route, the exported `getPeggedTokenBacking`, and the README section. The internal `getBacking` is kept since `getCollateralizationRatio` still uses it.

### Screenshots

N/A

### Related issue(s)

Closes #569

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.