### PR TITLE
subgraph: use npm_execpath instead of npm

### DIFF
--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -3,17 +3,17 @@
   "version": "1.6.0",
   "license": "MIT",
   "scripts": {
-    "prebuild": "npm run codegen",
+    "prebuild": "$npm_execpath run codegen",
     "build": "graph build",
     "codegen": "graph codegen",
     "create-local": "graph create --node http://localhost:8020/ $npm_package_name",
     "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ $npm_package_name --version-label $npm_package_version",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 $npm_package_name --version-label $npm_package_version",
     "graph:auth": "graph auth",
-    "postinstall": "npm run codegen",
+    "postinstall": "$npm_execpath run codegen",
     "remove-local": "graph remove --node http://localhost:8020/ $npm_package_name",
     "tag": "scripts/tag-subgraph.sh",
-    "pretest": "npm run codegen",
+    "pretest": "$npm_execpath run codegen",
     "test": "graph test --version=0.6.0"
   },
   "dependencies": {


### PR DESCRIPTION
### Description

The subgraph package previously executed `npm run codegen` in `prebuild`, `postinstall` and `pretest` hooks - despite the project using `pnpm`. This caused `npm` to be executed by `pnpm`, requiring both dependency managers to be installed.

Instead, use `$npm_execpath` to use whichever package manager is already in use.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #
Related to #

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
