### PR TITLE
Center bottom notifications of varying width

### DIFF
--- a/web/src/components/base/stack.tsx
+++ b/web/src/components/base/stack.tsx
@@ -13,7 +13,7 @@ const SCALE_FACTOR = 0.05;
 const STACK_OFFSET = 12;
 
 const positions = {
-  "bottom-center": "fixed bottom-4 left-1/2 z-40 w-72 -translate-x-1/2",
+  "bottom-center": "fixed bottom-4 left-1/2 z-40 w-80 -translate-x-1/2",
   "bottom-right":
     "fixed inset-x-4 bottom-4 z-40 md:inset-x-auto md:right-4 md:w-96",
 } as const;


### PR DESCRIPTION
### Description

Notifications for the Redeem Queue and the Earn Exit Queue appeared left-aligned instead of centered when notifications of different widths were shown together. This centers them properly regardless of their width.

### Screenshots

https://github.com/user-attachments/assets/505ee63f-91c7-4790-a29f-05d7553cbba2

### Related issue(s)

Closes #565

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.