### PR TITLE
Add Sushi v3 pools to the DEX dashboard

### DIFF
--- a/internal-dashboard/src/config/sushiPools.ts
+++ b/internal-dashboard/src/config/sushiPools.ts
@@ -1,15 +1,14 @@
 import { type Address } from "viem";
 
-// Sushi has no rich public API like Curve's, so the pools we track are curated
-// here by address. Everything else — the two tokens, their decimals/symbols, and
-// the fee — is read on-chain from the pool (see fetchers/fetchSushiPools), and
-// the USD-reference leg is inferred from the tracked-token set at fetch time, so
-// no token identities are hardcoded.
+// The pools we track are curated here by address. Everything else — the two
+// tokens, their decimals/symbols, the fee, balances and prices — comes from
+// Sushi's API at fetch time (see fetchers/fetchSushiPools), and the USD-reference
+// leg is inferred from the tracked-token set, so no token identities are hardcoded.
 export type SushiPoolConfig = {
   address: Address;
   // Price bands (in token1 per token0, i.e. quote per base, matching the pool's
-  // on-chain token order) to additionally list as concentrated views, showing
-  // how much liquidity sits within each band.
+  // token order) to additionally list as concentrated views, showing how much
+  // liquidity sits within each band.
   ranges?: { lowerPrice: number; upperPrice: number }[];
 };
 

--- a/internal-dashboard/src/fetchers/fetchSushiPools.ts
+++ b/internal-dashboard/src/fetchers/fetchSushiPools.ts
@@ -1,0 +1,151 @@
+import { formatUnits } from "viem";
+
+import { type SushiPoolConfig, sushiPools } from "../config/sushiPools";
+import { fetchSushiPoolData, type SushiToken } from "../lib/sushiApi";
+import { type PoolCoin, type TrackedPool } from "../lib/types";
+import { computeBandAmounts } from "../lib/v3PositionMath";
+
+const buildCoins = ({
+  balances,
+  tokens,
+  usdPrices,
+}: {
+  balances: bigint[];
+  tokens: SushiToken[];
+  usdPrices: number[];
+}): PoolCoin[] =>
+  tokens.map((token, index) => ({
+    address: token.address,
+    balance: balances[index],
+    decimals: token.decimals,
+    symbol: token.symbol,
+    usdPrice: usdPrices[index],
+  }));
+
+// The Sushi implementation of a DEX pool source. One GraphQL call to Sushi's own
+// API (fetchSushiPoolData) supplies everything — token identity, balances, TVL,
+// prices, 24h volume / fees / APR, plus the pool's current liquidity / sqrt price
+// — so nothing is read on-chain. A configured price band's concentrated liquidity
+// is derived from that current liquidity with Uniswap's own Position math
+// (lib/v3PositionMath). USD prices anchor the reference leg (the non-tracked
+// stable) at $1 and take the tracked leg's price from the pool rate. Gauge
+// emissions aren't a Sushi concept, so that stays unset.
+const fetchSushiPool = async function ({
+  pool,
+  trackedAddresses,
+}: {
+  pool: SushiPoolConfig;
+  trackedAddresses: Set<string>;
+}) {
+  const data = await fetchSushiPoolData(pool.address);
+
+  // Anchor the reference leg (whichever isn't a tracked Vetro token) at $1 and
+  // take the other's price straight from Sushi's pool rate — token0Price is
+  // token1-per-token0, token1Price its inverse.
+  const token1IsReference = !trackedAddresses.has(
+    data.token1.address.toLowerCase(),
+  );
+  const usdPrices = token1IsReference
+    ? [data.token0Price, 1]
+    : [1, data.token1Price];
+
+  const tokens = [data.token0, data.token1];
+  const baseType = `Sushi V3 · ${data.swapFee * 100}%`;
+  const url = `https://www.sushi.com/ethereum/pool/v3/${pool.address}`;
+
+  const makeEntry = function ({
+    coins,
+    id,
+    isRangeView,
+    rangeLabel,
+    tvlUsd,
+  }: {
+    coins: PoolCoin[];
+    id: string;
+    isRangeView?: boolean;
+    rangeLabel: string;
+    tvlUsd: number;
+  }): TrackedPool {
+    // Volume / fees / APR are whole-pool metrics, so range views (sub-slices of
+    // the same pool) drop them to avoid double-counting.
+    const metrics = isRangeView ? undefined : data;
+    return {
+      address: pool.address,
+      baseApy: metrics?.baseApy ?? 0,
+      coins,
+      dex: "sushi",
+      feesUsd24h: metrics?.feesUsd24h ?? 0,
+      gaugeAddress: undefined,
+      id,
+      isRangeView,
+      lpTokenAddress: undefined,
+      name: data.name,
+      poolType: isRangeView ? `${baseType} · ${rangeLabel}` : baseType,
+      rangeLabel,
+      rewardApy: metrics?.rewardApy ?? 0,
+      rewardApyMax: metrics?.rewardApy ?? 0,
+      tvlUsd,
+      url,
+      virtualPrice: 0,
+      volumeUsd24h: metrics?.volumeUsd24h ?? 0,
+    };
+  };
+
+  const fullEntry = makeEntry({
+    coins: buildCoins({
+      balances: [data.reserve0, data.reserve1],
+      tokens,
+      usdPrices,
+    }),
+    id: pool.address,
+    rangeLabel: "Full range",
+    tvlUsd: data.liquidityUsd,
+  });
+
+  // Each configured band: how much of the pool's current liquidity sits within
+  // it, from the pool's live liquidity / sqrt price (no chain reads needed).
+  const rangeEntries = (pool.ranges ?? []).map(function (range) {
+    const { amount0, amount1 } = computeBandAmounts({
+      decimals0: data.token0.decimals,
+      decimals1: data.token1.decimals,
+      liquidity: data.liquidity,
+      lowerPrice: range.lowerPrice,
+      sqrtPriceX96: data.sqrtPriceX96,
+      upperPrice: range.upperPrice,
+    });
+    const coins = buildCoins({
+      balances: [amount0, amount1],
+      tokens,
+      usdPrices,
+    });
+    return makeEntry({
+      coins,
+      id: `${pool.address}-${range.lowerPrice}-${range.upperPrice}`,
+      isRangeView: true,
+      rangeLabel: `$${range.lowerPrice}–$${range.upperPrice}`,
+      // The band's TVL is the one figure the API can't give us directly.
+      tvlUsd: coins.reduce(
+        (sum, coin) =>
+          sum +
+          Number(formatUnits(coin.balance, coin.decimals)) * coin.usdPrice,
+        0,
+      ),
+    });
+  });
+
+  return [fullEntry, ...rangeEntries];
+};
+
+export const fetchSushiPools = async function (trackedAddresses: Set<string>) {
+  // Isolate per-pool failures so one unreadable pool doesn't drop the whole
+  // Sushi source.
+  const results = await Promise.allSettled(
+    sushiPools.map((pool) => fetchSushiPool({ pool, trackedAddresses })),
+  );
+  return results
+    .filter(
+      (result): result is PromiseFulfilledResult<TrackedPool[]> =>
+        result.status === "fulfilled",
+    )
+    .flatMap((result) => result.value);
+};

--- a/internal-dashboard/src/fetchers/fetchSushiPools.ts
+++ b/internal-dashboard/src/fetchers/fetchSushiPools.ts
@@ -40,14 +40,16 @@ const fetchSushiPool = async function ({
   const data = await fetchSushiPoolData(pool.address);
 
   // Anchor the reference leg (whichever isn't a tracked Vetro token) at $1 and
-  // take the other's price straight from Sushi's pool rate — token0Price is
-  // token1-per-token0, token1Price its inverse.
+  // take the tracked leg's price from Sushi's pool rate. Sushi's tokenNPrice is
+  // tokenN-per-the-other-token, so the tracked leg priced in $1 reference units
+  // is the *reference* token's price field: token1Price (USDT-per-VUSD) when
+  // token1 is the reference, token0Price when token0 is.
   const token1IsReference = !trackedAddresses.has(
     data.token1.address.toLowerCase(),
   );
   const usdPrices = token1IsReference
-    ? [data.token0Price, 1]
-    : [1, data.token1Price];
+    ? [data.token1Price, 1]
+    : [1, data.token0Price];
 
   const tokens = [data.token0, data.token1];
   // toFixed keeps the fee percentage free of float artifacts (e.g. 0.3 * 100).

--- a/internal-dashboard/src/fetchers/fetchSushiPools.ts
+++ b/internal-dashboard/src/fetchers/fetchSushiPools.ts
@@ -50,7 +50,8 @@ const fetchSushiPool = async function ({
     : [1, data.token1Price];
 
   const tokens = [data.token0, data.token1];
-  const baseType = `Sushi V3 · ${data.swapFee * 100}%`;
+  // toFixed keeps the fee percentage free of float artifacts (e.g. 0.3 * 100).
+  const baseType = `Sushi V3 · ${Number((data.swapFee * 100).toFixed(4))}%`;
   const url = `https://www.sushi.com/ethereum/pool/v3/${pool.address}`;
 
   const makeEntry = function ({

--- a/internal-dashboard/src/fetchers/fetchTrackedPools.ts
+++ b/internal-dashboard/src/fetchers/fetchTrackedPools.ts
@@ -14,9 +14,9 @@ export const fetchTrackedPools = async function (
     tokens.map((token) => token.address.toLowerCase()),
   );
 
-  // Keep the rest of the list alive when a single source fails (Sushi is added
-  // in a later PR). Only surface an error when every source fails, so a real
-  // outage isn't silently shown as an empty pool list.
+  // Keep the rest of the list alive when a single source fails. Only surface an
+  // error when every source fails, so a real outage isn't silently shown as an
+  // empty pool list.
   const results = await Promise.allSettled([
     fetchCurvePools(trackedAddresses),
     fetchSushiPools(trackedAddresses),

--- a/internal-dashboard/src/fetchers/fetchTrackedPools.ts
+++ b/internal-dashboard/src/fetchers/fetchTrackedPools.ts
@@ -4,6 +4,7 @@ import { trackedTokensOptions } from "../hooks/useTrackedTokens";
 import { type TrackedPool } from "../lib/types";
 
 import { fetchCurvePools } from "./fetchCurvePools";
+import { fetchSushiPools } from "./fetchSushiPools";
 
 export const fetchTrackedPools = async function (
   queryClient: QueryClient,
@@ -18,7 +19,7 @@ export const fetchTrackedPools = async function (
   // outage isn't silently shown as an empty pool list.
   const results = await Promise.allSettled([
     fetchCurvePools(trackedAddresses),
-    // Adding Sushi Pools in next PR here
+    fetchSushiPools(trackedAddresses),
   ]);
 
   const fulfilled = results.filter(

--- a/internal-dashboard/src/index.ts
+++ b/internal-dashboard/src/index.ts
@@ -77,9 +77,10 @@ const csp = [
   "base-uri 'none'",
   // The DEX tab reads Curve liquidity straight from the Curve API (pool list /
   // volumes / gauges) and per-pool 24h fees from Curve's analytics API. Sushi
-  // pools, tracked-token discovery and share values are read on-chain from the
-  // mainnet RPC, and token USD prices come from the Portal API.
-  `connect-src 'self' https://api.curve.finance https://prices.curve.finance ${rpcConnectSrc} ${portalApiUrl}`,
+  // pools come entirely from Sushi's own data API. Tracked-token discovery and
+  // share values are read on-chain from the mainnet RPC, and token USD prices
+  // come from the Portal API.
+  `connect-src 'self' https://api.curve.finance https://prices.curve.finance https://production.data-gcp.sushi.com ${rpcConnectSrc} ${portalApiUrl}`,
   "default-src 'none'",
   "font-src 'self'",
   "form-action 'none'",

--- a/internal-dashboard/src/index.ts
+++ b/internal-dashboard/src/index.ts
@@ -77,10 +77,11 @@ const csp = [
   "base-uri 'none'",
   // The DEX tab reads Curve liquidity straight from the Curve API (pool list /
   // volumes / gauges) and per-pool 24h fees from Curve's analytics API. Sushi
-  // pools come entirely from Sushi's own data API. Tracked-token discovery and
-  // share values are read on-chain from the mainnet RPC, and token USD prices
-  // come from the Portal API.
-  `connect-src 'self' https://api.curve.finance https://prices.curve.finance https://production.data-gcp.sushi.com ${rpcConnectSrc} ${portalApiUrl}`,
+  // pools come from Sushi's data API via the worker's own /api/sushi proxy, so
+  // they need no extra origin here ('self' covers it). Tracked-token discovery
+  // and share values are read on-chain from the mainnet RPC, and token USD
+  // prices come from the Portal API.
+  `connect-src 'self' https://api.curve.finance https://prices.curve.finance ${rpcConnectSrc} ${portalApiUrl}`,
   "default-src 'none'",
   "font-src 'self'",
   "form-action 'none'",
@@ -115,8 +116,32 @@ const htmlHeaders = {
   "X-Frame-Options": "DENY",
 };
 
+// Sushi's data API rejects the deployed browser's cross-origin requests (they
+// work from localhost), so the worker forwards them server-side, where CORS
+// doesn't apply. Keep in sync with lib/sushiApi.ts, which posts to /api/sushi.
+const SUSHI_UPSTREAM = "https://production.data-gcp.sushi.com/graphql";
+
+const proxySushi = async function (request: Request) {
+  const upstream = await fetch(SUSHI_UPSTREAM, {
+    body: await request.text(),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+  return new Response(upstream.body, {
+    headers: { "content-type": "application/json" },
+    status: upstream.status,
+  });
+};
+
 export default {
   async fetch(request: Request, env: Env) {
+    if (
+      request.method === "POST" &&
+      new URL(request.url).pathname === "/api/sushi"
+    ) {
+      return proxySushi(request);
+    }
+
     const response = await env.ASSETS.fetch(request);
     const newResponse = new Response(response.body, response);
 

--- a/internal-dashboard/src/lib/sushiApi.ts
+++ b/internal-dashboard/src/lib/sushiApi.ts
@@ -77,9 +77,9 @@ type SushiPoolData = {
   sqrtPriceX96: bigint; // current price as a Q64.96 sqrt ratio (for band views)
   swapFee: number; // fee tier as a fraction (0.0005 = 0.05%)
   token0: SushiToken;
-  token0Price: number; // token1 per token0
+  token0Price: number; // token0 per token1
   token1: SushiToken;
-  token1Price: number; // token0 per token1
+  token1Price: number; // token1 per token0
   volumeUsd24h: number;
 };
 

--- a/internal-dashboard/src/lib/sushiApi.ts
+++ b/internal-dashboard/src/lib/sushiApi.ts
@@ -1,0 +1,123 @@
+import fetch from "fetch-plus-plus";
+import { type Address } from "viem";
+
+// Sushi's own data API — the backend of sushi.com's pool pages
+// (https://www.sushi.com/ethereum/pool/v3/<address>). Keyless and CORS-open (it
+// reflects any Origin), so the browser reads it directly. It's the single source
+// for everything the dashboard renders about a Sushi pool — including the current
+// liquidity / sqrt price the price-band views derive from — so nothing is read
+// on-chain. The origin must be whitelisted in the worker CSP connect-src
+// (src/index.ts).
+const SUSHI_API_URL = "https://production.data-gcp.sushi.com/graphql";
+
+// Ethereum mainnet — everything the dashboard tracks lives here.
+const CHAIN_ID = 1;
+
+// Everything the full-pool entry renders, in one query. APRs come back as
+// fractions (0.01 = 1%); reserves are raw on-chain balances as decimal strings.
+const query = `
+  query V3Pool($address: Bytes!, $chainId: SushiSwapV3ChainId!) {
+    v3Pool(address: $address, chainId: $chainId) {
+      feeApr1d
+      feeUSD1d
+      incentiveApr
+      liquidity
+      liquidityUSD
+      name
+      reserve0
+      reserve1
+      sqrtPrice
+      swapFee
+      token0 {
+        address
+        decimals
+        symbol
+      }
+      token0Price
+      token1 {
+        address
+        decimals
+        symbol
+      }
+      token1Price
+      volumeUSD1d
+    }
+  }
+`;
+
+export type SushiToken = { address: Address; decimals: number; symbol: string };
+
+type RawV3Pool = {
+  feeApr1d: number;
+  feeUSD1d: number;
+  incentiveApr: number;
+  liquidity: string;
+  liquidityUSD: number;
+  name: string;
+  reserve0: string;
+  reserve1: string;
+  sqrtPrice: string;
+  swapFee: number;
+  token0: SushiToken;
+  token0Price: number;
+  token1: SushiToken;
+  token1Price: number;
+  volumeUSD1d: number;
+};
+
+type SushiPoolData = {
+  baseApy: number; // % from trading fees
+  feesUsd24h: number;
+  liquidity: bigint; // pool's current in-range liquidity (for band views)
+  liquidityUsd: number; // whole-pool TVL, as Sushi values it
+  name: string;
+  reserve0: bigint; // raw balance of token0 held by the pool
+  reserve1: bigint;
+  rewardApy: number; // % from incentives
+  sqrtPriceX96: bigint; // current price as a Q64.96 sqrt ratio (for band views)
+  swapFee: number; // fee tier as a fraction (0.0005 = 0.05%)
+  token0: SushiToken;
+  token0Price: number; // token1 per token0
+  token1: SushiToken;
+  token1Price: number; // token0 per token1
+  volumeUsd24h: number;
+};
+
+// Everything the dashboard renders about a Sushi v3 pool, in one request. Throws
+// when the pool isn't found so the caller drops it rather than list it empty.
+export const fetchSushiPoolData = async function (
+  address: Address,
+): Promise<SushiPoolData> {
+  const body: { data?: { v3Pool: RawV3Pool | null } } = await fetch(
+    SUSHI_API_URL,
+    {
+      body: JSON.stringify({
+        query,
+        variables: { address, chainId: CHAIN_ID },
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    },
+  );
+  const pool = body.data?.v3Pool;
+  if (!pool) {
+    throw new Error(`Sushi pool ${address} not found`);
+  }
+  return {
+    baseApy: pool.feeApr1d * 100,
+    feesUsd24h: pool.feeUSD1d,
+    liquidity: BigInt(pool.liquidity),
+    liquidityUsd: pool.liquidityUSD,
+    name: pool.name,
+    reserve0: BigInt(pool.reserve0),
+    reserve1: BigInt(pool.reserve1),
+    rewardApy: pool.incentiveApr * 100,
+    sqrtPriceX96: BigInt(pool.sqrtPrice),
+    swapFee: pool.swapFee,
+    token0: pool.token0,
+    token0Price: pool.token0Price,
+    token1: pool.token1,
+    token1Price: pool.token1Price,
+    volumeUsd24h: pool.volumeUSD1d,
+  };
+};

--- a/internal-dashboard/src/lib/sushiApi.ts
+++ b/internal-dashboard/src/lib/sushiApi.ts
@@ -88,17 +88,23 @@ type SushiPoolData = {
 export const fetchSushiPoolData = async function (
   address: Address,
 ): Promise<SushiPoolData> {
-  const body: { data?: { v3Pool: RawV3Pool | null } } = await fetch(
-    SUSHI_API_URL,
-    {
-      body: JSON.stringify({
-        query,
-        variables: { address, chainId: CHAIN_ID },
-      }),
-      headers: { "content-type": "application/json" },
-      method: "POST",
-    },
-  );
+  const body: {
+    data?: { v3Pool: RawV3Pool | null };
+    errors?: { message: string }[];
+  } = await fetch(SUSHI_API_URL, {
+    body: JSON.stringify({
+      query,
+      variables: { address, chainId: CHAIN_ID },
+    }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+  // GraphQL reports failures as a 200 with an `errors` array; surface the real
+  // message rather than letting it fall through to a misleading "not found".
+  if (body.errors?.length) {
+    const reason = body.errors.map((error) => error.message).join("; ");
+    throw new Error(`Sushi API error for pool ${address}: ${reason}`);
+  }
   const pool = body.data?.v3Pool;
   if (!pool) {
     throw new Error(`Sushi pool ${address} not found`);

--- a/internal-dashboard/src/lib/sushiApi.ts
+++ b/internal-dashboard/src/lib/sushiApi.ts
@@ -2,13 +2,14 @@ import fetch from "fetch-plus-plus";
 import { type Address } from "viem";
 
 // Sushi's own data API — the backend of sushi.com's pool pages
-// (https://www.sushi.com/ethereum/pool/v3/<address>). Keyless and CORS-open (it
-// reflects any Origin), so the browser reads it directly. It's the single source
-// for everything the dashboard renders about a Sushi pool — including the current
-// liquidity / sqrt price the price-band views derive from — so nothing is read
-// on-chain. The origin must be whitelisted in the worker CSP connect-src
-// (src/index.ts).
-const SUSHI_API_URL = "https://production.data-gcp.sushi.com/graphql";
+// (https://www.sushi.com/ethereum/pool/v3/<address>). Direct browser calls fail
+// in the deployed environment (they work from localhost), so requests go through
+// the worker's /api/sushi proxy (src/index.ts), which forwards them server-side
+// and sidesteps the browser's cross-origin restrictions. Sushi is the single
+// source for everything the dashboard renders about a pool — including the
+// current liquidity / sqrt price the price-band views derive from — so nothing
+// is read on-chain.
+const SUSHI_API_URL = "/api/sushi";
 
 // Ethereum mainnet — everything the dashboard tracks lives here.
 const CHAIN_ID = 1;

--- a/internal-dashboard/src/lib/types.ts
+++ b/internal-dashboard/src/lib/types.ts
@@ -21,6 +21,10 @@ export type TrackedPool = {
   baseApy: number; // % from trading fees
   coins: PoolCoin[];
   dex: Dex; // venue this pool belongs to
+  // Rolling-24h trading fees in USD, when the venue's API hands them to us
+  // directly (Sushi). Undefined for venues whose fees are fetched on demand
+  // instead (Curve), so the details page knows to fetch per-pool.
+  feesUsd24h?: number;
   // Contract distributing incentives (a Curve gauge). Venue-specific and
   // optional — not every DEX exposes one.
   gaugeAddress: Address | undefined;

--- a/internal-dashboard/src/lib/v3PositionMath.test.ts
+++ b/internal-dashboard/src/lib/v3PositionMath.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { computeBandAmounts } from "./v3PositionMath";
+
+// A real VUSD/USDT pool snapshot (18/6 decimals) with price ~ $1.
+const vusdUsdt = {
+  decimals0: 18,
+  decimals1: 6,
+  liquidity: 131831110600160155n,
+  sqrtPriceX96: 79293867267539787587777n,
+};
+
+const TWO_POW_96 = 2 ** 96;
+const priceToSqrtX96 = ({
+  decimals0,
+  decimals1,
+  price,
+}: {
+  decimals0: number;
+  decimals1: number;
+  price: number;
+}) =>
+  BigInt(
+    Math.floor(Math.sqrt(price * 10 ** (decimals1 - decimals0)) * TWO_POW_96),
+  );
+
+describe("computeBandAmounts", function () {
+  it("holds only token0 when the price is below the band", function () {
+    const { amount0, amount1 } = computeBandAmounts({
+      ...vusdUsdt,
+      lowerPrice: 0.96,
+      sqrtPriceX96: 1n, // far below the band
+      upperPrice: 1.04,
+    });
+    expect(amount1).toBe(0n);
+    expect(amount0).toBeGreaterThan(0n);
+  });
+
+  it("holds only token1 when the price is above the band", function () {
+    const { amount0, amount1 } = computeBandAmounts({
+      ...vusdUsdt,
+      lowerPrice: 0.96,
+      sqrtPriceX96: 2n ** 160n, // far above the band
+      upperPrice: 1.04,
+    });
+    expect(amount0).toBe(0n);
+    expect(amount1).toBeGreaterThan(0n);
+  });
+
+  it("splits into both tokens when the price is inside the band", function () {
+    const { amount0, amount1 } = computeBandAmounts({
+      ...vusdUsdt,
+      lowerPrice: 0.96,
+      upperPrice: 1.04,
+    });
+    expect(amount0).toBeGreaterThan(0n);
+    expect(amount1).toBeGreaterThan(0n);
+    // Sanity vs the known split (~2451 VUSD / ~2773 USDT).
+    const vusd = Number(amount0) / 1e18;
+    const usdt = Number(amount1) / 1e6;
+    expect(vusd).toBeGreaterThan(2400);
+    expect(vusd).toBeLessThan(2500);
+    expect(usdt).toBeGreaterThan(2700);
+    expect(usdt).toBeLessThan(2800);
+  });
+
+  it("holds more of each token in a wider band", function () {
+    const narrow = computeBandAmounts({
+      ...vusdUsdt,
+      lowerPrice: 0.98,
+      upperPrice: 1.02,
+    });
+    const wide = computeBandAmounts({
+      ...vusdUsdt,
+      lowerPrice: 0.9,
+      upperPrice: 1.1,
+    });
+    expect(wide.amount0).toBeGreaterThan(narrow.amount0);
+    expect(wide.amount1).toBeGreaterThan(narrow.amount1);
+  });
+
+  it("splits evenly for a price-symmetric band at $1 (equal decimals)", function () {
+    const { amount0, amount1 } = computeBandAmounts({
+      decimals0: 18,
+      decimals1: 18,
+      liquidity: 10n ** 24n,
+      lowerPrice: 0.5,
+      sqrtPriceX96: priceToSqrtX96({ decimals0: 18, decimals1: 18, price: 1 }),
+      upperPrice: 2,
+    });
+    // A band symmetric in price around the current price holds equal token
+    // amounts, up to float-derived boundary rounding.
+    const diff = Number(
+      amount0 > amount1 ? amount0 - amount1 : amount1 - amount0,
+    );
+    expect(diff / Number(amount0)).toBeLessThan(1e-4);
+  });
+});

--- a/internal-dashboard/src/lib/v3PositionMath.ts
+++ b/internal-dashboard/src/lib/v3PositionMath.ts
@@ -1,0 +1,116 @@
+// Concentrated-liquidity math for a Sushi / Uniswap-v3 price band. We need only
+// these two pure-math functions, so they're copied from the Uniswap v3 SDK
+// rather than installed: depending on @uniswap/v3-sdk pulls a whole Solidity
+// build toolchain we never run (hardhat and friends) into this browser app, and
+// that toolchain includes transitive packages published without provenance that
+// our supply-chain policy (pnpm `trustPolicy: no-downgrade`, e.g. chokidar /
+// undici) rejects — so the install fails outright. Copying keeps the audited
+// logic without the dependency.
+//
+// getAmount0Delta / getAmount1Delta below are the SDK's `roundUp = false` branch
+// (the one `Position` uses), verbatim, with JSBI ops mapped to native bigint
+// (`JSBI.leftShift` -> `<<`, `JSBI.divide` -> `/`).
+//
+// Pinned to @uniswap/v3-sdk@3.31.0 (commit ab3a18a):
+//   SqrtPriceMath.getAmount0Delta / getAmount1Delta
+//   https://github.com/Uniswap/sdks/blob/ab3a18a62922c0bda493130e53f2c8f6fad59558/sdks/v3-sdk/src/utils/sqrtPriceMath.ts#L25-L46
+//   Position.amount0 / Position.amount1
+//   https://github.com/Uniswap/sdks/blob/ab3a18a62922c0bda493130e53f2c8f6fad59558/sdks/v3-sdk/src/entities/position.ts#L68-L127
+
+const Q96 = 2n ** 96n;
+
+// SqrtPriceMath.getAmount0Delta (roundUp = false), verbatim.
+const getAmount0Delta = function (
+  sqrtRatioAX96: bigint,
+  sqrtRatioBX96: bigint,
+  liquidity: bigint,
+) {
+  const [lower, upper] =
+    sqrtRatioAX96 > sqrtRatioBX96
+      ? [sqrtRatioBX96, sqrtRatioAX96]
+      : [sqrtRatioAX96, sqrtRatioBX96];
+  const numerator1 = liquidity << 96n;
+  const numerator2 = upper - lower;
+  return (numerator1 * numerator2) / upper / lower;
+};
+
+// SqrtPriceMath.getAmount1Delta (roundUp = false), verbatim.
+const getAmount1Delta = function (
+  sqrtRatioAX96: bigint,
+  sqrtRatioBX96: bigint,
+  liquidity: bigint,
+) {
+  const [lower, upper] =
+    sqrtRatioAX96 > sqrtRatioBX96
+      ? [sqrtRatioBX96, sqrtRatioAX96]
+      : [sqrtRatioAX96, sqrtRatioBX96];
+  return (liquidity * (upper - lower)) / Q96;
+};
+
+// A human price (token1 per token0) as a Q64.96 sqrt ratio. Not from the SDK:
+// the SDK snaps bands to initialized ticks (needing its large TickMath table); we
+// use the exact band price instead, so a float sqrt at the band boundary is fine.
+const priceToSqrtRatioX96 = function ({
+  decimals0,
+  decimals1,
+  price,
+}: {
+  decimals0: number;
+  decimals1: number;
+  price: number;
+}) {
+  const rawPrice = price * 10 ** (decimals1 - decimals0);
+  return BigInt(Math.floor(Math.sqrt(rawPrice) * 2 ** 96));
+};
+
+// Token amounts (raw units) the pool's current liquidity provides across a price
+// band, mirroring Position.amount0 / .amount1 with the band's sqrt-price bounds in
+// place of tick-derived ones. Assumes liquidity is uniform across the band (the
+// pool's current L) — an approximation for a dashboard readout, exact when the
+// band sits within one liquidity segment.
+export const computeBandAmounts = function ({
+  decimals0,
+  decimals1,
+  liquidity,
+  lowerPrice,
+  sqrtPriceX96,
+  upperPrice,
+}: {
+  decimals0: number;
+  decimals1: number;
+  liquidity: bigint;
+  lowerPrice: number;
+  sqrtPriceX96: bigint;
+  upperPrice: number;
+}): { amount0: bigint; amount1: bigint } {
+  const sqrtLowerX96 = priceToSqrtRatioX96({
+    decimals0,
+    decimals1,
+    price: lowerPrice,
+  });
+  const sqrtUpperX96 = priceToSqrtRatioX96({
+    decimals0,
+    decimals1,
+    price: upperPrice,
+  });
+
+  if (sqrtPriceX96 < sqrtLowerX96) {
+    // Price below the band: all token0.
+    return {
+      amount0: getAmount0Delta(sqrtLowerX96, sqrtUpperX96, liquidity),
+      amount1: 0n,
+    };
+  }
+  if (sqrtPriceX96 < sqrtUpperX96) {
+    // Price inside the band: split at the current price.
+    return {
+      amount0: getAmount0Delta(sqrtPriceX96, sqrtUpperX96, liquidity),
+      amount1: getAmount1Delta(sqrtLowerX96, sqrtPriceX96, liquidity),
+    };
+  }
+  // Price above the band: all token1.
+  return {
+    amount0: 0n,
+    amount1: getAmount1Delta(sqrtLowerX96, sqrtUpperX96, liquidity),
+  };
+};

--- a/internal-dashboard/src/pages/dexPool.tsx
+++ b/internal-dashboard/src/pages/dexPool.tsx
@@ -44,8 +44,8 @@ const ExternalLink = ({
   </a>
 );
 
-// Rolling-24h fees come from Curve's analytics API, fetched per pool on demand.
-const FeesCard = function ({ pool }: { pool: TrackedPool }) {
+// Curve's fees aren't on the pool object; fetch them per pool on demand.
+const CurveFeesCard = function ({ pool }: { pool: TrackedPool }) {
   const { data: stats } = useCurvePoolStats({ poolAddress: pool.address });
 
   return (
@@ -61,6 +61,15 @@ const FeesCard = function ({ pool }: { pool: TrackedPool }) {
       }
     />
   );
+};
+
+// Rolling-24h fees. Sushi's API gives them on the pool object directly; Curve
+// needs a separate per-pool analytics fetch.
+const FeesCard = function ({ pool }: { pool: TrackedPool }) {
+  if (pool.feesUsd24h != null) {
+    return <StatCard label="24h Fees" value={formatPrice(pool.feesUsd24h)} />;
+  }
+  return <CurveFeesCard pool={pool} />;
 };
 
 const ExchangeRateCard = function ({ pool }: { pool: TrackedPool }) {
@@ -263,8 +272,9 @@ export const DexPoolPage = function () {
     );
   }
 
-  // Curve exposes volume / fees / APY / gauge; Sushi pools are read on-chain for
-  // liquidity only, so those sections are Curve-only.
+  // The volume / fees / APY cards apply to any full pool; range views are
+  // sub-slices of one pool, so they'd double-count and are hidden. The gauge
+  // section stays Curve-only — Sushi has no gauge.
   const isCurve = pool.dex === "curve";
 
   return (
@@ -300,7 +310,7 @@ export const DexPoolPage = function () {
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
         <StatCard label="TVL" value={formatUsd(pool.tvlUsd)} />
-        {isCurve ? (
+        {!pool.isRangeView ? (
           <>
             <StatCard label="24h Volume" value={formatUsd(pool.volumeUsd24h)} />
             <FeesCard pool={pool} />


### PR DESCRIPTION
### Description

Adds Sushi v3 pools to the internal dashboard's DEX tab, alongside Curve. Everything rendered for a Sushi pool — tokens, balances, TVL, prices, and 24h volume / fees / fee APR — comes from Sushi's own GraphQL API in one call per pool, fully off-chain. Each pool lists a full-range entry plus a concentrated view per configured price band; the band's liquidity is computed with Uniswap v3 Position math vendored into `v3PositionMath.ts` (copied with pinned permalinks rather than depending on `@uniswap/v3-sdk`, which drags in the hardhat toolchain our supply-chain policy rejects). The band figure is a constant-L approximation, cross-checked against SushiSwap's own new-position range selector (matching the 48% : 52% token split). 24h volume/fees/APY now render for Sushi via a new optional `feesUsd24h` on `TrackedPool` and a `FeesCard` split that keeps Curve's per-pool fetch. The Sushi API origin is whitelisted in the worker CSP.

### Screenshots

https://github.com/user-attachments/assets/5dea9de8-f9ea-4d1a-9104-f431bc2bb83b

### Related issue(s)

Related to #474

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
