### PR TITLE
Warm treasury analytics endpoint via KV cron

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -22,6 +22,8 @@ import { getTotalDepositsHistory } from "./total-deposits-history.ts";
 import { createOriginFn, parseOrigins } from "./validate-origin.ts";
 import * as variableStake from "./variable-stake.ts";
 import { validPeriods as vaultHistoryValidPeriods } from "./vault-history-period.ts";
+import { readWarmedTask, warmScheduled } from "./warm-cache.ts";
+import { treasuryTask, warmTasks } from "./warm-tasks.ts";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -126,13 +128,13 @@ app.get(
   }),
   async function (c) {
     try {
-      const url = c.env.CUSTOM_RPC_URL_MAINNET;
       const gatewayAddress = c.get("gatewayAddress");
-      const data = await analytics.getTreasuryComposition({
-        gatewayAddress,
-        url,
+      const data = await readWarmedTask({
+        c,
+        item: gatewayAddress,
+        task: treasuryTask,
       });
-      return c.json(convertBigIntsToString(data));
+      return c.json(data);
     } catch (error) {
       throw new Error(`Failed to get treasury composition: ${error.message}`);
     }
@@ -403,11 +405,22 @@ app.onError(function (error, c) {
   return c.json({ error: "Internal Server Error" }, 500);
 });
 
+const handler = Object.assign(app, {
+  async scheduled(event: ScheduledController, env: Env) {
+    await warmScheduled({
+      cron: event.cron,
+      env,
+      kv: env.CACHE_KV,
+      tasks: warmTasks,
+    });
+  },
+}) satisfies ExportedHandler<Env>;
+
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
     enableLogs: true,
     environment: "production",
   }),
-  app,
+  handler,
 );

--- a/api/src/warm-cache.ts
+++ b/api/src/warm-cache.ts
@@ -1,0 +1,84 @@
+import * as Sentry from "@sentry/cloudflare";
+import type { Context } from "hono";
+
+/**
+ * A cache-warming task: one endpoint's KV values, refreshed on a cron schedule.
+ */
+export type WarmTask<Item> = {
+  // The cron expression (must match one in wrangler `triggers.crons`)
+  cron: string;
+  items: readonly Item[];
+  key: (item: Item) => string;
+  produce: (item: Item, env: Env) => Promise<unknown>;
+};
+
+// Warmed values expire after 15 minutes: if the cron stalls (or `produce()` fails)
+const cacheTtl = 15 * 60;
+
+/**
+ * Read the warmed value for one `item` of a `task` from within a request. On a
+ * KV miss (fresh deploy, or an item added before its first cron tick) fall back
+ * to computing on demand and write through so the next reader gets a fast hit;
+ * the write is backgrounded via `waitUntil` so the caller doesn't block on KV.
+ */
+export async function readWarmedTask<Item>({
+  c,
+  item,
+  task,
+}: {
+  c: Context<{ Bindings: Env }>;
+  item: Item;
+  task: WarmTask<Item>;
+}) {
+  const key = task.key(item);
+  const kv = c.env.CACHE_KV;
+  const cached = await kv.get(key, "json");
+  if (cached !== null) {
+    return cached;
+  }
+  const data = await task.produce(item, c.env);
+  c.executionCtx.waitUntil(
+    kv.put(key, JSON.stringify(data), { expirationTtl: cacheTtl }),
+  );
+  return data;
+}
+
+/**
+ * Warm every item of every task whose cron matches the fired one. Failures are
+ * isolated per key: a compute or write error is reported to Sentry and leaves
+ * the last-known-good KV value untouched.
+ */
+export async function warmScheduled({
+  cron,
+  env,
+  kv,
+  tasks,
+}: {
+  cron: string;
+  env: Env;
+  kv: KVNamespace;
+  // Heterogeneous registry: tasks warm different item types (gateways, market
+  // ids, ...), so no single element type fits. Each task is self-consistent.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tasks: readonly WarmTask<any>[];
+}) {
+  const due = tasks.filter((task) => task.cron === cron);
+  await Promise.all(
+    due.flatMap((task) =>
+      task.items.map(async function (item) {
+        try {
+          const key = task.key(item);
+          const data = await task.produce(item, env);
+          if (data === null || data === undefined) {
+            throw new Error(`Warm task produced no data for ${key}`);
+          }
+          await kv.put(key, JSON.stringify(data), {
+            expirationTtl: cacheTtl,
+          });
+        } catch (error) {
+          Sentry.captureException(error);
+        }
+      }),
+    ),
+  );
+}

--- a/api/src/warm-cache.ts
+++ b/api/src/warm-cache.ts
@@ -37,9 +37,15 @@ export async function readWarmedTask<Item>({
     return cached;
   }
   const data = await task.produce(item, c.env);
-  c.executionCtx.waitUntil(
-    kv.put(key, JSON.stringify(data), { expirationTtl: cacheTtl }),
-  );
+  // Write through so the next reader gets a fast hit, but never cache empty
+  // data and report background write failures — mirroring the cron path.
+  if (data !== null && data !== undefined) {
+    c.executionCtx.waitUntil(
+      kv
+        .put(key, JSON.stringify(data), { expirationTtl: cacheTtl })
+        .catch((error) => Sentry.captureException(error)),
+    );
+  }
   return data;
 }
 

--- a/api/src/warm-tasks.ts
+++ b/api/src/warm-tasks.ts
@@ -1,0 +1,20 @@
+import { gatewayAddresses } from "@vetro-protocol/gateway";
+import type { Address } from "viem";
+
+import { getTreasuryComposition } from "./analytics.ts";
+import { convertBigIntsToString } from "./convert-bigints-to-string.ts";
+import type { WarmTask } from "./warm-cache.ts";
+
+// Warms `GET /analytics/treasury/:gatewayAddress`
+export const treasuryTask: WarmTask<Address> = {
+  cron: "* * * * *",
+  items: gatewayAddresses,
+  key: (gatewayAddress) => `analytics:treasury:${gatewayAddress}`,
+  produce: (gatewayAddress, env) =>
+    getTreasuryComposition({
+      gatewayAddress,
+      url: env.CUSTOM_RPC_URL_MAINNET,
+    }).then(convertBigIntsToString),
+};
+
+export const warmTasks = [treasuryTask];

--- a/api/src/worker-env.d.ts
+++ b/api/src/worker-env.d.ts
@@ -2,6 +2,7 @@
 // When you add or rename a binding in `wrangler.jsonc`,
 // update this interface to match.
 interface Env {
+  CACHE_KV: KVNamespace;
   CUSTOM_RPC_URL_MAINNET?: string;
   MERKL_OPPORTUNITY_SVETBTC?: string;
   MERKL_OPPORTUNITY_SVUSD?: string;

--- a/api/test/warm-cache.test.ts
+++ b/api/test/warm-cache.test.ts
@@ -1,0 +1,170 @@
+import * as Sentry from "@sentry/cloudflare";
+import type { Context } from "hono";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  readWarmedTask,
+  type WarmTask,
+  warmScheduled,
+} from "../src/warm-cache.ts";
+
+vi.mock("@sentry/cloudflare", () => ({
+  captureException: vi.fn(),
+}));
+
+// A minimal in-memory KV that records writes and lets tests force put failures.
+function createFakeKv({
+  putError,
+  store = {},
+}: {
+  putError?: Error;
+  store?: Record<string, unknown>;
+} = {}) {
+  const puts: { key: string; value: string }[] = [];
+  return {
+    get: vi.fn(async (key: string) => (key in store ? store[key] : null)),
+    put: vi.fn(async function (key: string, value: string) {
+      if (putError) {
+        throw putError;
+      }
+      puts.push({ key, value });
+    }),
+    puts,
+  };
+}
+
+// A fake Hono context that runs `waitUntil` work so tests can await writes.
+function createFakeContext(kv: unknown) {
+  const pending: Promise<unknown>[] = [];
+  const c = {
+    env: { CACHE_KV: kv },
+    executionCtx: {
+      waitUntil: (promise: Promise<unknown>) => pending.push(promise),
+    },
+  } as unknown as Context<{ Bindings: Env }>;
+  return {
+    c,
+    settled: () => Promise.all(pending),
+  };
+}
+
+const task: WarmTask<string> = {
+  cron: "* * * * *",
+  items: ["a", "b"],
+  key: (item) => `key:${item}`,
+  produce: vi.fn(),
+};
+
+describe("warm-cache/readWarmedTask", function () {
+  it("returns the cached value without producing on a hit", async function () {
+    const kv = createFakeKv({ store: { "key:a": { cached: true } } });
+    const { c } = createFakeContext(kv);
+
+    const data = await readWarmedTask({ c, item: "a", task });
+
+    expect(data).toEqual({ cached: true });
+    expect(task.produce).not.toHaveBeenCalled();
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it("produces, returns and writes through on a miss", async function () {
+    const kv = createFakeKv();
+    vi.mocked(task.produce).mockResolvedValue({ fresh: true });
+    const { c, settled } = createFakeContext(kv);
+
+    const data = await readWarmedTask({ c, item: "a", task });
+    await settled();
+
+    expect(data).toEqual({ fresh: true });
+    expect(task.produce).toHaveBeenCalledWith("a", c.env);
+    expect(kv.puts).toEqual([
+      { key: "key:a", value: JSON.stringify({ fresh: true }) },
+    ]);
+  });
+
+  it("returns empty data on a miss but does not cache it", async function () {
+    const kv = createFakeKv();
+    vi.mocked(task.produce).mockResolvedValue(undefined);
+    const { c, settled } = createFakeContext(kv);
+
+    const data = await readWarmedTask({ c, item: "a", task });
+    await settled();
+
+    expect(data).toBeUndefined();
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it("reports a background write failure to Sentry", async function () {
+    const putError = new Error("kv down");
+    const kv = createFakeKv({ putError });
+    vi.mocked(task.produce).mockResolvedValue({ fresh: true });
+    const { c, settled } = createFakeContext(kv);
+
+    const data = await readWarmedTask({ c, item: "a", task });
+    await settled();
+
+    expect(data).toEqual({ fresh: true });
+    expect(Sentry.captureException).toHaveBeenCalledWith(putError);
+  });
+});
+
+describe("warm-cache/warmScheduled", function () {
+  it("only warms tasks whose cron matches the fired one", async function () {
+    const kv = createFakeKv();
+    const other: WarmTask<string> = {
+      cron: "*/5 * * * *",
+      items: ["z"],
+      key: (item) => `other:${item}`,
+      produce: vi.fn().mockResolvedValue({ v: 1 }),
+    };
+    vi.mocked(task.produce).mockResolvedValue({ v: 1 });
+
+    await warmScheduled({
+      cron: "* * * * *",
+      env: {} as Env,
+      kv: kv as unknown as KVNamespace,
+      tasks: [task, other],
+    });
+
+    expect(other.produce).not.toHaveBeenCalled();
+    expect(kv.puts.map((p) => p.key)).toEqual(["key:a", "key:b"]);
+  });
+
+  it("isolates per-key failures and reports them to Sentry", async function () {
+    const kv = createFakeKv();
+    vi.mocked(task.produce).mockImplementation(async function (item) {
+      if (item === "a") {
+        throw new Error("produce a failed");
+      }
+      return { item };
+    });
+
+    await warmScheduled({
+      cron: "* * * * *",
+      env: {} as Env,
+      kv: kv as unknown as KVNamespace,
+      tasks: [task],
+    });
+
+    // The failing item is skipped; the healthy one is still warmed.
+    expect(kv.puts).toEqual([
+      { key: "key:b", value: JSON.stringify({ item: "b" }) },
+    ]);
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats empty produced data as a failure and leaves KV untouched", async function () {
+    const kv = createFakeKv();
+    vi.mocked(task.produce).mockResolvedValue(null);
+
+    await warmScheduled({
+      cron: "* * * * *",
+      env: {} as Env,
+      kv: kv as unknown as KVNamespace,
+      tasks: [{ ...task, items: ["a"] }],
+    });
+
+    expect(kv.put).not.toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+});

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -15,6 +15,16 @@
       "enabled": true,
     },
   },
+  // Runs locally, no real binding
+  "kv_namespaces": [
+    {
+      "binding": "CACHE_KV",
+      "id": "00000000000000000000000000000000",
+    },
+  ],
+  "triggers": {
+    "crons": ["* * * * *"],
+  },
   "vars": {
     "MERKL_OPPORTUNITY_SVETBTC": "",
     "MERKL_OPPORTUNITY_SVUSD": "",
@@ -24,6 +34,15 @@
   "env": {
     "staging": {
       "name": "vetro-api-staging",
+      "kv_namespaces": [
+        {
+          "binding": "CACHE_KV",
+          "id": "6178978b72a04fff9d90d9f994787ba3",
+        },
+      ],
+      "triggers": {
+        "crons": ["* * * * *"],
+      },
       "vars": {
         "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
         "ORIGINS": "https://*.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev",
@@ -34,6 +53,15 @@
     "production": {
       "name": "vetro-api",
       "preview_urls": false,
+      "kv_namespaces": [
+        {
+          "binding": "CACHE_KV",
+          "id": "b3c5b487520e40df8785dc40e797aadb",
+        },
+      ],
+      "triggers": {
+        "crons": ["* * * * *"],
+      },
       "observability": {
         "enabled": true,
         "head_sampling_rate": 0.1,


### PR DESCRIPTION
### Description

Adds cron-based cache warming for the treasury analytics endpoint (`GET /analytics/treasury/:gatewayAddress`), the first analytics endpoint to move off live per-request RPC (see #574).

A Cloudflare cron runs every minute and precomputes each gateway's treasury composition into a `CACHE_KV` namespace. The endpoint now reads the warmed value from KV instead of composing it from a live RPC call on the request path. On a KV miss (fresh deploy, or a gateway added before its first cron tick) it falls back to computing on demand and writes through in the background via `waitUntil`, so there's no correctness regression — only added latency on that one read.

Warmed values carry a 15-minute TTL: if the cron stalls or the RPC keeps failing, a read eventually misses KV and falls back to live compute (recovering, or surfacing a 500) rather than serving indefinitely-stale reserve data. The `scheduled()` handler is attached to the Hono `app` (via `Object.assign`) rather than a fresh handler object so `Sentry.withSentry` keeps its Hono error instrumentation.

The mechanism is generic (`WarmTask` + `warmScheduled`), so the remaining analytics endpoints in #574 can be added as additional tasks.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #574

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
