### PR TITLE
Add E2E test for whitelisted Earn withdraw

### DIFF
--- a/packages/earn/src/abi/stakingVaultAbi.ts
+++ b/packages/earn/src/abi/stakingVaultAbi.ts
@@ -36,6 +36,13 @@ export const stakingVaultAbi = [
     type: "function",
   },
   {
+    inputs: [],
+    name: "owner",
+    outputs: [{ type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
     inputs: [{ name: "account_", type: "address" }],
     name: "getActiveRequestIds",
     outputs: [{ type: "uint256[]" }],
@@ -141,6 +148,24 @@ export const stakingVaultAbi = [
       { name: "requestId", type: "uint256" },
       { name: "shares", type: "uint256" },
     ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  // Owner Functions
+  {
+    inputs: [{ name: "enabled_", type: "bool" }],
+    name: "updateCooldownEnabled",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { name: "account_", type: "address" },
+      { name: "status_", type: "bool" },
+    ],
+    name: "updateInstantWithdrawWhitelist",
+    outputs: [],
     stateMutability: "nonpayable",
     type: "function",
   },

--- a/web/e2e/earn.spec.ts
+++ b/web/e2e/earn.spec.ts
@@ -1,12 +1,29 @@
-import { TEST_ADDRESS } from "@hemilabs/anvil-fork-setup/utils";
+import {
+  TEST_ADDRESS,
+  TEST_PRIVATE_KEY,
+} from "@hemilabs/anvil-fork-setup/utils";
 import { expect } from "@playwright/test";
-import { parseAbiItem, parseEventLogs, parseUnits } from "viem";
-import { getTransactionReceipt } from "viem/actions";
-import { balanceOf } from "viem-erc20/actions";
+import {
+  createWalletClient,
+  http,
+  parseAbiItem,
+  parseEventLogs,
+  parseUnits,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import {
+  getTransactionReceipt,
+  waitForTransactionReceipt,
+  writeContract,
+} from "viem/actions";
+import { mainnet } from "viem/chains";
+import { approve, balanceOf } from "viem-erc20/actions";
 
+import { stakingVaultAbi } from "../../packages/earn/src/abi/stakingVaultAbi.ts";
 import { sVusdAddress } from "../../packages/earn/src/stakingVaultAddresses.ts";
+import { whitelistInstantWithdraw } from "../scripts/whitelistInstantWithdraw.ts";
 
-import { createEthereumClient } from "./anvil";
+import { ANVIL_URL, createEthereumClient } from "./anvil";
 import { test } from "./fixtures/wallet";
 import { getMainnetToken, waitForBalance } from "./helpers";
 
@@ -153,4 +170,136 @@ test("deposit VUSD into the Earn pool", async function ({
   await expect(page.getByText(/\([\d.,]+\s*VUSD\)/)).toBeVisible({
     timeout: 10_000,
   });
+});
+
+const WITHDRAW_DISPLAY = "3";
+const WITHDRAW_AMOUNT = parseUnits(WITHDRAW_DISPLAY, vusd.decimals);
+
+// The instant (one-step) withdraw is a plain ERC-4626 withdraw, which emits the
+// standard Withdraw(sender, receiver, owner, assets, shares). `assets` is the
+// VUSD paid out to the receiver and `shares` the sVUSD burned — both read
+// straight off the withdraw tx, no block-range scan.
+const withdrawEvent = parseAbiItem(
+  "event Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares)",
+);
+
+// Give the test account a real staked position by actually depositing VUSD into
+// the vault (approve + deposit) as the test account, signing directly against
+// Anvil rather than through the browser mock wallet. A real deposit leaves the
+// vault holding the underlying VUSD, so the later withdraw can pay out — minting
+// sVUSD via storage would leave the vault unbacked and the withdraw would revert.
+async function stakeVusd(assets: bigint) {
+  const walletClient = createWalletClient({
+    account: privateKeyToAccount(TEST_PRIVATE_KEY),
+    chain: mainnet,
+    transport: http(ANVIL_URL),
+  });
+
+  const approvalHash = await approve(walletClient, {
+    address: vusd.address,
+    amount: assets,
+    spender: sVusdAddress,
+  });
+  await waitForTransactionReceipt(walletClient, { hash: approvalHash });
+
+  const depositHash = await writeContract(walletClient, {
+    abi: stakingVaultAbi,
+    address: sVusdAddress,
+    args: [assets, TEST_ADDRESS],
+    functionName: "deposit",
+  });
+  await waitForTransactionReceipt(walletClient, { hash: depositHash });
+}
+
+test("withdraw VUSD from the Earn pool (whitelisted one-step exit)", async function ({
+  page,
+  walletTxHashes,
+}) {
+  const publicClient = createEthereumClient();
+
+  await stakeVusd(DEPOSIT_AMOUNT);
+  await whitelistInstantWithdraw({ address: TEST_ADDRESS, forkUrl: ANVIL_URL });
+
+  const [vusdBefore, svusdBefore] = await Promise.all([
+    balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: vusd.address,
+    }),
+    balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: sVusdAddress,
+    }),
+  ]);
+
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  await page.getByRole("link", { name: "Earn" }).click();
+  await expect(page).toHaveURL(/\/en\/earn/);
+
+  // Scope to the VUSD pool bar and open its Withdraw drawer. The bar is the only
+  // element holding both the "VUSD" label and a Withdraw button; `.last()` picks
+  // that innermost match rather than an ancestor container.
+  const vusdPool = page
+    .locator("div")
+    .filter({ has: page.getByText("VUSD", { exact: true }) })
+    .filter({ has: page.getByRole("button", { name: "Withdraw" }) })
+    .last();
+  await vusdPool.getByRole("button", { name: "Withdraw" }).click();
+
+  // The drawer slides in directly in withdraw mode.
+  await expect(
+    page.getByRole("heading", { name: "Manage your stake position" }),
+  ).toBeVisible();
+
+  await expect(page.getByText("Confirm withdrawal")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Request withdrawal" }),
+  ).toBeHidden();
+
+  await page
+    .locator('input[type="text"]:not([disabled])')
+    .first()
+    .fill(WITHDRAW_DISPLAY);
+
+  const submitButton = page
+    .locator("form")
+    .getByRole("button", { exact: true, name: "Withdraw" });
+  await expect(submitButton).toBeEnabled();
+  await submitButton.dispatchEvent("click");
+
+  await expect(page.getByText("Withdrawal complete")).toBeVisible({
+    timeout: 40_000,
+  });
+
+  const withdrawTxHash = walletTxHashes.at(-1);
+  expect(withdrawTxHash).toBeDefined();
+  const receipt = await getTransactionReceipt(publicClient, {
+    hash: withdrawTxHash!,
+  });
+  const withdrawLogs = parseEventLogs({
+    abi: [withdrawEvent],
+    args: { owner: TEST_ADDRESS },
+    eventName: "Withdraw",
+    logs: receipt.logs,
+  });
+  expect(withdrawLogs).toHaveLength(1);
+  const { assets: vusdWithdrawn, shares: svusdBurned } = withdrawLogs[0].args;
+  expect(vusdWithdrawn).toBe(WITHDRAW_AMOUNT);
+  expect(svusdBurned).toBeGreaterThan(0n);
+
+  // Assertion — VUSD balance rose by exactly the withdrawn assets and sVUSD
+  // dropped by exactly the burned shares.
+  await waitForBalance({ client: publicClient, token: vusd.address }).toBe(
+    vusdBefore + vusdWithdrawn,
+  );
+
+  const svusdAfter = await balanceOf(publicClient, {
+    account: TEST_ADDRESS,
+    address: sVusdAddress,
+  });
+  expect(svusdBefore - svusdBurned).toBe(svusdAfter);
 });

--- a/web/scripts/whitelistInstantWithdraw.ts
+++ b/web/scripts/whitelistInstantWithdraw.ts
@@ -1,0 +1,127 @@
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import {
+  type Address,
+  createPublicClient,
+  createTestClient,
+  http,
+  isAddress,
+  parseEther,
+} from "viem";
+import {
+  impersonateAccount,
+  readContract,
+  setBalance,
+  stopImpersonatingAccount,
+  waitForTransactionReceipt,
+  writeContract,
+} from "viem/actions";
+import { mainnet } from "viem/chains";
+
+import { stakingVaultAbi } from "../../packages/earn/src/abi/stakingVaultAbi.ts";
+import { sVusdAddress } from "../../packages/earn/src/stakingVaultAddresses.ts";
+
+// The StakingVault is Ownable2Step, so its owner-only setters can be called
+// directly after impersonating owner() — no role grant needed (unlike the
+// gateway's instant-redeem whitelist, which is gated behind MAINTAINER_ROLE).
+
+export async function whitelistInstantWithdraw({
+  address,
+  forkUrl = "http://127.0.0.1:8545",
+  vaultAddress = sVusdAddress,
+}: {
+  address: Address;
+  forkUrl?: string;
+  vaultAddress?: Address;
+}) {
+  const transport = http(forkUrl);
+
+  const publicClient = createPublicClient({ chain: mainnet, transport });
+  const testClient = createTestClient({
+    chain: mainnet,
+    mode: "anvil",
+    transport,
+  });
+
+  const [owner, isWhitelisted] = await Promise.all([
+    readContract(publicClient, {
+      abi: stakingVaultAbi,
+      address: vaultAddress,
+      functionName: "owner",
+    }),
+    readContract(publicClient, {
+      abi: stakingVaultAbi,
+      address: vaultAddress,
+      args: [address],
+      functionName: "instantWithdrawWhitelist",
+    }),
+  ]);
+
+  if (isWhitelisted) {
+    console.log(`${address} is already whitelisted for instant withdraw.`);
+    return;
+  }
+
+  await impersonateAccount(testClient, { address: owner });
+  await setBalance(testClient, { address: owner, value: parseEther("1") });
+
+  try {
+    // Enable cooldown so the non-whitelisted path is genuinely multi-step;
+    // this makes the whitelisted one-step path deterministic regardless of the
+    // fork's current cooldownEnabled state.
+    const enableHash = await writeContract(testClient, {
+      abi: stakingVaultAbi,
+      account: owner,
+      address: vaultAddress,
+      args: [true],
+      functionName: "updateCooldownEnabled",
+    });
+    await waitForTransactionReceipt(publicClient, { hash: enableHash });
+
+    const whitelistHash = await writeContract(testClient, {
+      abi: stakingVaultAbi,
+      account: owner,
+      address: vaultAddress,
+      args: [address, true],
+      functionName: "updateInstantWithdrawWhitelist",
+    });
+    await waitForTransactionReceipt(publicClient, { hash: whitelistHash });
+  } finally {
+    await stopImpersonatingAccount(testClient, { address: owner });
+  }
+
+  console.log(
+    `${address} whitelisted for instant withdraw on vault ${vaultAddress}.`,
+  );
+}
+
+// Allow running as a standalone script for consumers:
+//   node web/scripts/whitelistInstantWithdraw.ts --address 0x… [--fork-url …] [--vault …]
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { values } = parseArgs({
+    options: {
+      address: { short: "a", type: "string" },
+      "fork-url": { short: "f", type: "string" },
+      vault: { short: "v", type: "string" },
+    },
+    strict: true,
+  });
+
+  if (values.vault && !isAddress(values.vault, { strict: false })) {
+    console.error("Invalid --vault. Must be a valid address.");
+    process.exit(1);
+  }
+
+  if (!values.address || !isAddress(values.address, { strict: false })) {
+    console.error(
+      "Address is invalid. Usage: node web/scripts/whitelistInstantWithdraw.ts --address 0xYourAddress",
+    );
+    process.exit(1);
+  }
+
+  await whitelistInstantWithdraw({
+    address: values.address,
+    forkUrl: values["fork-url"],
+    vaultAddress: (values.vault as Address) ?? sVusdAddress,
+  });
+}

--- a/web/scripts/whitelistInstantWithdraw.ts
+++ b/web/scripts/whitelistInstantWithdraw.ts
@@ -57,11 +57,6 @@ export async function whitelistInstantWithdraw({
     }),
   ]);
 
-  if (isWhitelisted) {
-    console.log(`${address} is already whitelisted for instant withdraw.`);
-    return;
-  }
-
   await impersonateAccount(testClient, { address: owner });
   await setBalance(testClient, { address: owner, value: parseEther("1") });
 
@@ -78,14 +73,18 @@ export async function whitelistInstantWithdraw({
     });
     await waitForTransactionReceipt(publicClient, { hash: enableHash });
 
-    const whitelistHash = await writeContract(testClient, {
-      abi: stakingVaultAbi,
-      account: owner,
-      address: vaultAddress,
-      args: [address, true],
-      functionName: "updateInstantWithdrawWhitelist",
-    });
-    await waitForTransactionReceipt(publicClient, { hash: whitelistHash });
+    if (isWhitelisted) {
+      console.log(`${address} is already whitelisted for instant withdraw.`);
+    } else {
+      const whitelistHash = await writeContract(testClient, {
+        abi: stakingVaultAbi,
+        account: owner,
+        address: vaultAddress,
+        args: [address, true],
+        functionName: "updateInstantWithdrawWhitelist",
+      });
+      await waitForTransactionReceipt(publicClient, { hash: whitelistHash });
+    }
   } finally {
     await stopImpersonatingAccount(testClient, { address: owner });
   }


### PR DESCRIPTION
### Description

Adds an end-to-end (Playwright) test covering the Earn page's **whitelisted one-step withdraw** — a user who already holds sVUSD and is instant-withdraw whitelisted exits their staked position in a single ERC-4626 `withdraw`, bypassing the multi-day cooldown queue. This complements the existing deposit E2E test, so both sides of the Earn stake/unstake flow are now exercised against a real Anvil mainnet fork.

The test runs its setup on-chain (after the wallet fixture's per-test snapshot, so it's reverted afterward): it stakes VUSD to obtain a real, vault-backed sVUSD position, then enables cooldown and whitelists the account so the UI renders the one-step path. Enabling cooldown makes the scenario deterministic regardless of the fork's live state — it genuinely exercises the whitelist branch rather than passing coincidentally. It then drives the withdraw drawer, asserts the one-step UI ("Confirm withdrawal" step, "Withdraw" button — not "Request withdrawal"), and verifies exact balance deltas by parsing the `Withdraw(assets, shares)` event.

Supporting changes:
- **`web/scripts/whitelistInstantWithdraw.ts`** — a fork helper (mirroring `whitelistInstantRedeem.ts`) that impersonates the vault owner to enable cooldown and whitelist an account. The vault is `Ownable2Step`, so no role-granting is needed.
- **`packages/earn/src/abi/stakingVaultAbi.ts`** — adds `owner()` and the `updateCooldownEnabled` / `updateInstantWithdrawWhitelist` owner setters the helper needs (the app previously only read the whitelist).

### Screenshots

N/A — test-only change, no UI modifications.

### Checklist

- [x] Manual testing passed. (\`pnpm test:e2e earn\` — both Earn tests pass locally)
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A. (mirrors the undocumented \`whitelistInstantRedeem.ts\` script; no README section)
- [x] Environment variables set in CI, or N/A.