### PR TITLE
Geoblocking part 1

### DIFF
--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -192,19 +192,49 @@ const htmlHeaders = {
   "X-Frame-Options": "DENY",
 };
 
-// Countries and regions subject to geo-restriction (soft-block).
-const restrictedCountries = new Set(["US"]);
-const restrictedContinents = new Set(["EU"]);
+// Countries subject to geo-restriction (soft-block): EU 27 member states, EEA
+// (Norway, Iceland, Liechtenstein), US and Tor users.
+const restrictedCountries = new Set([
+  "AT",
+  "BE",
+  "BG",
+  "CY",
+  "CZ",
+  "DE",
+  "DK",
+  "EE",
+  "ES",
+  "FI",
+  "FR",
+  "GR",
+  "HR",
+  "HU",
+  "IE",
+  "IS",
+  "IT",
+  "LI",
+  "LT",
+  "LU",
+  "LV",
+  "MT",
+  "NL",
+  "NO",
+  "PL",
+  "PT",
+  "RO",
+  "SE",
+  "SI",
+  "SK",
+  "T1", // Tor exit node (Cloudflare sets this for Tor users).
+  "US",
+]);
 
 function isGeoRestricted(request: Request): boolean {
   const cf = request.cf;
   if (!cf) {
     return false;
   }
-  return (
-    restrictedCountries.has(String(cf.country ?? "")) ||
-    restrictedContinents.has(String(cf.continent ?? ""))
-  );
+  return restrictedCountries.has(String(cf.country ?? ""));
 }
 
 export default {

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -193,7 +193,7 @@ const htmlHeaders = {
 };
 
 // Countries subject to geo-restriction (soft-block): EU 27 member states, EEA
-// (Norway, Iceland, Liechtenstein), US and Tor users.
+// (Norway, Iceland, Liechtenstein), US.
 const restrictedCountries = new Set([
   "AT",
   "BE",
@@ -225,7 +225,6 @@ const restrictedCountries = new Set([
   "SE",
   "SI",
   "SK",
-  "T1", // Tor exit node (Cloudflare sets this for Tor users).
   "US",
 ]);
 

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -192,6 +192,21 @@ const htmlHeaders = {
   "X-Frame-Options": "DENY",
 };
 
+// Countries and regions subject to geo-restriction (soft-block).
+const restrictedCountries = new Set(["US"]);
+const restrictedContinents = new Set(["EU"]);
+
+function isGeoRestricted(request: Request): boolean {
+  const cf = request.cf;
+  if (!cf) {
+    return false;
+  }
+  return (
+    restrictedCountries.has(String(cf.country ?? "")) ||
+    restrictedContinents.has(String(cf.continent ?? ""))
+  );
+}
+
 export default {
   async fetch(request: Request, env: Env) {
     const response = await env.ASSETS.fetch(request);
@@ -209,6 +224,13 @@ export default {
     for (const [key, value] of Object.entries(htmlHeaders)) {
       newResponse.headers.set(key, value);
     }
+
+    // Geo-restriction session cookie for front-end soft-blocking.
+    const restricted = isGeoRestricted(request);
+    newResponse.headers.append(
+      "Set-Cookie",
+      `geo-restricted=${restricted ? "1" : "0"}; SameSite=Strict; Secure; Path=/`,
+    );
 
     // Add dynamic Content-Security-Policy header with unique per-request nonce.
     newResponse.headers.set(

--- a/web/src/utils/geoRestriction.ts
+++ b/web/src/utils/geoRestriction.ts
@@ -1,7 +1,7 @@
 // Reads the geo-restriction session cookie set by the Cloudflare Worker.
 // Returns true when the user is in a restricted region and wallet actions
 // should be disabled.
-export function isGeoRestricted(): boolean {
+export function isGeoRestricted() {
   const match = document.cookie.match(/(^|;\s*)geo-restricted=([^;]*)/);
   return match?.[2] === "1";
 }

--- a/web/src/utils/geoRestriction.ts
+++ b/web/src/utils/geoRestriction.ts
@@ -1,0 +1,7 @@
+// Reads the geo-restriction session cookie set by the Cloudflare Worker.
+// Returns true when the user is in a restricted region and wallet actions
+// should be disabled.
+export function isGeoRestricted(): boolean {
+  const match = document.cookie.match(/(^|;\s*)geo-restricted=([^;]*)/);
+  return match?.[2] === "1";
+}

--- a/web/test/utils/geoRestriction.test.ts
+++ b/web/test/utils/geoRestriction.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isGeoRestricted } from "../../src/utils/geoRestriction";
+
+describe("isGeoRestricted", function () {
+  let cookieValue: string;
+
+  beforeEach(function () {
+    cookieValue = "";
+    vi.stubGlobal(
+      "document",
+      Object.defineProperty({}, "cookie", { get: () => cookieValue }),
+    );
+  });
+
+  afterEach(function () {
+    vi.unstubAllGlobals();
+  });
+
+  it("should return true when geo-restricted=1", function () {
+    cookieValue = "geo-restricted=1";
+    expect(isGeoRestricted()).toBe(true);
+  });
+
+  it("should return false when geo-restricted=0", function () {
+    cookieValue = "geo-restricted=0";
+    expect(isGeoRestricted()).toBe(false);
+  });
+
+  it("should return false when cookie is missing", function () {
+    cookieValue = "";
+    expect(isGeoRestricted()).toBe(false);
+  });
+
+  it("should find cookie among multiple cookies", function () {
+    cookieValue = "theme=dark; geo-restricted=1; lang=en";
+    expect(isGeoRestricted()).toBe(true);
+  });
+});


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR implements the soft-blocking logic to comply with legal regulations to restrict the usage of the application in the US and EU+EEA zone.

In a follow-up PR, the cookie set by the Cloudflare worker and read by the app will be used to disable certain actions or components.

#### Details

This pull request introduces frontend geo-restriction handling by setting a session cookie based on the user's country and providing a utility to read this cookie in the browser. It also adds comprehensive tests to ensure correct behavior. The main focus is on identifying users from restricted regions (EU, EEA, US) and enabling the frontend to soft-block wallet actions accordingly.

**Geo-restriction logic and integration:**

* Added a list of restricted countries and a helper function `isGeoRestricted(request)` in `web/src/index.ts` to determine if a request originates from a restricted region.
* Updated the response handler in `web/src/index.ts` to set a `geo-restricted` session cookie (`1` for restricted, `0` otherwise) for frontend use.

**Frontend utility and testing:**

* Introduced `isGeoRestricted()` utility in `web/src/utils/geoRestriction.ts` to read the `geo-restricted` cookie and signal if wallet actions should be disabled.
* Added a test suite in `web/test/utils/geoRestriction.test.ts` to verify the correct behavior of the `isGeoRestricted()` utility under various cookie scenarios.

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #549

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
