### PR TITLE
Show sub-cent USD amounts as "< $0.01"

### DIFF
--- a/web/src/utils/currency.ts
+++ b/web/src/utils/currency.ts
@@ -3,13 +3,20 @@ import { formatUnits } from "viem";
 
 import { getTokenPrice } from "./token";
 
-export const formatUsd = (value: number) =>
-  new Intl.NumberFormat("en-US", {
+export const formatUsd = function (value: number) {
+  if (value > 0 && value < 0.01) {
+    return "< $0.01";
+  }
+  if (value < 0 && value > -0.01) {
+    return "< -$0.01";
+  }
+  return new Intl.NumberFormat("en-US", {
     currency: "USD",
     maximumFractionDigits: 2,
     notation: "compact",
     style: "currency",
   }).format(value);
+};
 
 type TokenAmountUsdArgs = {
   amount: bigint;

--- a/web/test/utils/currency.test.ts
+++ b/web/test/utils/currency.test.ts
@@ -1,8 +1,37 @@
 import { describe, expect, it } from "vitest";
 
-import { splitDecimalParts } from "../../src/utils/currency";
+import { formatUsd, splitDecimalParts } from "../../src/utils/currency";
 
 describe("utils/currency", function () {
+  describe("formatUsd", function () {
+    it("should format zero as $0", function () {
+      expect(formatUsd(0)).toBe("$0");
+    });
+
+    it("should format a whole value", function () {
+      expect(formatUsd(1234.56)).toBe("$1.23K");
+    });
+
+    it("should format a large value with compact notation", function () {
+      expect(formatUsd(1_200_000)).toBe("$1.2M");
+    });
+
+    it("should floor positive sub-cent values to '< $0.01'", function () {
+      expect(formatUsd(0.005)).toBe("< $0.01");
+      expect(formatUsd(0.009)).toBe("< $0.01");
+    });
+
+    it("should floor negative sub-cent values to '< -$0.01'", function () {
+      expect(formatUsd(-0.005)).toBe("< -$0.01");
+      expect(formatUsd(-0.009)).toBe("< -$0.01");
+    });
+
+    it("should format exactly one cent normally", function () {
+      expect(formatUsd(0.01)).toBe("$0.01");
+      expect(formatUsd(-0.01)).toBe("-$0.01");
+    });
+  });
+
   describe("splitDecimalParts", function () {
     it("should return empty decimal for zero", function () {
       expect(splitDecimalParts(0)).toEqual({ decimal: "", integer: "$0" });


### PR DESCRIPTION
### Description

`formatUsd` rounded any value under a cent to `$0`, so a tiny but nonzero amount read as exactly zero — misleading. This affects every USD figure across the Analytics allocation legends (TVL tokens, Yield strategies, and the Reserve buffer), which all format through `formatUsd`. The Reserve buffer was just the reported instance (#440).

The fix floors sub-cent magnitudes to `< $0.01` (and `< -$0.01` for negatives), mirroring the existing `formatPercentage` → `< 0.01%` behavior already used by the Collateralization card. Exactly-zero values still render as `$0`, and the chart filter stays `amount > 0` (unchanged), so exactly-zero items are excluded from the bar while a tiny-but-real value keeps its thin bar — now sensibly labelled.

`formatUsd` is shared beyond Analytics, so the Earn stats (staked/earned USD) gain the same behavior — an intended, consistent improvement.

### Screenshots

<img width="1176" height="724" alt="image" src="https://github.com/user-attachments/assets/5b9766c0-4a7c-431e-b961-310b0a5fd8b1" />

### Related issue(s)

Closes #440

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.