### PR TITLE
Warm TVL and collateralization-ratio via KV cron

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -26,6 +26,7 @@ import { readWarmedTask, warmScheduled } from "./warm-cache.ts";
 import {
   collateralizationRatioTask,
   treasuryTask,
+  tvlTask,
   warmTasks,
 } from "./warm-tasks.ts";
 
@@ -72,10 +73,13 @@ app.get(
   }),
   async function (c) {
     try {
-      const url = c.env.CUSTOM_RPC_URL_MAINNET;
       const gatewayAddress = c.get("gatewayAddress");
-      const data = await analytics.getTvl({ gatewayAddress, url });
-      return c.json(convertBigIntsToString(data));
+      const data = await readWarmedTask({
+        c,
+        item: gatewayAddress,
+        task: tvlTask,
+      });
+      return c.json(data);
     } catch (error) {
       throw new Error(`Failed to get TVL: ${error.message}`);
     }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -23,7 +23,11 @@ import { createOriginFn, parseOrigins } from "./validate-origin.ts";
 import * as variableStake from "./variable-stake.ts";
 import { validPeriods as vaultHistoryValidPeriods } from "./vault-history-period.ts";
 import { readWarmedTask, warmScheduled } from "./warm-cache.ts";
-import { treasuryTask, warmTasks } from "./warm-tasks.ts";
+import {
+  collateralizationRatioTask,
+  treasuryTask,
+  warmTasks,
+} from "./warm-tasks.ts";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -39,18 +43,18 @@ app.get(
   "/analytics/collateralization-ratio/:gatewayAddress",
   validateGatewayAddress,
   cache({
-    cacheControl: "max-age=300",
+    cacheControl: "max-age=60",
     cacheName: "vetro-api",
   }),
   async function (c) {
     try {
-      const url = c.env.CUSTOM_RPC_URL_MAINNET;
       const gatewayAddress = c.get("gatewayAddress");
-      const data = await analytics.getCollateralizationRatio({
-        gatewayAddress,
-        url,
+      const data = await readWarmedTask({
+        c,
+        item: gatewayAddress,
+        task: collateralizationRatioTask,
       });
-      return c.json(convertBigIntsToString(data));
+      return c.json(data);
     } catch (error) {
       throw new Error(
         `Failed to get collateralization ratio: ${error.message}`,

--- a/api/src/warm-tasks.ts
+++ b/api/src/warm-tasks.ts
@@ -1,7 +1,10 @@
 import { gatewayAddresses } from "@vetro-protocol/gateway";
 import type { Address } from "viem";
 
-import { getTreasuryComposition } from "./analytics.ts";
+import {
+  getCollateralizationRatio,
+  getTreasuryComposition,
+} from "./analytics.ts";
 import { convertBigIntsToString } from "./convert-bigints-to-string.ts";
 import type { WarmTask } from "./warm-cache.ts";
 
@@ -17,4 +20,17 @@ export const treasuryTask: WarmTask<Address> = {
     }).then(convertBigIntsToString),
 };
 
-export const warmTasks = [treasuryTask];
+// Warms `GET /analytics/collateralization-ratio/:gatewayAddress`
+export const collateralizationRatioTask: WarmTask<Address> = {
+  cron: "*/5 * * * *",
+  items: gatewayAddresses,
+  key: (gatewayAddress) =>
+    `analytics:collateralization-ratio:${gatewayAddress}`,
+  produce: (gatewayAddress, env) =>
+    getCollateralizationRatio({
+      gatewayAddress,
+      url: env.CUSTOM_RPC_URL_MAINNET,
+    }).then(convertBigIntsToString),
+};
+
+export const warmTasks = [treasuryTask, collateralizationRatioTask];

--- a/api/src/warm-tasks.ts
+++ b/api/src/warm-tasks.ts
@@ -4,6 +4,7 @@ import type { Address } from "viem";
 import {
   getCollateralizationRatio,
   getTreasuryComposition,
+  getTvl,
 } from "./analytics.ts";
 import { convertBigIntsToString } from "./convert-bigints-to-string.ts";
 import type { WarmTask } from "./warm-cache.ts";
@@ -33,4 +34,16 @@ export const collateralizationRatioTask: WarmTask<Address> = {
     }).then(convertBigIntsToString),
 };
 
-export const warmTasks = [treasuryTask, collateralizationRatioTask];
+// Warms `GET /analytics/tvl/:gatewayAddress`
+export const tvlTask: WarmTask<Address> = {
+  cron: "* * * * *",
+  items: gatewayAddresses,
+  key: (gatewayAddress) => `analytics:tvl:${gatewayAddress}`,
+  produce: (gatewayAddress, env) =>
+    getTvl({
+      gatewayAddress,
+      url: env.CUSTOM_RPC_URL_MAINNET,
+    }).then(convertBigIntsToString),
+};
+
+export const warmTasks = [treasuryTask, collateralizationRatioTask, tvlTask];

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -22,8 +22,12 @@
       "id": "00000000000000000000000000000000",
     },
   ],
+  // Inherited by all environments
   "triggers": {
-    "crons": ["* * * * *"],
+    "crons": [
+      "* * * * *", // every minute
+      "*/5 * * * *", // every 5 minutes
+    ],
   },
   "vars": {
     "MERKL_OPPORTUNITY_SVETBTC": "",
@@ -40,9 +44,6 @@
           "id": "6178978b72a04fff9d90d9f994787ba3",
         },
       ],
-      "triggers": {
-        "crons": ["* * * * *"],
-      },
       "vars": {
         "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
         "ORIGINS": "https://*.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev",
@@ -59,9 +60,6 @@
           "id": "b3c5b487520e40df8785dc40e797aadb",
         },
       ],
-      "triggers": {
-        "crons": ["* * * * *"],
-      },
       "observability": {
         "enabled": true,
         "head_sampling_rate": 0.1,


### PR DESCRIPTION
### Description

Continues #574 — moving the API's global analytics endpoints off live per-request RPC and onto the KV-warmed path established in #577. This PR adds the next two gateway-keyed endpoints:

- `GET /analytics/collateralization-ratio/:gatewayAddress` — warmed every 5 min. Its edge cache is dropped from 300s to 60s: now that a warm read is a ~6ms KV lookup instead of a ~1s RPC call, we halve worst-case staleness at negligible latency cost.
- `GET /analytics/tvl/:gatewayAddress` — warmed on the existing 1-min cron; its 60s edge cache is unchanged, so no wrangler change was needed.

Each handler now reads its warmed KV value with on-demand fallback + write-through on a miss, reusing the generic `WarmTask` + `readWarmedTask` mechanism from #577. Response shapes are unchanged. Also deduplicates `triggers.crons` into the single top-level wrangler block — it's an inheritable key, so staging and production inherit it without repeating it per env.

**Commits:**

- 3a5cbf5 Warm collateralization-ratio via KV cron
- 2cce436 Warm TVL analytics via KV cron

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #574

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A. _(N/A — the `warm-cache` helper tests cover the mechanism; per #577, adding a task needs no per-task test.)_
- [x] Documentation updated, or N/A. _(N/A — response shapes unchanged.)_
- [x] Environment variables set in CI, or N/A. _(N/A — reuses the `CACHE_KV` binding from #577.)_
