### PR TITLE
Remove @vitest/coverage-v8 from knip exclusion

### DIFF
--- a/.knip.json
+++ b/.knip.json
@@ -1,6 +1,6 @@
 {
   "ignore": ["web/scripts/*"],
-  "ignoreDependencies": ["@vitest/coverage-v8", "eslint-config-prettier"],
+  "ignoreDependencies": ["eslint-config-prettier"],
   "ignoreWorkspaces": ["internal-dashboard"],
   "workspaces": {
     "api": {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

`@vitest/coverage-v8` was incorrectly ignored in knip. See warning when running `npm run deps:check` in [this job](https://github.com/vetro-protocol/vetro-monorepo/actions/runs/28613827338/job/84852580053?pr=581),

> Run pnpm run --if-present deps:check
>
> @vetro-protocol/monorepo@1.0.0 deps:check /home/runner/work/vetro-monorepo/vetro-monorepo
> knip
>
> Configuration hints (1)
> @vitest/coverage-v8    .knip.json  Remove from ignoreDependencies

No more warning

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
