### PR TITLE
Reset form input after successful submit

### DIFF
--- a/web/e2e/earn.spec.ts
+++ b/web/e2e/earn.spec.ts
@@ -115,6 +115,11 @@ test("deposit VUSD into the Earn pool", async function ({
     timeout: 60_000,
   });
 
+  // Check input resets to "0" on success
+  await expect(
+    page.locator('input[type="text"]:not([disabled])').first(),
+  ).toHaveValue("0");
+
   // Assertion 1 — VUSD balance dropped by exactly the deposited amount.
   await waitForBalance({ client: publicClient, token: vusd.address }).toBe(
     vusdBefore - DEPOSIT_AMOUNT,
@@ -274,6 +279,11 @@ test("withdraw VUSD from the Earn pool (whitelisted one-step exit)", async funct
   await expect(page.getByText("Withdrawal complete")).toBeVisible({
     timeout: 40_000,
   });
+
+  // Check input resets to "0" on success
+  await expect(
+    page.locator('input[type="text"]:not([disabled])').first(),
+  ).toHaveValue("0");
 
   const withdrawTxHash = walletTxHashes.at(-1);
   expect(withdrawTxHash).toBeDefined();

--- a/web/e2e/swap.spec.ts
+++ b/web/e2e/swap.spec.ts
@@ -84,6 +84,11 @@ test("swap USDC → VUSD via the gateway", async function ({ page }) {
     timeout: 40_000,
   });
 
+  // Check input resets to "0" on success
+  await expect(
+    page.locator('input[type="text"]:not([disabled])').first(),
+  ).toHaveValue("0", { timeout: 15_000 });
+
   // No popups — the mock wallet signs and forwards to Anvil silently.
   // Assert by polling balances directly against the fork.
   await waitForBalance({
@@ -189,6 +194,11 @@ test("redeem VUSD → USDC via the gateway (instant redeem)", async function ({
     timeout: 40_000,
   });
 
+  // Check input resets to "0" on success
+  await expect(
+    page.locator('input[type="text"]:not([disabled])').first(),
+  ).toHaveValue("0", { timeout: 15_000 });
+
   // No popups — the mock wallet signs and forwards to Anvil silently.
   // Assert by polling balances directly against the fork.
   await waitForBalance({
@@ -258,6 +268,11 @@ test("redeem VUSD via the gateway (two-step queue redeem)", async function ({
   await expect(page.getByText(/sent to queue/i)).toBeVisible({
     timeout: 60_000,
   });
+
+  // Check input resets to "0" on success
+  await expect(
+    page.locator('input[type="text"]:not([disabled])').first(),
+  ).toHaveValue("0", { timeout: 15_000 });
 
   // The VUSD is now locked in the gateway, so the wallet balance already dropped.
   await waitForBalance({ client: publicClient, token: vusd.address }).toBe(

--- a/web/src/components/bridgeForm/index.tsx
+++ b/web/src/components/bridgeForm/index.tsx
@@ -274,6 +274,13 @@ function BridgeFormContent({ tokens }: ContentProps) {
     }
   }
 
+  function handleDrawerClose() {
+    setIsDrawerOpen(false);
+    if (flowStatus === "sent") {
+      dispatch({ payload: "0", type: "SET_FROM_INPUT_VALUE" });
+    }
+  }
+
   return (
     <>
       <Form
@@ -346,7 +353,7 @@ function BridgeFormContent({ tokens }: ContentProps) {
           fromToken={fromToken}
           layerZeroFee={layerZeroFee}
           networkFee={networkFee}
-          onClose={() => setIsDrawerOpen(false)}
+          onClose={handleDrawerClose}
           onRetry={handleRetry}
           showApproveStep={startedWithApproval}
           toAmount={toAmountDisplay}

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -74,9 +74,24 @@ export function Deposit({
   });
   const { t } = useTranslation();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const handleDrawerClose = useCallback(() => setIsDrawerOpen(false), []);
   const [flowStatus, setFlowStatus] = useState<DepositFlowStatus>("idle");
   const [showToast, setShowToast] = useState(false);
+  const [toastData, setToastData] = useState({
+    fromAmount: "",
+    fromSymbol: "",
+    toAmount: "",
+    toSymbol: "",
+  });
+
+  const handleDrawerClose = useCallback(
+    function handleDrawerClose() {
+      setIsDrawerOpen(false);
+      if (flowStatus === "deposited") {
+        onInputChange("0");
+      }
+    },
+    [flowStatus, onInputChange],
+  );
   // Captures whether approval was needed when the flow started, because
   // useNeedsApproval flips to false after a successful approval tx.
   const [startedWithApproval, setStartedWithApproval] = useState(false);
@@ -153,6 +168,12 @@ export function Deposit({
       emitter.on("deposit-transaction-succeeded", function () {
         onCompleted();
         setFlowStatus("deposited");
+        setToastData({
+          fromAmount: fromInputValue,
+          fromSymbol: fromToken.symbol,
+          toAmount: outputValue,
+          toSymbol: toToken.symbol,
+        });
         setShowToast(true);
         watchToken();
       });
@@ -317,12 +338,10 @@ export function Deposit({
       {showToast && (
         <Toast
           closable
-          description={t("pages.swap.toast.swap-success-description", {
-            fromAmount: fromInputValue,
-            fromSymbol: fromToken.symbol,
-            toAmount: outputValue,
-            toSymbol: toToken.symbol,
-          })}
+          description={t(
+            "pages.swap.toast.swap-success-description",
+            toastData,
+          )}
           onClose={() => setShowToast(false)}
           title={t("pages.swap.toast.swap-success-title")}
         />

--- a/web/src/components/swapForm/index.tsx
+++ b/web/src/components/swapForm/index.tsx
@@ -2,7 +2,7 @@ import { useDebounce } from "@hemilabs/react-hooks/useDebounce";
 import { usePeggedTokensByGateway } from "hooks/usePeggedTokensByGateway";
 import { useSwapMode } from "hooks/useSwapMode";
 import { useWhitelistedTokens } from "hooks/useWhitelistedTokens";
-import { useReducer } from "react";
+import { useCallback, useReducer } from "react";
 import type { TokenWithGateway } from "types";
 import { parseTokenUnits } from "utils/token";
 import type { Address } from "viem";
@@ -69,9 +69,9 @@ function SwapFormContent({
     });
   }
 
-  function onInputChange(value: string) {
+  const onInputChange = useCallback(function onInputChange(value: string) {
     dispatch({ payload: value, type: "SET_FROM_INPUT_VALUE" });
-  }
+  }, []);
 
   function onToggleApprove10x() {
     dispatch({ type: "TOGGLE_APPROVE_10X" });

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -71,10 +71,25 @@ export function OneStepRedeem({
   const ethereumChain = useMainnet();
   const { t } = useTranslation();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const handleDrawerClose = useCallback(() => setIsDrawerOpen(false), []);
   const [flowStatus, setFlowStatus] = useState<RedeemFlowStatus>("idle");
   const [showToast, setShowToast] = useState(false);
+  const [toastData, setToastData] = useState({
+    fromAmount: "",
+    fromSymbol: "",
+    toAmount: "",
+    toSymbol: "",
+  });
   const [startedWithApproval, setStartedWithApproval] = useState(false);
+
+  const handleDrawerClose = useCallback(
+    function handleDrawerClose() {
+      setIsDrawerOpen(false);
+      if (flowStatus === "redeemed") {
+        onInputChange("0");
+      }
+    },
+    [flowStatus, onInputChange],
+  );
 
   const { data: fromTokenBalance } = useTokenBalance({
     address: fromToken.address,
@@ -147,6 +162,12 @@ export function OneStepRedeem({
       emitter.on("redeem-transaction-succeeded", function () {
         onCompleted();
         setFlowStatus("redeemed");
+        setToastData({
+          fromAmount: fromInputValue,
+          fromSymbol: fromToken.symbol,
+          toAmount: outputValue,
+          toSymbol: toToken.symbol,
+        });
         setShowToast(true);
       });
       emitter.on("redeem-transaction-reverted", function () {
@@ -328,12 +349,10 @@ export function OneStepRedeem({
       {showToast && (
         <Toast
           closable
-          description={t("pages.swap.toast.swap-success-description", {
-            fromAmount: fromInputValue,
-            fromSymbol: fromToken.symbol,
-            toAmount: outputValue,
-            toSymbol: toToken.symbol,
-          })}
+          description={t(
+            "pages.swap.toast.swap-success-description",
+            toastData,
+          )}
           onClose={() => setShowToast(false)}
           title={t("pages.swap.toast.swap-success-title")}
         />

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -71,10 +71,20 @@ export function TwoStepRedeem({
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [isTutorialOpen, setIsTutorialOpen] = useState(false);
-  const handleDrawerClose = useCallback(() => setIsDrawerOpen(false), []);
   const [flowStatus, setFlowStatus] = useState<RequestRedeemFlowStatus>("idle");
   const [showToast, setShowToast] = useState(false);
+  const [toastData, setToastData] = useState({ amount: "", symbol: "" });
   const [startedWithApproval, setStartedWithApproval] = useState(false);
+
+  const handleDrawerClose = useCallback(
+    function handleDrawerClose() {
+      setIsDrawerOpen(false);
+      if (flowStatus === "request-redeemed") {
+        onInputChange("0");
+      }
+    },
+    [flowStatus, onInputChange],
+  );
 
   const { data: seconds } = useWithdrawalDelay({
     gatewayAddress: fromToken.gatewayAddress,
@@ -135,6 +145,7 @@ export function TwoStepRedeem({
       emitter.on("request-redeem-transaction-succeeded", function () {
         onCompleted();
         setFlowStatus("request-redeemed");
+        setToastData({ amount: fromInputValue, symbol: fromToken.symbol });
         setShowToast(true);
         document
           .getElementById("redeem-queue")
@@ -314,10 +325,7 @@ export function TwoStepRedeem({
           closable
           description={t("pages.swap.toast.redeem-queued-description")}
           onClose={() => setShowToast(false)}
-          title={t("pages.swap.toast.redeem-queued-title", {
-            amount: fromInputValue,
-            symbol: fromToken.symbol,
-          })}
+          title={t("pages.swap.toast.redeem-queued-title", toastData)}
         />
       )}
     </>

--- a/web/src/pages/earn/components/stakeDrawer/stakeDrawerContent.tsx
+++ b/web/src/pages/earn/components/stakeDrawer/stakeDrawerContent.tsx
@@ -45,6 +45,11 @@ export function StakeDrawerContent({
     dispatch({ payload: value, type: "SET_INPUT_VALUE" });
   }
 
+  function handleSuccess(toast: ToastData) {
+    handleInputChange("0");
+    onSuccess(toast);
+  }
+
   function handleDepositStepChange(step: DepositStep) {
     dispatch({ payload: step, type: "SET_DEPOSIT_STEP" });
   }
@@ -80,7 +85,7 @@ export function StakeDrawerContent({
           onApprove10xToggle={handleToggleApprove10x}
           onDepositStepChange={handleDepositStepChange}
           onInputChange={handleInputChange}
-          onSuccess={onSuccess}
+          onSuccess={handleSuccess}
           peggedToken={peggedToken}
           stakingVaultAddress={stakingVaultAddress}
         />
@@ -88,7 +93,7 @@ export function StakeDrawerContent({
         <StakeWithdrawForm
           inputValue={state.inputValue}
           onInputChange={handleInputChange}
-          onSuccess={onSuccess}
+          onSuccess={handleSuccess}
           onWithdrawStepChange={handleWithdrawStepChange}
           peggedToken={peggedToken}
           stakingVaultAddress={stakingVaultAddress}


### PR DESCRIPTION
### Description

Clear the amount input back to `0` once a deposit, redeem, stake, or bridge flow completes and the drawer closes. Previously the entered amount lingered in the input after a successful transaction, so the user had to clear it manually before starting a new one.

Because the success toast reads the input value, the from/to amounts and symbols are snapshotted into state at success time so the toast message stays correct after the input is reset.

Covers all Swap forms (deposit, one-step redeem, two-step queue redeem), the Earn stake/withdraw drawer, and the Bridge form.

### Screenshots

Earn - Deposit

https://github.com/user-attachments/assets/74a972ec-069a-4b34-b9ca-442c7cd2904b

Earn - Withdraw

https://github.com/user-attachments/assets/7b250a17-5399-4712-80e2-58f34b8dd327

Swap - Sending to Redeem Queue

https://github.com/user-attachments/assets/1e0655d2-8c51-40c8-a033-4ad59c8157e2

Swapping to VUSD

https://github.com/user-attachments/assets/e3e66974-943c-4056-9c80-3e8be8aa3929

Bridge

https://github.com/user-attachments/assets/c7b4b874-8ccf-4689-8cbe-fcdf8bc16ce7


On borrow this wasn't a problem

### Related issue(s)

Closes #568

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.