### PR TITLE
Warm staked analytics via KV cron

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -5,7 +5,6 @@ import { cache } from "hono/cache";
 import { cors } from "hono/cors";
 import type { Address } from "viem";
 
-import * as analytics from "./analytics.ts";
 import { getApyHistory } from "./apy-history.ts";
 import * as borrow from "./borrow.ts";
 import { convertBigIntsToString } from "./convert-bigints-to-string.ts";
@@ -25,6 +24,7 @@ import { validPeriods as vaultHistoryValidPeriods } from "./vault-history-period
 import { readWarmedTask, warmScheduled } from "./warm-cache.ts";
 import {
   collateralizationRatioTask,
+  stakedTask,
   treasuryTask,
   tvlTask,
   warmTasks,
@@ -95,10 +95,13 @@ app.get(
   }),
   async function (c) {
     try {
-      const url = c.env.CUSTOM_RPC_URL_MAINNET;
       const gatewayAddress = c.get("gatewayAddress");
-      const data = await analytics.getStaked({ gatewayAddress, url });
-      return c.json(convertBigIntsToString(data));
+      const data = await readWarmedTask({
+        c,
+        item: gatewayAddress,
+        task: stakedTask,
+      });
+      return c.json(data);
     } catch (error) {
       throw new Error(`Failed to get staked total: ${error.message}`);
     }

--- a/api/src/warm-tasks.ts
+++ b/api/src/warm-tasks.ts
@@ -3,6 +3,7 @@ import type { Address } from "viem";
 
 import {
   getCollateralizationRatio,
+  getStaked,
   getTreasuryComposition,
   getTvl,
 } from "./analytics.ts";
@@ -46,4 +47,21 @@ export const tvlTask: WarmTask<Address> = {
     }).then(convertBigIntsToString),
 };
 
-export const warmTasks = [treasuryTask, collateralizationRatioTask, tvlTask];
+// Warms `GET /analytics/staked/:gatewayAddress`
+export const stakedTask: WarmTask<Address> = {
+  cron: "* * * * *",
+  items: gatewayAddresses,
+  key: (gatewayAddress) => `analytics:staked:${gatewayAddress}`,
+  produce: (gatewayAddress, env) =>
+    getStaked({
+      gatewayAddress,
+      url: env.CUSTOM_RPC_URL_MAINNET,
+    }).then(convertBigIntsToString),
+};
+
+export const warmTasks = [
+  treasuryTask,
+  collateralizationRatioTask,
+  tvlTask,
+  stakedTask,
+];


### PR DESCRIPTION
### Description

Move `GET /analytics/staked/:gatewayAddress` to the KV-warmed path — the fourth endpoint migrated in #574, after `treasury`, `collateralization-ratio`, and `tvl`. Previously the handler recomputed on every cache miss, so the unlucky request ate the full ~0.5s RPC latency; now it reads a value pre-warmed by the cron, targeting sub-100ms on every request.

- `warm-tasks.ts` — adds `stakedTask` (mirrors `tvlTask`): warms `analytics:staked:<gateway>` for every gateway on the existing 1-min cron, reusing `getStaked` unchanged.
- `index.ts` — the handler now reads the warmed value via `readWarmedTask` (KV read → on-demand fallback + write-through on a miss). The 60s edge `cache()` and `validateGatewayAddress` middleware are untouched. Also drops the now-orphaned `import * as analytics` — this handler was its last consumer.

No `wrangler.jsonc` change (the `* * * * *` cron and `CACHE_KV` binding already exist) and no `README.md` change (response shape unchanged: `{ "staked": "<raw uint256>" }`).

### Screenshots

N/A — API change, no UI.

### Related issue(s)

Related #574

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A. — N/A: generic `warm-cache` helper unchanged; `warm-tasks.ts` is declarative config (matches the tvl PR precedent). `pnpm test` (109) passes.
- [x] Documentation updated, or N/A. — N/A: response shape unchanged.
- [x] Environment variables set in CI, or N/A. — N/A.