### PR TITLE
Add TextArea design system component

### DIFF
--- a/web/src/components/base/textarea/index.tsx
+++ b/web/src/components/base/textarea/index.tsx
@@ -1,0 +1,92 @@
+import { type ComponentProps, useId } from "react";
+
+import "./textarea.css";
+
+type TextAreaProps = Omit<ComponentProps<"textarea">, "className"> & {
+  error?: boolean;
+  errorMessage?: string;
+  helperText?: string;
+  label?: string;
+};
+
+type MessageProps = {
+  errorId: string;
+  errorMessage?: string;
+  helperId: string;
+  helperText?: string;
+};
+
+// The error message takes precedence over the helper text.
+const Message = function ({
+  errorId,
+  errorMessage,
+  helperId,
+  helperText,
+}: MessageProps) {
+  if (errorMessage) {
+    return (
+      <p
+        className="text-b-regular text-rose-600 transition-colors group-focus-within/textarea:text-gray-500"
+        id={errorId}
+        role="alert"
+      >
+        {errorMessage}
+      </p>
+    );
+  }
+  if (helperText) {
+    return (
+      <p className="text-caption text-gray-500" id={helperId}>
+        {helperText}
+      </p>
+    );
+  }
+  return null;
+};
+
+export const TextArea = function ({
+  error,
+  errorMessage,
+  helperText,
+  id,
+  label,
+  ...props
+}: TextAreaProps) {
+  const fallbackId = useId();
+  const textareaId = id ?? fallbackId;
+  const errorId = `${textareaId}-error`;
+  const helperId = `${textareaId}-helper`;
+  const invalid = error || Boolean(errorMessage);
+  const showHelper = !errorMessage && Boolean(helperText);
+
+  return (
+    <div className="group/textarea flex flex-col gap-2">
+      {label ? (
+        <label className="text-b-medium text-gray-900" htmlFor={textareaId}>
+          {label}
+        </label>
+      ) : null}
+      <textarea
+        {...props}
+        aria-describedby={
+          [
+            props["aria-describedby"],
+            errorMessage ? errorId : null,
+            showHelper ? helperId : null,
+          ]
+            .filter(Boolean)
+            .join(" ") || undefined
+        }
+        aria-invalid={invalid || undefined}
+        className="textarea--base"
+        id={textareaId}
+      />
+      <Message
+        errorId={errorId}
+        errorMessage={errorMessage}
+        helperId={helperId}
+        helperText={helperText}
+      />
+    </div>
+  );
+};

--- a/web/src/components/base/textarea/textarea.css
+++ b/web/src/components/base/textarea/textarea.css
@@ -1,0 +1,33 @@
+@reference "../../../index.css";
+
+.textarea--base {
+  @apply text-b-regular min-h-[151px] w-full resize-y rounded-xl bg-white py-2 pr-1.5 pl-3 text-gray-900 shadow-sm transition-shadow outline-none placeholder:text-gray-500;
+}
+
+.textarea--base:hover:not(:focus, [aria-invalid="true"]) {
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    0 1px 2px 0 rgba(0, 0, 0, 0.08),
+    0 7px 11px -6px rgba(0, 0, 0, 0.08);
+}
+
+.textarea--base:focus {
+  box-shadow:
+    var(--shadow-sm),
+    0 0 0 4px rgba(0, 0, 0, 0.12);
+}
+
+.textarea--base[aria-invalid="true"] {
+  box-shadow:
+    var(--shadow-sm),
+    0 0 0 1px rgba(255, 32, 86, 0.53),
+    0 0 1px 0 rgba(255, 32, 86, 0.48);
+}
+
+.textarea--base[aria-invalid="true"]:focus {
+  box-shadow:
+    0 0 0 4px rgba(255, 32, 86, 0.16),
+    0 0 1px 0 rgba(255, 32, 86, 0.48),
+    0 0 0 1px rgba(255, 32, 86, 0.53),
+    var(--shadow-sm);
+}

--- a/web/stories/textarea.stories.tsx
+++ b/web/stories/textarea.stories.tsx
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+import { TextArea } from "../src/components/base/textarea";
+
+const meta = {
+  argTypes: {
+    error: {
+      control: "boolean",
+    },
+    errorMessage: {
+      control: "text",
+    },
+    helperText: {
+      control: "text",
+    },
+  },
+  component: TextArea,
+  title: "Components/TextArea",
+} satisfies Meta<typeof TextArea>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const helperText = "Please enter as many details as you can.";
+const label = "What happened?";
+const placeholder =
+  "Describe what happened. Include the operation type and transaction hash if you have them.";
+
+export const Default: Story = {
+  args: {
+    helperText,
+    label,
+    placeholder,
+  },
+  render: function Render(args) {
+    const [value, setValue] = useState("");
+
+    return (
+      <div className="w-[352px]">
+        <TextArea
+          {...args}
+          onChange={(event) => setValue(event.target.value)}
+          value={value}
+        />
+      </div>
+    );
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    helperText,
+    label,
+    placeholder,
+  },
+  render: function Render(args) {
+    const [value, setValue] = useState(
+      "I tried to redeem VUSD but the transaction is stuck.",
+    );
+
+    return (
+      <div className="w-[352px]">
+        <TextArea
+          {...args}
+          onChange={(event) => setValue(event.target.value)}
+          value={value}
+        />
+      </div>
+    );
+  },
+};
+
+export const Error: Story = {
+  args: {
+    errorMessage: "Invalid input",
+    helperText,
+    label,
+    placeholder,
+  },
+  render: function Render(args) {
+    const [value, setValue] = useState("");
+
+    return (
+      <div className="w-[352px]">
+        <TextArea
+          {...args}
+          onChange={(event) => setValue(event.target.value)}
+          value={value}
+        />
+      </div>
+    );
+  },
+};
+
+export const States: Story = {
+  render: function Render() {
+    const [empty, setEmpty] = useState("");
+    const [filled, setFilled] = useState(
+      "I tried to redeem VUSD but the transaction is stuck.",
+    );
+    const [invalid, setInvalid] = useState("");
+
+    return (
+      <div className="flex w-[352px] flex-col gap-6">
+        <div>
+          <p className="text-xsm mb-2 font-medium text-gray-500">
+            Default with helper (hover and focus to see other states)
+          </p>
+          <TextArea
+            helperText={helperText}
+            label={label}
+            onChange={(event) => setEmpty(event.target.value)}
+            placeholder={placeholder}
+            value={empty}
+          />
+        </div>
+        <div>
+          <p className="text-xsm mb-2 font-medium text-gray-500">
+            Filled (with value)
+          </p>
+          <TextArea
+            helperText={helperText}
+            label={label}
+            onChange={(event) => setFilled(event.target.value)}
+            placeholder={placeholder}
+            value={filled}
+          />
+        </div>
+        <div>
+          <p className="text-xsm mb-2 font-medium text-gray-500">
+            Error (replaces the helper text; focus to see error + focus state)
+          </p>
+          <TextArea
+            errorMessage="Please describe what happened."
+            helperText={helperText}
+            label={label}
+            onChange={(event) => setInvalid(event.target.value)}
+            placeholder={placeholder}
+            value={invalid}
+          />
+        </div>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
### Description

Add a reusable `TextArea` base component for the design system, mirroring the existing `Input` control. It supports a label, helper text, and error states, with accessibility wired up via `aria-invalid` and `aria-describedby`. The error message takes precedence over the helper text. This is the text area used by the form in #550.

Includes a Storybook story covering the default, filled, error, and combined states.

### Screenshots

https://github.com/user-attachments/assets/7dd5af28-01bf-4cf4-a033-9f1647896377

### Related issue(s)

Related to #550

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.