### PR TITLE
Add 2-step withdraw test for Earn

### DIFF
--- a/web/e2e/earn.spec.ts
+++ b/web/e2e/earn.spec.ts
@@ -5,14 +5,18 @@ import {
 import { expect } from "@playwright/test";
 import {
   createWalletClient,
+  erc20Abi,
   http,
+  isAddressEqual,
   parseAbiItem,
   parseEventLogs,
   parseUnits,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import {
+  getBlock,
   getTransactionReceipt,
+  readContract,
   waitForTransactionReceipt,
   writeContract,
 } from "viem/actions";
@@ -21,7 +25,10 @@ import { approve, balanceOf } from "viem-erc20/actions";
 
 import { stakingVaultAbi } from "../../packages/earn/src/abi/stakingVaultAbi.ts";
 import { sVusdAddress } from "../../packages/earn/src/stakingVaultAddresses.ts";
+import { fastForwardTime } from "../scripts/fastForwardTime.ts";
+import { setCooldownEnabled } from "../scripts/setCooldownEnabled.ts";
 import { whitelistInstantWithdraw } from "../scripts/whitelistInstantWithdraw.ts";
+import type { ExitTicket } from "../src/pages/earn/types.ts";
 
 import { ANVIL_URL, createEthereumClient } from "./anvil";
 import { test } from "./fixtures/wallet";
@@ -312,4 +319,233 @@ test("withdraw VUSD from the Earn pool (whitelisted one-step exit)", async funct
     address: sVusdAddress,
   });
   expect(svusdBefore - svusdBurned).toBe(svusdAfter);
+});
+
+test("withdraw VUSD from the Earn pool (two-step cooldown exit)", async function ({
+  page,
+  walletTxHashes,
+}) {
+  const publicClient = createEthereumClient();
+
+  // Seed a real staked position, then enable cooldown WITHOUT whitelisting so
+  // the app takes the two-step path: when cooldown is disabled the app treats
+  // everyone as instant (fetchCanInstantWithdraw), and whitelisting would force
+  // the instant one-step form. Leaving the account un-whitelisted keeps the
+  // "Request withdrawal" flow and renders the exit-tickets section.
+  await stakeVusd(DEPOSIT_AMOUNT);
+  await setCooldownEnabled({ forkUrl: ANVIL_URL });
+
+  expect(
+    await readContract(publicClient, {
+      abi: stakingVaultAbi,
+      address: sVusdAddress,
+      functionName: "cooldownEnabled",
+    }),
+  ).toBe(true);
+
+  const [vusdBefore, svusdBefore] = await Promise.all([
+    balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: vusd.address,
+    }),
+    balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: sVusdAddress,
+    }),
+  ]);
+
+  // Drive the exit-tickets table from a mocked API response we control (the
+  // endpoint is otherwise stubbed with [] by the wallet fixture).
+  let exitTicketsBody: ExitTicket[] = [];
+  await page.route("**/variable-stake/exit-tickets/**", (route) =>
+    route.fulfill({ json: exitTicketsBody }),
+  );
+
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  await page.getByRole("link", { name: "Earn" }).click();
+  await expect(page).toHaveURL(/\/en\/earn/);
+
+  // Open the VUSD pool's Withdraw drawer (same locator as the one-step test).
+  const vusdPool = page
+    .locator("div")
+    .filter({ has: page.getByText("VUSD", { exact: true }) })
+    .filter({ has: page.getByRole("button", { name: "Withdraw" }) })
+    .last();
+  await vusdPool.getByRole("button", { name: "Withdraw" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Manage your stake position" }),
+  ).toBeVisible();
+
+  // Fill the amount first: with an empty input the submit button reads "Enter an
+  // amount", and only resolves to its action label once a valid amount is set.
+  await page
+    .locator('input[type="text"]:not([disabled])')
+    .first()
+    .fill(WITHDRAW_DISPLAY);
+
+  // Two-step path: with an amount entered the submit reads "Request withdrawal"
+  // (the instant path would read "Withdraw" instead) — this proves the account
+  // is on the request → cooldown → claim flow. Generous timeout: the drawer's
+  // form body is gated on the canInstantWithdraw/staked-balance reads, and this
+  // is the first hit to the Earn route when the test runs in isolation (Vite
+  // compiles it on demand).
+  const submitButton = page
+    .locator("form")
+    .getByRole("button", { name: "Request withdrawal" });
+  await expect(submitButton).toBeEnabled({ timeout: 20_000 });
+  // Dispatch the click to bypass the fee-section tooltip overlay in CI (see the
+  // deposit test for the full rationale).
+  await submitButton.dispatchEvent("click");
+
+  await expect(page.getByText("Withdrawal request confirmed")).toBeVisible({
+    timeout: 60_000,
+  });
+
+  // The drawer auto-closes ~2s after success and clears its stake-mode URL
+  // params (nuqs). Wait for that before reloading below — otherwise the
+  // persisted params reopen the drawer and its overlay intercepts clicks on the
+  // exit-tickets table (see the deposit test for the same rationale).
+  await expect(
+    page.getByRole("heading", { name: "Manage your stake position" }),
+  ).toBeHidden({ timeout: 15_000 });
+
+  // Read the request tx: WithdrawRequested carries the requestId, the locked
+  // shares/assets, and the on-chain claimableAt. This is the same event
+  // useStakeWithdraw parses to build its optimistic ticket.
+  const requestTxHash = walletTxHashes.at(-1);
+  expect(requestTxHash).toBeDefined();
+  const requestReceipt = await getTransactionReceipt(publicClient, {
+    hash: requestTxHash!,
+  });
+  const requestLogs = parseEventLogs({
+    abi: stakingVaultAbi,
+    args: { owner: TEST_ADDRESS },
+    eventName: "WithdrawRequested",
+    logs: requestReceipt.logs,
+  });
+  expect(requestLogs).toHaveLength(1);
+  const { assets, claimableAt, requestId, shares } = requestLogs[0].args;
+  expect(claimableAt).toBeGreaterThan(0n);
+  expect(assets).toBe(WITHDRAW_AMOUNT);
+  expect(shares).toBeGreaterThan(0n);
+
+  // Shares leave the wallet at request time; VUSD is only paid out on claim.
+  const svusdAfterRequest = await balanceOf(publicClient, {
+    account: TEST_ADDRESS,
+    address: sVusdAddress,
+  });
+  expect(svusdAfterRequest).toBe(svusdBefore - shares);
+  expect(
+    await balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: vusd.address,
+    }),
+  ).toBe(vusdBefore);
+
+  const ticket: ExitTicket = {
+    assets: assets.toString(),
+    claimableAt: claimableAt.toString(),
+    owner: TEST_ADDRESS,
+    requestId: requestId.toString(),
+    requestTxHash: requestTxHash!,
+    shares: shares.toString(),
+    stakingVaultAddress: sVusdAddress,
+  };
+
+  // Cooldown state — mock returns the ticket with its real (future) claimableAt.
+  exitTicketsBody = [ticket];
+  await page.reload();
+  await expect(
+    page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  const exitTickets = page.locator("#exit-tickets");
+  await expect(exitTickets.getByText("Cooldown in progress")).toBeVisible({
+    timeout: 20_000,
+  });
+
+  // Fast-forward the fork past claimableAt so the claim tx passes the contract's
+  // block.timestamp check (Gateway/vault _handleRedeemOrWithdraw).
+  const { timestamp: chainNow } = await getBlock(publicClient);
+  await fastForwardTime({
+    forkUrl: ANVIL_URL,
+    seconds: Number(claimableAt - chainNow),
+  });
+
+  // Ready state — override claimableAt to a past unix ts so getTicketStatus
+  // resolves to "ready" against the real browser clock.
+  exitTicketsBody = [{ ...ticket, claimableAt: "1" }];
+  await page.reload();
+  await expect(
+    page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  await expect(exitTickets.getByText("Ready to withdraw")).toBeVisible({
+    timeout: 20_000,
+  });
+
+  // Step 2 — claim from the row. `exact` avoids matching the "Withdraw all"
+  // button.
+  const rowWithdrawButton = exitTickets.getByRole("button", {
+    exact: true,
+    name: "Withdraw",
+  });
+  await expect(rowWithdrawButton).toBeEnabled();
+  await rowWithdrawButton.click();
+
+  await expect(page.getByText("Withdrawal complete")).toBeVisible({
+    timeout: 40_000,
+  });
+
+  // Confirm the payout against the claim tx itself: sum the VUSD transferred to
+  // the receiver in the claim receipt. walletTxHashes ends with the claim tx
+  // (seeding used a separate client; the only browser txs are the request then
+  // the claim). The StakingVault ABI has no claim event, so read the standard
+  // ERC-20 Transfer(to = receiver) logs on the VUSD token.
+  const claimTxHash = walletTxHashes.at(-1);
+  expect(claimTxHash).toBeDefined();
+  const claimReceipt = await getTransactionReceipt(publicClient, {
+    hash: claimTxHash!,
+  });
+  const vusdReceived = parseEventLogs({
+    abi: erc20Abi,
+    args: { to: TEST_ADDRESS },
+    eventName: "Transfer",
+    logs: claimReceipt.logs,
+  })
+    .filter((log) => isAddressEqual(log.address, vusd.address))
+    .reduce((sum, log) => sum + log.args.value, 0n);
+  expect(vusdReceived).toBeGreaterThan(0n);
+
+  // useClaimWithdraw optimistically sets claimTxHash on the cached ticket, so the
+  // row flips to "Withdrawn". Mirror that onto the mocked endpoint too, so a
+  // background refetch can't overwrite the optimistic state and revert the row
+  // back to "ready".
+  exitTicketsBody = [
+    { ...ticket, claimableAt: "1", claimTxHash: claimTxHash! },
+  ];
+  await expect(exitTickets.getByText("Withdrawn")).toBeVisible();
+
+  // VUSD rose by exactly what the claim receipt paid out; sVUSD stays at its
+  // post-request value (the shares were already removed at request time).
+  await waitForBalance({ client: publicClient, token: vusd.address }).toBe(
+    vusdBefore + vusdReceived,
+  );
+  expect(
+    await balanceOf(publicClient, {
+      account: TEST_ADDRESS,
+      address: sVusdAddress,
+    }),
+  ).toBe(svusdAfterRequest);
+
+  // Check the toast
+  await expect(page.getByText("Withdrawal complete")).toBeVisible({
+    timeout: 10_000,
+  });
 });

--- a/web/e2e/fixtures/wallet.ts
+++ b/web/e2e/fixtures/wallet.ts
@@ -52,6 +52,17 @@ export const test = base.extend<WalletFixtures>({
       transports: { [mainnet.id]: recordingTransport(walletTxHashes) },
     });
 
+    // VITE_VETRO_API_URL points at a fake localhost host (see playwright.config)
+    await page.route("**/variable-stake/apy", (route) =>
+      route.fulfill({ json: {} }),
+    );
+    await page.route("**/variable-stake/cost-basis/**", (route) =>
+      route.fulfill({ json: {} }),
+    );
+    await page.route("**/variable-stake/exit-tickets/**", (route) =>
+      route.fulfill({ json: [] }),
+    );
+
     // The fork is started and funded once in globalSetup, then shared across
     // every test (workers: 1). Without isolation, on-chain mutations from one
     // test leak into the next — e.g. a redeem leaves the gateway allowance set,

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -28,12 +28,13 @@ export default defineConfig({
   webServer: {
     command: `pnpm dev --port ${PORT} --strictPort`,
     env: {
-      // Swap/redeem is fully on-chain; the backend APIs only supply USD display
-      // values. Disable them so e2e stays hermetic (prices render as $0, which
+      // Swap/redeem is fully on-chain; the portal API only supplies USD display
+      // values. Disable it so e2e stays hermetic (prices render as $0, which
       // these tests don't assert on). isValidUrl("") is false → query disabled.
       VITE_PORTAL_API_URL: "",
       VITE_RPC_URL_MAINNET: ANVIL_URL,
-      VITE_VETRO_API_URL: "",
+      // The Vetro API is enabled with a fake localhost URL
+      VITE_VETRO_API_URL: "http://localhost:5555",
     },
     reuseExistingServer: false,
     timeout: 120_000,

--- a/web/scripts/fastForwardTime.ts
+++ b/web/scripts/fastForwardTime.ts
@@ -1,18 +1,20 @@
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 import { createTestClient, http } from "viem";
-import { getBlock, mine } from "viem/actions";
+import { getBlock, increaseTime, mine } from "viem/actions";
 import { mainnet } from "viem/chains";
 
-// Mainnet's ~12s block time. Each mined block advances the fork's
-// block.timestamp by this many seconds.
-const SECONDS_PER_BLOCK = 12;
-
-// Fast-forward the fork by at least `seconds` (mining enough 12s blocks to cover
-// it, always at least one) and return the fork's new block.timestamp. Useful for
-// stepping past time-locked gateway flows (e.g. the withdrawal delay on a
-// two-step redeem) without waiting in real time. Returning the actual timestamp
-// lets callers mirror it onto other clocks instead of re-deriving an estimate.
+/**
+ * Fast-forward the fork by `seconds` and return the fork's new block.timestamp.
+ * Uses evm_increaseTime + a single mined block rather than mining one 12s block
+ * per second, so it stays instant even for multi-day jumps (e.g. the Earn
+ * unstake cooldown, which is a week — mining ~50k blocks would time out the
+ * RPC). Useful for stepping past time-locked flows without waiting in real
+ * time; returning the actual timestamp lets callers mirror it onto other clocks
+ * instead of re-deriving an estimate.
+ *
+ * @returns The fork's new block.timestamp (unix seconds) after the jump.
+ */
 export async function fastForwardTime({
   forkUrl,
   seconds,
@@ -26,8 +28,8 @@ export async function fastForwardTime({
     transport: http(forkUrl),
   });
 
-  const blocks = Math.max(1, Math.ceil(seconds / SECONDS_PER_BLOCK));
-  await mine(testClient, { blocks, interval: SECONDS_PER_BLOCK });
+  await increaseTime(testClient, { seconds });
+  await mine(testClient, { blocks: 1 });
 
   const { timestamp } = await getBlock(testClient);
   return timestamp;

--- a/web/scripts/setCooldownEnabled.ts
+++ b/web/scripts/setCooldownEnabled.ts
@@ -1,0 +1,91 @@
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import {
+  type Address,
+  createPublicClient,
+  createTestClient,
+  http,
+  isAddress,
+  parseEther,
+} from "viem";
+import {
+  impersonateAccount,
+  readContract,
+  setBalance,
+  stopImpersonatingAccount,
+  waitForTransactionReceipt,
+  writeContract,
+} from "viem/actions";
+import { mainnet } from "viem/chains";
+
+import { stakingVaultAbi } from "../../packages/earn/src/abi/stakingVaultAbi.ts";
+import { sVusdAddress } from "../../packages/earn/src/stakingVaultAddresses.ts";
+
+// The StakingVault is Ownable2Step, so its owner-only setters can be called
+// directly after impersonating owner() — no role grant needed (see
+// whitelistInstantWithdraw.ts). Enabling cooldown WITHOUT whitelisting forces
+// the non-instant, two-step withdraw path (request → cooldown → claim): the app
+// treats everyone as instant when cooldown is disabled (fetchCanInstantWithdraw),
+// so the exit-tickets flow is only reachable with cooldown on.
+export async function setCooldownEnabled({
+  forkUrl = "http://127.0.0.1:8545",
+  vaultAddress = sVusdAddress,
+}: {
+  forkUrl?: string;
+  vaultAddress?: Address;
+}) {
+  const transport = http(forkUrl);
+
+  const publicClient = createPublicClient({ chain: mainnet, transport });
+  const testClient = createTestClient({
+    chain: mainnet,
+    mode: "anvil",
+    transport,
+  });
+
+  const owner = await readContract(publicClient, {
+    abi: stakingVaultAbi,
+    address: vaultAddress,
+    functionName: "owner",
+  });
+
+  await impersonateAccount(testClient, { address: owner });
+  await setBalance(testClient, { address: owner, value: parseEther("1") });
+
+  try {
+    const enableHash = await writeContract(testClient, {
+      abi: stakingVaultAbi,
+      account: owner,
+      address: vaultAddress,
+      args: [true],
+      functionName: "updateCooldownEnabled",
+    });
+    await waitForTransactionReceipt(publicClient, { hash: enableHash });
+  } finally {
+    await stopImpersonatingAccount(testClient, { address: owner });
+  }
+
+  console.log(`Cooldown enabled on vault ${vaultAddress}.`);
+}
+
+// Allow running as a standalone script for consumers:
+//   node web/scripts/setCooldownEnabled.ts [--fork-url …] [--vault …]
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { values } = parseArgs({
+    options: {
+      "fork-url": { short: "f", type: "string" },
+      vault: { short: "v", type: "string" },
+    },
+    strict: true,
+  });
+
+  if (values.vault && !isAddress(values.vault, { strict: false })) {
+    console.error("Invalid --vault. Must be a valid address.");
+    process.exit(1);
+  }
+
+  await setCooldownEnabled({
+    forkUrl: values["fork-url"],
+    vaultAddress: (values.vault as Address) ?? sVusdAddress,
+  });
+}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds an E2E test for the Earn withdrawal flow in 2 steps.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Note that the test rapidly closes after the Claim TX is successful because Playwright detects the HTML of the Toast before it renders due to the animation the toast uses

https://github.com/user-attachments/assets/30b4116c-b388-4db2-b547-057bdea0c17d

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
