### PR TITLE
internal-dashboard: update worker config, security headers

### DIFF
--- a/internal-dashboard/README.md
+++ b/internal-dashboard/README.md
@@ -19,6 +19,4 @@ pnpm tsc      # typecheck only
 
 ## Deployment
 
-Deployed to Cloudflare with `wrangler` (see `wrangler.jsonc`). The `staging` and
-`production` environments map to the `vetro-internal-dashboard-staging` and
-`vetro-internal-dashboard` Workers respectively.
+Deployed to Cloudflare with `wrangler` (see `wrangler.jsonc`).

--- a/internal-dashboard/src/index.ts
+++ b/internal-dashboard/src/index.ts
@@ -66,6 +66,13 @@ const rpcConnectSrc = (import.meta.env.VITE_RPC_URL_MAINNET ?? "")
   .split("+")
   .join(" ");
 
+// In dev mode, Vite injects an inline React Fast Refresh preamble script, so
+// 'unsafe-inline' is required.
+const scriptSrc = [
+  "'self'",
+  ...(import.meta.env.DEV ? ["'unsafe-inline'"] : []),
+].join(" ");
+
 const csp = [
   "base-uri 'none'",
   // The DEX tab reads Curve liquidity straight from the Curve API (pool list /
@@ -80,7 +87,7 @@ const csp = [
   // Token logos come from the Hemilabs token list (GitHub Pages), falling back
   // to the Curve/Sushi asset CDNs (jsDelivr).
   "img-src 'self' data: https://hemilabs.github.io https://cdn.jsdelivr.net",
-  "script-src 'self'",
+  `script-src ${scriptSrc}`,
   // Tailwind v4 injects styles via a <style> tag, so 'unsafe-inline' is needed.
   "style-src 'self' 'unsafe-inline'",
   "upgrade-insecure-requests",
@@ -90,8 +97,9 @@ const csp = [
 // Applied to all responses – these have meaningful effect on sub-resources.
 const commonHeaders = {
   "Content-Security-Policy": "default-src 'none'",
+  "Cross-Origin-Embedder-Policy": "credentialless",
   "Cross-Origin-Resource-Policy": "same-origin",
-  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Referrer-Policy": "no-referrer",
   "X-Content-Type-Options": "nosniff",
 };
 

--- a/internal-dashboard/wrangler.jsonc
+++ b/internal-dashboard/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "main": "src/index.ts",
-  "name": "vetro-internal-dashboard-staging",
+  "name": "vetro-internal-dashboard",
   "compatibility_date": "2026-02-05",
   "workers_dev": false,
   "preview_urls": true,
@@ -16,14 +16,6 @@
   "assets": {
     "binding": "ASSETS",
     "not_found_handling": "single-page-application",
-  },
-  "env": {
-    "production": {
-      "name": "vetro-internal-dashboard",
-      "preview_urls": false,
-    },
-    "staging": {
-      "name": "vetro-internal-dashboard-staging",
-    },
+    "run_worker_first": true,
   },
 }


### PR DESCRIPTION
### Description

Prepare the Vetro `internal-dashboard` app for deployment to CF Workers.

- Set `run_worker_first` for asset handling in the `vetro-internal-dashboard` worker
- Add `'unsafe-inline'` to CSP when running in Vite dev mode (app breaks otherwise)
- Change `Referrer-Policy: no-referrer` (for internal apps)
- Add `Cross-Origin-Embedded-Policy: credentialless` to further isolate the app (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Embedder-Policy)

For COEP, `require-corp` would work if `https://hemilabs.github.io` responded with a CORP header (perhaps this should move to a CF Worker too?) - it is already supported by jsdelivr.

Tested with `pnpm dev` and `pnpm preview` locally.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
N/A

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #
Related to #474

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
