### PR TITLE
Remove extra knip command

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,6 @@
   "version": "1.3.0",
   "scripts": {
     "build": "pnpm types:check && tsc",
-    "deps:check": "knip",
     "dev": "wrangler dev",
     "test": "vitest run",
     "tsc": "tsc",


### PR DESCRIPTION
### Description

Removes the redundant `deps:check` script from `api/package.json`. Knip is already run at the workspace level, so the per-package `deps:check` command in the API was an extra, duplicate entry point that is no longer needed.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.