### PR TITLE
Make redeem queue table fill container width

### DIFF
--- a/web/src/components/swapForm/redeemQueueTable.tsx
+++ b/web/src/components/swapForm/redeemQueueTable.tsx
@@ -130,7 +130,7 @@ export function RedeemQueueTable({
         ),
         header: () => <Header text={t("pages.swap.redeem-queue.status")} />,
         id: "status",
-        meta: { width: "200px" },
+        meta: { className: "grow", width: "200px" },
       },
       {
         cell: ({ row }) => (


### PR DESCRIPTION
### Description

The Redeem Queue table on the Swap page had fixed-width columns that clumped to the left, leaving an empty gap on the right so the "Action" column never reached the parent container's right margin.

This adds \`grow\` to the Status column so it absorbs the free space and pushes the Action buttons (Redeem / ✕) to the right edge, aligning the table with the surrounding elements. It reuses the same pattern already used by the borrow tables (\`marketsTable\`, \`positionsTable\`), so the shared \`Table\` primitive and the other tables are untouched.

### Screenshots

<img width="1185" height="346" alt="image" src="https://github.com/user-attachments/assets/bc1c2659-5a2b-4216-8c66-ed3c755f2b4f" />

### Related issue(s)

Closes #213

### Checklist

- [ ] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.