### PR TITLE
Add contact form API endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -317,8 +317,8 @@ Secrets are set separately using the Wrangler CLI.
 | Variable                  | Description                                                                                                   | Default                 |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------- |
 | CONTACT_FORM_ENABLED      | Feature toggle for `POST /contact`. When not `"true"`, the endpoint returns `404`.                            | `"false"`               |
-| CONTACT_FORM_RECIPIENT    | Destination address for contact form emails. Must be a verified Email Routing destination.                    |                         |
-| CONTACT_FORM_SENDER       | `from` address for contact form emails. Its domain must be a verified Email Routing sending domain.           |                         |
+| CONTACT_FORM_RECIPIENT    | Destination address for contact form emails. Must be a verified Email Routing destination.                    | `support@vetro.org`     |
+| CONTACT_FORM_SENDER       | `from` address for contact form emails. Its domain must be a verified Email Routing sending domain.           | `noreply@vetro.org`     |
 | CUSTOM_RPC_URL_MAINNET    | Ethereum RPC node URL(s). Overrides `viem`'s default. Several URLs joined by `+` become a fallback transport. |                         |
 | MERKL_OPPORTUNITY_SVETBTC | Merkl opportunity id for the sVetBTC staking vault. Optional; if unset, that vault yields no rewards.         |                         |
 | MERKL_OPPORTUNITY_SVUSD   | Merkl opportunity id for the sVUSD staking vault. Optional; if unset, that vault yields no rewards.           |                         |

--- a/api/README.md
+++ b/api/README.md
@@ -284,6 +284,8 @@ Returns all user's variable stake exit tickets to i.e. allow claiming the withdr
 Submit a support request. The contents are emailed to the configured recipient
 using the Cloudflare `send_email` binding (the recipient must be a verified
 Email Routing destination; the sender address comes from `CONTACT_FORM_SENDER`).
+A confirmation email is also sent to the submitter acknowledging their request;
+its replies route back to `CONTACT_FORM_RECIPIENT`.
 
 Gated by the `CONTACT_FORM_ENABLED` feature toggle: when it is not `"true"` the
 endpoint behaves as if it does not exist and returns `404`.
@@ -304,29 +306,32 @@ endpoint behaves as if it does not exist and returns `404`.
 
 #### Response
 
-Returns `204 No Content` with an empty body once the email is sent.
+Returns `204 No Content` with an empty body once the support email is sent. The
+confirmation email to the submitter is best-effort: if it fails, the failure is
+reported to Sentry and the response is still `204`.
 
 Returns `404` when the feature is disabled, `400` for an invalid body / email /
-category / message, and `500` if sending fails.
+category / message, and `500` if sending the support email fails.
 
 ## Configuration
 
 Environment variables are configured in `wrangler.jsonc`.
 Secrets are set separately using the Wrangler CLI.
 
-| Variable                  | Description                                                                                                   | Default                 |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| CONTACT_FORM_ENABLED      | Feature toggle for `POST /contact`. When not `"true"`, the endpoint returns `404`.                            | `"false"`               |
-| CONTACT_FORM_RECIPIENT    | Destination address for contact form emails. Must be a verified Email Routing destination.                    | `support@vetro.org`     |
-| CONTACT_FORM_SENDER       | `from` address for contact form emails. Its domain must be a verified Email Routing sending domain.           | `noreply@vetro.org`     |
-| CUSTOM_RPC_URL_MAINNET    | Ethereum RPC node URL(s). Overrides `viem`'s default. Several URLs joined by `+` become a fallback transport. |                         |
-| MERKL_OPPORTUNITY_SVETBTC | Merkl opportunity id for the sVetBTC staking vault. Optional; if unset, that vault yields no rewards.         |                         |
-| MERKL_OPPORTUNITY_SVUSD   | Merkl opportunity id for the sVUSD staking vault. Optional; if unset, that vault yields no rewards.           |                         |
-| ORIGINS                   | Comma-separated list of allowed origins. (1)                                                                  | `http://localhost:5173` |
-| SENTRY_DSN                | Sentry DSN. When unset, Sentry is disabled.                                                                   |                         |
-| SUBGRAPH_API_KEY          | The subgraph API key.                                                                                         |                         |
-| SUBGRAPH_ID               | The subgraph id.                                                                                              |                         |
-| SUBGRAPH_URL_TEMPLATE     | The subgraph URL template. (2)                                                                                | (localhost)             |
+| Variable                  | Description                                                                                                   | Default                   |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| CONTACT_FORM_ENABLED      | Feature toggle for `POST /contact`. When not `"true"`, the endpoint returns `404`.                            | `"false"`                 |
+| CONTACT_FORM_RECIPIENT    | Destination address for contact form emails. Must be a verified Email Routing destination.                    | `support@vetro.org`       |
+| CONTACT_FORM_SENDER       | `from` address for contact form emails. Its domain must be a verified Email Routing sending domain.           | `noreply@forms.vetro.org` |
+| CUSTOM_RPC_URL_MAINNET    | Ethereum RPC node URL(s). Overrides `viem`'s default. Several URLs joined by `+` become a fallback transport. |                           |
+| MERKL_OPPORTUNITY_SVETBTC | Merkl opportunity id for the sVetBTC staking vault. Optional; if unset, that vault yields no rewards.         |                           |
+| MERKL_OPPORTUNITY_SVUSD   | Merkl opportunity id for the sVUSD staking vault. Optional; if unset, that vault yields no rewards.           |                           |
+| ORIGINS                   | Comma-separated list of allowed origins. (1)                                                                  | `http://localhost:5173`   |
+| SENTRY_DSN                | Sentry DSN. When unset, Sentry is disabled.                                                                   |                           |
+| SUBGRAPH_API_KEY          | The subgraph API key.                                                                                         |                           |
+| SUBGRAPH_ID               | The subgraph id.                                                                                              |                           |
+| SUBGRAPH_URL_TEMPLATE     | The subgraph URL template. (2)                                                                                | (localhost)               |
+| WEBSITE_URL               | Public URL of the web app, referenced in the contact form confirmation email.                                 | `http://localhost:5173/`  |
 
 (1) Globs with stars (`*`) are supported. I.e. `https://*.hemi.xyz` will match any subdomain or subdomain chain.
 (2) API key and id are replaced in the template at the `$API_KEY` and `$ID` positions.

--- a/api/README.md
+++ b/api/README.md
@@ -279,6 +279,36 @@ Returns all user's variable stake exit tickets to i.e. allow claiming the withdr
 ]
 ```
 
+### `POST /contact`
+
+Submit a support request. The contents are emailed to the configured recipient
+using the Cloudflare `send_email` binding (the recipient must be a verified
+Email Routing destination; the sender address comes from `CONTACT_FORM_SENDER`).
+
+Gated by the `CONTACT_FORM_ENABLED` feature toggle: when it is not `"true"` the
+endpoint behaves as if it does not exist and returns `404`.
+
+#### Request body
+
+```json
+{
+  "category": "swap",
+  "email": "user@example.com",
+  "message": "Describe what happened (max 5000 characters)."
+}
+```
+
+`category` must be one of the known topics (`swap`, `bridge`, `earn`,
+`other`). `email` must be well-formed. `message` must be non-empty and at most
+5000 characters.
+
+#### Response
+
+Returns `204 No Content` with an empty body once the email is sent.
+
+Returns `404` when the feature is disabled, `400` for an invalid body / email /
+category / message, and `500` if sending fails.
+
 ## Configuration
 
 Environment variables are configured in `wrangler.jsonc`.
@@ -286,6 +316,9 @@ Secrets are set separately using the Wrangler CLI.
 
 | Variable                  | Description                                                                                                   | Default                 |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| CONTACT_FORM_ENABLED      | Feature toggle for `POST /contact`. When not `"true"`, the endpoint returns `404`.                            | `"false"`               |
+| CONTACT_FORM_RECIPIENT    | Destination address for contact form emails. Must be a verified Email Routing destination.                    |                         |
+| CONTACT_FORM_SENDER       | `from` address for contact form emails. Its domain must be a verified Email Routing sending domain.           |                         |
 | CUSTOM_RPC_URL_MAINNET    | Ethereum RPC node URL(s). Overrides `viem`'s default. Several URLs joined by `+` become a fallback transport. |                         |
 | MERKL_OPPORTUNITY_SVETBTC | Merkl opportunity id for the sVetBTC staking vault. Optional; if unset, that vault yields no rewards.         |                         |
 | MERKL_OPPORTUNITY_SVUSD   | Merkl opportunity id for the sVUSD staking vault. Optional; if unset, that vault yields no rewards.           |                         |
@@ -297,6 +330,8 @@ Secrets are set separately using the Wrangler CLI.
 
 (1) Globs with stars (`*`) are supported. I.e. `https://*.hemi.xyz` will match any subdomain or subdomain chain.
 (2) API key and id are replaced in the template at the `$API_KEY` and `$ID` positions.
+
+The `POST /contact` endpoint also requires a `send_email` binding named `SEND_EMAIL`, configured in `wrangler.jsonc`. Sending only works once the domain is verified and the recipient is added as a destination in Cloudflare Email Routing.
 
 ## Local development
 

--- a/api/src/contact.ts
+++ b/api/src/contact.ts
@@ -73,6 +73,46 @@ export const sendContactEmail = ({
     from: env.CONTACT_FORM_SENDER!,
     replyTo: email,
     subject: `New support request: ${category}`,
-    text: `From: ${email}\nCategory: ${category}\n\n${message}`,
+    text: `New contact form submission.
+
+From: ${email}
+Category: ${category}
+Received: ${new Date().toUTCString()}
+
+Message:
+${message}
+
+--
+Reply directly to this email to respond to the sender`,
     to: env.CONTACT_FORM_RECIPIENT!,
+  });
+
+/**
+ * Sends the submitter an acknowledgement that their contact form request was
+ * received. Replies route back to CONTACT_FORM_RECIPIENT so the support team
+ * picks up any response.
+ */
+export const sendContactConfirmation = ({
+  category,
+  email,
+  env,
+}: Omit<ContactForm, "message"> & { env: Env }) =>
+  env.SEND_EMAIL.send({
+    from: env.CONTACT_FORM_SENDER!,
+    replyTo: env.CONTACT_FORM_RECIPIENT!,
+    subject: "We received your message",
+    text: `Hi,
+
+Thanks for contacting us. We have received your enquiry
+(category: ${category}) and will respond as soon as we can.
+
+This was sent to ${email}. If you did not submit this,
+you can ignore this email.
+
+--
+Vetro Service & Support Ltd.
+You received this because you used the contact form at ${env.WEBSITE_URL}.
+Privacy policy: https://vetro.org/privacy-policy
+Contact: ${env.CONTACT_FORM_RECIPIENT!}`,
+    to: email,
   });

--- a/api/src/contact.ts
+++ b/api/src/contact.ts
@@ -1,0 +1,78 @@
+import type { Context, Next } from "hono";
+
+type ContactForm = {
+  category: string;
+  email: string;
+  message: string;
+};
+
+declare module "hono" {
+  interface ContextVariableMap {
+    contactForm: ContactForm;
+  }
+}
+
+// Topics the web app's contact form dropdown offers.
+const contactCategories = ["bridge", "earn", "other", "swap"];
+
+// Keep this in sync with the web app's isValidEmail (web/src/utils/email.ts):
+// a minimal, permissive check — some text, an "@", and more text after it.
+const emailPattern = /^[^\s@]+@[^\s@]+$/;
+const maxMessageLength = 5000;
+
+export function contactFeatureToggle(
+  c: Context<{ Bindings: Env }>,
+  next: Next,
+) {
+  if (c.env.CONTACT_FORM_ENABLED !== "true") {
+    return c.json({ error: "Not Found" }, 404);
+  }
+  return next();
+}
+
+export async function validateContactForm(c: Context, next: Next) {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid request body" }, 400);
+  }
+
+  const { category, email, message } = (body ?? {}) as Record<string, unknown>;
+
+  if (typeof email !== "string" || !emailPattern.test(email)) {
+    return c.json({ error: "Invalid email address" }, 400);
+  }
+  if (typeof category !== "string" || !contactCategories.includes(category)) {
+    return c.json({ error: "Invalid category" }, 400);
+  }
+  if (
+    typeof message !== "string" ||
+    message.trim().length === 0 ||
+    message.length > maxMessageLength
+  ) {
+    return c.json({ error: "Invalid message" }, 400);
+  }
+
+  c.set("contactForm", { category, email, message });
+  return next();
+}
+
+/**
+ * Sends the contact form contents by email using the Cloudflare `send_email`
+ * binding. The recipient must be a verified Email Routing destination; the
+ * sender address comes from CONTACT_FORM_SENDER.
+ */
+export const sendContactEmail = ({
+  category,
+  email,
+  env,
+  message,
+}: ContactForm & { env: Env }) =>
+  env.SEND_EMAIL.send({
+    from: env.CONTACT_FORM_SENDER!,
+    replyTo: email,
+    subject: `New support request: ${category}`,
+    text: `From: ${email}\nCategory: ${category}\n\n${message}`,
+    to: env.CONTACT_FORM_RECIPIENT!,
+  });

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -8,6 +8,11 @@ import type { Address } from "viem";
 import * as analytics from "./analytics.ts";
 import { getApyHistory } from "./apy-history.ts";
 import * as borrow from "./borrow.ts";
+import {
+  contactFeatureToggle,
+  sendContactEmail,
+  validateContactForm,
+} from "./contact.ts";
 import { convertBigIntsToString } from "./convert-bigints-to-string.ts";
 import { getSubgraphUrl } from "./env.ts";
 import {
@@ -380,6 +385,17 @@ app.get(
     } catch (error) {
       throw new Error(`Failed to get exit tickets: ${error.message}`);
     }
+  },
+);
+
+app.post(
+  "/contact",
+  contactFeatureToggle,
+  validateContactForm,
+  async function (c) {
+    const { category, email, message } = c.get("contactForm");
+    await sendContactEmail({ category, email, env: c.env, message });
+    return c.body(null, 204);
   },
 );
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -10,6 +10,7 @@ import { getApyHistory } from "./apy-history.ts";
 import * as borrow from "./borrow.ts";
 import {
   contactFeatureToggle,
+  sendContactConfirmation,
   sendContactEmail,
   validateContactForm,
 } from "./contact.ts";
@@ -395,6 +396,13 @@ app.post(
   async function (c) {
     const { category, email, message } = c.get("contactForm");
     await sendContactEmail({ category, email, env: c.env, message });
+    // The confirmation to the submitter is best-effort: a failure here must not
+    // fail the request, since the support notification already went out.
+    try {
+      await sendContactConfirmation({ category, email, env: c.env });
+    } catch (error) {
+      Sentry.captureException(error);
+    }
     return c.body(null, 204);
   },
 );

--- a/api/src/worker-env.d.ts
+++ b/api/src/worker-env.d.ts
@@ -3,10 +3,14 @@
 // update this interface to match.
 interface Env {
   CACHE_KV: KVNamespace;
+  CONTACT_FORM_ENABLED?: string;
+  CONTACT_FORM_RECIPIENT?: string;
+  CONTACT_FORM_SENDER?: string;
   CUSTOM_RPC_URL_MAINNET?: string;
   MERKL_OPPORTUNITY_SVETBTC?: string;
   MERKL_OPPORTUNITY_SVUSD?: string;
   ORIGINS: string;
+  SEND_EMAIL: SendEmail;
   CF_VERSION_METADATA?: WorkerVersionMetadata;
   SENTRY_DSN?: string;
   SUBGRAPH_API_KEY?: string;

--- a/api/src/worker-env.d.ts
+++ b/api/src/worker-env.d.ts
@@ -16,4 +16,5 @@ interface Env {
   SUBGRAPH_API_KEY?: string;
   SUBGRAPH_ID?: string;
   SUBGRAPH_URL_TEMPLATE: string;
+  WEBSITE_URL: string;
 }

--- a/api/test/contact.test.ts
+++ b/api/test/contact.test.ts
@@ -1,0 +1,139 @@
+import type { Context } from "hono";
+import { describe, expect, it, vi } from "vitest";
+
+import { contactFeatureToggle, validateContactForm } from "../src/contact.ts";
+
+const validForm = {
+  category: "swap",
+  email: "user@example.com",
+  message: "Something went wrong.",
+};
+
+// Minimal Hono Context for testing.
+function buildContext({ body = validForm, env = {} } = {}) {
+  const json = vi.fn((data, status) => ({ data, status }));
+  const next = vi.fn();
+  const set = vi.fn();
+  const context = {
+    env: {
+      CONTACT_FORM_ENABLED: "true",
+      ...env,
+    },
+    json,
+    req: {
+      json: vi.fn(async function () {
+        if (typeof body === "string") {
+          throw new SyntaxError("Invalid JSON");
+        }
+        return body;
+      }),
+    },
+    set,
+  };
+  return {
+    context: context as unknown as Context<{ Bindings: Env }>,
+    json,
+    next,
+    set,
+  };
+}
+
+describe("contactFeatureToggle", function () {
+  it("returns 404 when the toggle is off", function () {
+    const { context, json, next } = buildContext({
+      env: { CONTACT_FORM_ENABLED: "false" },
+    });
+
+    contactFeatureToggle(context, next);
+
+    expect(json).toHaveBeenCalledWith({ error: "Not Found" }, 404);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next when the toggle is on", function () {
+    const { context, json, next } = buildContext();
+
+    contactFeatureToggle(context, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(json).not.toHaveBeenCalled();
+  });
+});
+
+describe("validateContactForm", function () {
+  it("returns 400 for a malformed request body", async function () {
+    // @ts-expect-error Testing invalid input
+    const { context, json, next } = buildContext({ body: "not json" });
+
+    await validateContactForm(context, next);
+
+    expect(json).toHaveBeenCalledWith({ error: "Invalid request body" }, 400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-string email", async function () {
+    const { context, json, next } = buildContext({
+      // @ts-expect-error Testing invalid input
+      body: { ...validForm, email: 42 },
+    });
+
+    await validateContactForm(context, next);
+
+    expect(json).toHaveBeenCalledWith({ error: "Invalid email address" }, 400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a malformed email", async function () {
+    const { context, json, next } = buildContext({
+      body: { ...validForm, email: "not-an-email" },
+    });
+
+    await validateContactForm(context, next);
+
+    expect(json).toHaveBeenCalledWith({ error: "Invalid email address" }, 400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an unknown category", async function () {
+    const { context, json, next } = buildContext({
+      body: { ...validForm, category: "nope" },
+    });
+
+    await validateContactForm(context, next);
+
+    expect(json).toHaveBeenCalledWith({ error: "Invalid category" }, 400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an empty message", async function () {
+    const { context, json, next } = buildContext({
+      body: { ...validForm, message: "   " },
+    });
+
+    await validateContactForm(context, next);
+
+    expect(json).toHaveBeenCalledWith({ error: "Invalid message" }, 400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a message longer than 5000 characters", async function () {
+    const { context, json, next } = buildContext({
+      body: { ...validForm, message: "a".repeat(5001) },
+    });
+
+    await validateContactForm(context, next);
+
+    expect(json).toHaveBeenCalledWith({ error: "Invalid message" }, 400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("stores the form and calls next for a valid body", async function () {
+    const { context, json, next, set } = buildContext();
+
+    await validateContactForm(context, next);
+
+    expect(set).toHaveBeenCalledWith("contactForm", validForm);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(json).not.toHaveBeenCalled();
+  });
+});

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -32,7 +32,7 @@
   "vars": {
     "CONTACT_FORM_ENABLED": "false",
     "CONTACT_FORM_RECIPIENT": "support@vetro.org",
-    "CONTACT_FORM_SENDER": "noreply@vetro.org",
+    "CONTACT_FORM_SENDER": "noreply@forms.vetro.org",
     "MERKL_OPPORTUNITY_SVETBTC": "",
     "MERKL_OPPORTUNITY_SVUSD": "",
     "ORIGINS": "http://localhost:3000,http://localhost:5173",
@@ -52,7 +52,7 @@
         // Contact form enabled on staging for testing purposes.
         "CONTACT_FORM_ENABLED": "true",
         "CONTACT_FORM_RECIPIENT": "gonzalo@hemi.xyz",
-        "CONTACT_FORM_SENDER": "noreply@vetro.org",
+        "CONTACT_FORM_SENDER": "noreply@forms.vetro.org",
         "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
         "ORIGINS": "https://*.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
@@ -80,7 +80,7 @@
       "vars": {
         "CONTACT_FORM_ENABLED": "false",
         "CONTACT_FORM_RECIPIENT": "support@vetro.org",
-        "CONTACT_FORM_SENDER": "noreply@vetro.org",
+        "CONTACT_FORM_SENDER": "noreply@forms.vetro.org",
         "ORIGINS": "https://app.vetro.org,https://beta.vetro.org,https://*.hemi.xyz",
         "SENTRY_DSN": "https://fc941b61bc1aaaa28545687b7ca97fc6@o4508162066350080.ingest.de.sentry.io/4511626274209873",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -30,11 +30,15 @@
     ],
   },
   "vars": {
+    "CONTACT_FORM_ENABLED": "false",
+    "CONTACT_FORM_RECIPIENT": "support@vetro.org",
+    "CONTACT_FORM_SENDER": "noreply@vetro.org",
     "MERKL_OPPORTUNITY_SVETBTC": "",
     "MERKL_OPPORTUNITY_SVUSD": "",
     "ORIGINS": "http://localhost:3000,http://localhost:5173",
     "SUBGRAPH_URL_TEMPLATE": "http://localhost:8000/subgraphs/name/vetro-app-subgraph",
   },
+  "send_email": [{ "name": "SEND_EMAIL" }],
   "env": {
     "staging": {
       "name": "vetro-api-staging",
@@ -45,11 +49,16 @@
         },
       ],
       "vars": {
+        // Contact form enabled on staging for testing purposes.
+        "CONTACT_FORM_ENABLED": "true",
+        "CONTACT_FORM_RECIPIENT": "gonzalo@hemi.xyz",
+        "CONTACT_FORM_SENDER": "noreply@vetro.org",
         "CUSTOM_RPC_URL_MAINNET": "https://eth.drpc.org",
         "ORIGINS": "https://*.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
       },
+      "send_email": [{ "name": "SEND_EMAIL" }],
     },
     "production": {
       "name": "vetro-api",
@@ -69,11 +78,15 @@
         },
       },
       "vars": {
+        "CONTACT_FORM_ENABLED": "false",
+        "CONTACT_FORM_RECIPIENT": "support@vetro.org",
+        "CONTACT_FORM_SENDER": "noreply@vetro.org",
         "ORIGINS": "https://app.vetro.org,https://beta.vetro.org,https://*.hemi.xyz",
         "SENTRY_DSN": "https://fc941b61bc1aaaa28545687b7ca97fc6@o4508162066350080.ingest.de.sentry.io/4511626274209873",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
       },
+      "send_email": [{ "name": "SEND_EMAIL" }],
     },
   },
 }

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -37,6 +37,7 @@
     "MERKL_OPPORTUNITY_SVUSD": "",
     "ORIGINS": "http://localhost:3000,http://localhost:5173",
     "SUBGRAPH_URL_TEMPLATE": "http://localhost:8000/subgraphs/name/vetro-app-subgraph",
+    "WEBSITE_URL": "http://localhost:5173/",
   },
   "send_email": [{ "name": "SEND_EMAIL" }],
   "env": {
@@ -57,6 +58,7 @@
         "ORIGINS": "https://*.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
+        "WEBSITE_URL": "https://vetro.letshamsterdance.xyz/",
       },
       "send_email": [{ "name": "SEND_EMAIL" }],
     },
@@ -85,6 +87,7 @@
         "SENTRY_DSN": "https://fc941b61bc1aaaa28545687b7ca97fc6@o4508162066350080.ingest.de.sentry.io/4511626274209873",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
+        "WEBSITE_URL": "https://app.vetro.org/",
       },
       "send_email": [{ "name": "SEND_EMAIL" }],
     },

--- a/web/src/hooks/useSubmitContactForm.ts
+++ b/web/src/hooks/useSubmitContactForm.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
+import { isValidUrl } from "utils/url";
 
 type ContactFormValues = {
   category: string;
@@ -14,10 +15,14 @@ export const useSubmitContactForm = () =>
     // The endpoint responds with `204 No Content` (fetch-plus-plus resolves to
     // `undefined`) on success, and throws on any non-2xx so the form surfaces
     // its error toast.
-    mutationFn: (values) =>
-      fetch(`${apiUrl}/contact`, {
+    mutationFn(values) {
+      if (apiUrl === undefined || !isValidUrl(apiUrl)) {
+        throw new Error("VITE_VETRO_API_URL is not configured");
+      }
+      return fetch(`${apiUrl}/contact`, {
         body: JSON.stringify(values),
         headers: { "content-type": "application/json" },
         method: "POST",
-      }) as Promise<void>,
+      }) as Promise<void>;
+    },
   });

--- a/web/src/hooks/useSubmitContactForm.ts
+++ b/web/src/hooks/useSubmitContactForm.ts
@@ -1,4 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
+import fetch from "fetch-plus-plus";
 
 type ContactFormValues = {
   category: string;
@@ -6,13 +7,17 @@ type ContactFormValues = {
   message: string;
 };
 
+const apiUrl = import.meta.env.VITE_VETRO_API_URL;
+
 export const useSubmitContactForm = () =>
   useMutation<void, Error, ContactFormValues>({
-    // The contact API is not wired up to the client yet, so this stubs a
-    // successful submission by waiting 5s before resolving. Replace with the
-    // real `POST /contact` call once the API is implemented. The endpoint
-    // responds with `204 No Content`, so there is no response body to return.
-    // See https://github.com/vetro-protocol/vetro-monorepo/issues/550
-    mutationFn: () =>
-      new Promise((resolve) => setTimeout(() => resolve(), 5000)),
+    // The endpoint responds with `204 No Content` (fetch-plus-plus resolves to
+    // `undefined`) on success, and throws on any non-2xx so the form surfaces
+    // its error toast.
+    mutationFn: (values) =>
+      fetch(`${apiUrl}/contact`, {
+        body: JSON.stringify(values),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }) as Promise<void>,
   });


### PR DESCRIPTION
### Description

Adds a `POST /contact` endpoint (Hono / Cloudflare Worker) that emails support requests via the Cloudflare `send_email` binding, gated by the `CONTACT_FORM_ENABLED` toggle (off by default). It validates category/email/message and sets reply-to to the submitter's address so support can reply directly and continue the thread. Wires the web submit hook (`useSubmitContactForm`) to the real endpoint, replacing the 5s stub. Adds unit tests for the validation and feature-toggle middleware, and documents the endpoint + env vars in `api/README.md`.

Because Wrangler does not inherit top-level `vars` or bindings into named environments, the `CONTACT_FORM_*` vars and the `send_email` binding are repeated per environment.

> [!IMPORTANT]
> Needs coordination before merging: the email domains must be whitelisted in Cloudflare Email Routing first — a verified sending domain for `noreply@vetro.org` and verified destination addresses. Sending will fail until that's set up.

> [!NOTE]
> Rollout: enabled on **staging** only (emails go to a tester inbox); **disabled on production**, to be turned on later once the above is verified.

Pending follow-ups (out of scope here):
- Support uploading screenshots as attachments on the contact email
- Captcha and/or rate-limiting (the endpoint is currently unauthenticated)

### Screenshots

N/A — no UI changes in this PR.

### Related issue(s)

Related to #550

### Checklist

- [ ] Manual testing passed. (unit tests + `wrangler dry-run` pass; live email send blocked on Cloudflare domain whitelisting)
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A. (config lives in `wrangler.jsonc`, no CI secrets needed)