### PR TITLE
Round read-only token amounts with DisplayAmount

### DIFF
--- a/web/src/components/swapForm/redeemQueueTable.tsx
+++ b/web/src/components/swapForm/redeemQueueTable.tsx
@@ -1,6 +1,7 @@
 import { type ColumnDef } from "@tanstack/react-table";
 import { Badge } from "components/base/badge";
 import { Button, ButtonIcon } from "components/base/button";
+import { DisplayAmount } from "components/base/displayAmount";
 import { StatusBadge } from "components/base/statusBadge";
 import { Table } from "components/base/table";
 import { Header } from "components/base/table/header";
@@ -11,7 +12,6 @@ import type { RedeemRequest } from "hooks/useGetRedeemRequests";
 import { type ReactNode, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { formatCountdown } from "utils/countdown";
-import { formatAmount } from "utils/token";
 
 type Props = {
   data: RedeemRequest[];
@@ -106,16 +106,12 @@ export function RedeemQueueTable({
     (): ColumnDef<RedeemRequest>[] => [
       {
         cell: ({ row }) => (
-          <div className="flex items-center gap-2">
+          <div className="text-b-medium flex items-center gap-2 text-gray-900">
             <TokenLogo {...row.original.peggedToken} />
-            <span className="text-b-medium text-gray-900">
-              {formatAmount({
-                amount: row.original.amountLocked,
-                decimals: row.original.peggedToken.decimals,
-                isError: false,
-              })}{" "}
-              {row.original.peggedToken.symbol}
-            </span>
+            <DisplayAmount
+              amount={row.original.amountLocked}
+              token={row.original.peggedToken}
+            />
           </div>
         ),
         header: () => (

--- a/web/src/components/tokenSelectorModal/tokenRow.tsx
+++ b/web/src/components/tokenSelectorModal/tokenRow.tsx
@@ -45,9 +45,9 @@ export function TokenRow<T extends Token>({
       </div>
       {address ? (
         <div className="flex shrink-0 flex-col items-end gap-0.5">
-          <span className="text-b-medium text-gray-900">
+          <div className="text-b-medium text-gray-900">
             <RenderCryptoValue status={status} token={token} value={balance} />
-          </span>
+          </div>
           <span className="text-b-regular text-gray-500">
             $<BridgeTokenFiatValue token={token} value={balance} />
           </span>

--- a/web/src/components/tokenSelectorModal/tokenRow.tsx
+++ b/web/src/components/tokenSelectorModal/tokenRow.tsx
@@ -1,10 +1,10 @@
 import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
+import { RenderCryptoValue } from "components/base/cryptoValue";
 import { BridgeTokenFiatValue } from "components/bridgeForm/bridgeTokenFiatValue";
 import { TokenChainLogo } from "components/bridgeForm/tokenChainLogo";
 import { TokenLogo } from "components/tokenLogo";
 import type { ReactNode } from "react";
 import type { Token } from "types";
-import { formatAmount } from "utils/token";
 import { useAccount } from "wagmi";
 
 type Props<T extends Token> = {
@@ -21,7 +21,7 @@ export function TokenRow<T extends Token>({
   token,
 }: Props<T>) {
   const { address } = useAccount();
-  const { data: balance, isError } = useTokenBalance({
+  const { data: balance, status } = useTokenBalance({
     address: token.address,
     chainId: token.chainId,
   });
@@ -46,11 +46,7 @@ export function TokenRow<T extends Token>({
       {address ? (
         <div className="flex shrink-0 flex-col items-end gap-0.5">
           <span className="text-b-medium text-gray-900">
-            {formatAmount({
-              amount: balance,
-              decimals: token.decimals,
-              isError,
-            })}
+            <RenderCryptoValue status={status} token={token} value={balance} />
           </span>
           <span className="text-b-regular text-gray-500">
             $<BridgeTokenFiatValue token={token} value={balance} />

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -308,7 +308,6 @@
         "withdraw-all-toast-title": "All exit tickets withdrawn",
         "withdraw-toast-description": "Your funds have been successfully withdrawn to your wallet.",
         "withdraw-toast-title": "Withdrawal complete",
-        "withdrawal-amount": "{{amount}} {{symbol}}",
         "withdrawal-tx": "Withdrawal:",
         "withdrawing": "Withdrawing...",
         "withdrawn": "Withdrawn"

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -311,7 +311,6 @@
         "withdraw-all-toast-title": "Todos los tickets de salida retirados",
         "withdraw-toast-description": "Sus fondos han sido retirados exitosamente a su billetera.",
         "withdraw-toast-title": "Retiro completado",
-        "withdrawal-amount": "{{amount}} {{symbol}}",
         "withdrawal-tx": "Retiro:",
         "withdrawing": "Retirando...",
         "withdrawn": "Retirado"

--- a/web/src/pages/earn/components/exitTickets/withdrawalCell.tsx
+++ b/web/src/pages/earn/components/exitTickets/withdrawalCell.tsx
@@ -16,10 +16,10 @@ export function WithdrawalCell({ ticket }: Props) {
 
   if (peggedToken) {
     return (
-      <span className="text-xsm flex items-center gap-x-2 font-medium text-gray-900">
+      <div className="text-xsm flex items-center gap-x-2 font-medium text-gray-900">
         <TokenLogo size="small" {...peggedToken} />
         <DisplayAmount amount={BigInt(ticket.assets)} token={peggedToken} />
-      </span>
+      </div>
     );
   }
 

--- a/web/src/pages/earn/components/exitTickets/withdrawalCell.tsx
+++ b/web/src/pages/earn/components/exitTickets/withdrawalCell.tsx
@@ -1,8 +1,7 @@
+import { DisplayAmount } from "components/base/displayAmount";
 import { TokenLogo } from "components/tokenLogo";
 import { useVaultPeggedToken } from "hooks/useVaultPeggedToken";
-import { useTranslation } from "react-i18next";
 import Skeleton from "react-loading-skeleton";
-import { formatAmount } from "utils/token";
 
 import type { ExitTicket } from "../../types";
 
@@ -11,7 +10,6 @@ type Props = {
 };
 
 export function WithdrawalCell({ ticket }: Props) {
-  const { t } = useTranslation();
   const { data: peggedToken, isError } = useVaultPeggedToken(
     ticket.stakingVaultAddress,
   );
@@ -20,14 +18,7 @@ export function WithdrawalCell({ ticket }: Props) {
     return (
       <span className="text-xsm flex items-center gap-x-2 font-medium text-gray-900">
         <TokenLogo size="small" {...peggedToken} />
-        {t("pages.earn.exit-tickets.withdrawal-amount", {
-          amount: formatAmount({
-            amount: BigInt(ticket.assets),
-            decimals: peggedToken.decimals,
-            isError: false,
-          }),
-          symbol: peggedToken.symbol,
-        })}
+        <DisplayAmount amount={BigInt(ticket.assets)} token={peggedToken} />
       </span>
     );
   }


### PR DESCRIPTION
### Description

Large / high-precision token values were rendered through raw `formatUnits` (via the `formatAmount` helper), so they showed up untrimmed on screen. This adopts the existing `DisplayAmount` / `RenderCryptoValue` components — which round the value and reveal the full amount in a hover tooltip — at the read-only token-value sites reported in the issue:

- Earn exit-queue withdrawal cell
- Swap redeem-queue table (redeemable balance)
- Token-selector balance row

Fiat/USD values are left untouched (already rounded). Token amounts baked into i18n sentence strings, activity/toast text, disabled inputs, and balance labels are out of scope for this pass, since a React tooltip component cannot be interpolated into a plain string.

### Screenshots

https://github.com/user-attachments/assets/c2a2495d-96d8-4b6b-a240-116ccb21b5b8

### Related issue(s)

Closes #553

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.