### PR TITLE
Bump eslint-config-bloq to 4.8.2

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,23 +3,19 @@
   "ignorePatterns": [
     "api/.wrangler/**/*",
     "internal-dashboard/dist/**/*",
+    "subgraph/**/*",
     "web/dist/**/*",
     "web/storybook-static/**/*"
   ],
   "overrides": [
     {
-      "excludedFiles": [
-        "internal-dashboard/dist/**/*",
-        "subgraph/generated/**/*",
-        "web/dist/**/*"
-      ],
+      "excludedFiles": ["internal-dashboard/dist/**/*", "web/dist/**/*"],
       "extends": ["bloq/esm", "bloq/typescript", "prettier"],
       "files": [
         "*.{js,mjs}",
         "api/**/*.ts",
         "internal-dashboard/**/*.{js,ts,tsx}",
         "packages/**/*.{js,ts,tsx}",
-        "subgraph/**/*.ts",
         "web/**/*.{js,ts,tsx}"
       ]
     },
@@ -42,7 +38,7 @@
       "files": ["*.d.ts"]
     },
     {
-      "excludedFiles": ["api/tests/*.ts", "subgraph/tests/*.ts"],
+      "excludedFiles": ["api/tests/*.ts"],
       "extends": ["bloq/typescript", "bloq/vitest"],
       "files": ["*.{spec,test}.{js,ts}"]
     },

--- a/internal-dashboard/src/lib/curveApi.ts
+++ b/internal-dashboard/src/lib/curveApi.ts
@@ -76,10 +76,10 @@ export const fetchGauges = (): Promise<CurveGaugeInfo[]> =>
   );
 
 type CurvePoolStats = {
-  liquidityFee24h: number;
-  tradingFee24h: number;
-  tradingVolume24h: number;
-  tvlUsd: number;
+  liquidityFee24h: number | null;
+  tradingFee24h: number | null;
+  tradingVolume24h: number | null;
+  tvlUsd: number | null;
 };
 
 // Rolling-24h fees and volume for a single pool, as shown on curvemonitor.

--- a/internal-dashboard/src/pages/dexPool.tsx
+++ b/internal-dashboard/src/pages/dexPool.tsx
@@ -57,7 +57,9 @@ const CurveFeesCard = function ({ pool }: { pool: TrackedPool }) {
       }
       label="24h Fees"
       value={
-        stats?.tradingFee24h != null ? formatPrice(stats.tradingFee24h) : "—"
+        stats?.tradingFee24h !== undefined
+          ? formatPrice(stats.tradingFee24h)
+          : "—"
       }
     />
   );

--- a/internal-dashboard/src/pages/dexPool.tsx
+++ b/internal-dashboard/src/pages/dexPool.tsx
@@ -68,7 +68,7 @@ const CurveFeesCard = function ({ pool }: { pool: TrackedPool }) {
 // Rolling-24h fees. Sushi's API gives them on the pool object directly; Curve
 // needs a separate per-pool analytics fetch.
 const FeesCard = function ({ pool }: { pool: TrackedPool }) {
-  if (pool.feesUsd24h != null) {
+  if (pool.feesUsd24h !== null && pool.feesUsd24h !== undefined) {
     return <StatCard label="24h Fees" value={formatPrice(pool.feesUsd24h)} />;
   }
   return <CurveFeesCard pool={pool} />;

--- a/internal-dashboard/src/pages/dexPool.tsx
+++ b/internal-dashboard/src/pages/dexPool.tsx
@@ -51,13 +51,13 @@ const CurveFeesCard = function ({ pool }: { pool: TrackedPool }) {
   return (
     <StatCard
       hint={
-        stats && stats.liquidityFee24h > 0
+        stats && stats.liquidityFee24h !== null && stats.liquidityFee24h > 0
           ? `+ ${formatPrice(stats.liquidityFee24h)} liquidity fees`
           : undefined
       }
       label="24h Fees"
       value={
-        stats?.tradingFee24h !== undefined
+        stats?.tradingFee24h !== undefined && stats.tradingFee24h !== null
           ? formatPrice(stats.tradingFee24h)
           : "—"
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "better-sort-package-json": "1.1.1",
     "commitlint-config-bloq": "1.1.0",
     "eslint": "8.57.0",
-    "eslint-config-bloq": "4.7.0",
+    "eslint-config-bloq": "4.8.2",
     "husky": "9.1.7",
     "knip": "6.9.0",
     "lint-staged": "17.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 8.57.0
         version: 8.57.0
       eslint-config-bloq:
-        specifier: 4.7.0
-        version: 4.7.0(@types/estree@1.0.8)(eslint@8.57.0)(typescript@6.0.2)(vitest@4.1.9)
+        specifier: 4.8.2
+        version: 4.8.2(@types/estree@1.0.8)(eslint@8.57.0)(typescript@6.0.2)(vitest@4.1.9)
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -4968,10 +4968,6 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==, tarball: https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz}
 
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==, tarball: https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz}
-    engines: {node: '>= 0.4'}
-
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==, tarball: https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz}
     engines: {node: '>= 0.4'}
@@ -5028,8 +5024,9 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
-  eslint-config-bloq@4.7.0:
-    resolution: {integrity: sha512-lUrMh4C5+sfp5TKpA4/Np1R0kfgaMtT7At6BkY/jeok3WfGEpBtlvg1sGaF/a+FtKEJlpeIaDprNXES+cT5iVg==, tarball: https://registry.npmjs.org/eslint-config-bloq/-/eslint-config-bloq-4.7.0.tgz}
+  eslint-config-bloq@4.8.2:
+    resolution: {integrity: sha512-LHpaTtRX7e6YgK9uypiVhjOFk+aieE3GG0c/lrsFFxauuvP20w+a7ndhWccUASBul/gfQ7z6On0cdb0G7dEiRg==, tarball: https://registry.npmjs.org/eslint-config-bloq/-/eslint-config-bloq-4.8.2.tgz}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.0.0
 
@@ -5181,6 +5178,12 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+
+  eslint-plugin-react-hooks@6.1.1:
+    resolution: {integrity: sha512-St9EKZzOAQF704nt2oJvAKZHjhrpg25ClQoaAlHmPZuajFldVLqRDW4VBNAS01NzeiQF0m0qhG1ZA807K6aVaQ==, tarball: https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-6.1.1.tgz}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==, tarball: https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz}
@@ -5523,9 +5526,6 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==, tarball: https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.13.0:
-    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==, tarball: https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz}
-
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==, tarball: https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz}
 
@@ -5557,6 +5557,7 @@ packages:
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==, tarball: https://registry.npmjs.org/glob/-/glob-7.1.7.tgz}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==, tarball: https://registry.npmjs.org/glob/-/glob-7.2.3.tgz}
@@ -8699,6 +8700,12 @@ packages:
 
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==, tarball: https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz}
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==, tarball: https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==, tarball: https://registry.npmjs.org/zod/-/zod-3.22.4.tgz}
@@ -12029,7 +12036,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.53.1
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 9.0.5
-      semver: 7.7.3
+      semver: 7.8.5
       tinyglobby: 0.2.16
       ts-api-utils: 2.4.0(typescript@6.0.2)
       typescript: 6.0.2
@@ -13010,11 +13017,11 @@ snapshots:
 
   array-includes@3.1.9:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-abstract: 1.24.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       get-intrinsic: 1.3.0
       is-string: 1.1.1
       math-intrinsics: 1.1.0
@@ -13032,24 +13039,24 @@ snapshots:
 
   array.prototype.findlastindex@1.2.6:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-abstract: 1.24.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       es-shim-unscopables: 1.1.0
 
   array.prototype.flat@1.3.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-abstract: 1.24.1
       es-shim-unscopables: 1.1.0
 
   array.prototype.flatmap@1.3.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-abstract: 1.24.1
       es-shim-unscopables: 1.1.0
@@ -14042,10 +14049,6 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
-  es-object-atoms@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
-
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -14144,9 +14147,9 @@ snapshots:
   eslint-compat-utils@0.6.5(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
-      semver: 7.7.3
+      semver: 7.8.5
 
-  eslint-config-bloq@4.7.0(@types/estree@1.0.8)(eslint@8.57.0)(typescript@6.0.2)(vitest@4.1.9):
+  eslint-config-bloq@4.8.2(@types/estree@1.0.8)(eslint@8.57.0)(typescript@6.0.2)(vitest@4.1.9):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.53.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint@8.57.0)(typescript@6.0.2)
       '@typescript-eslint/parser': 8.53.1(eslint@8.57.0)(typescript@6.0.2)
@@ -14157,12 +14160,15 @@ snapshots:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint@8.57.0)
       eslint-plugin-jsdoc: 43.2.0(eslint@8.57.0)
       eslint-plugin-jsonc: 2.21.0(eslint@8.57.0)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
       eslint-plugin-markdownlint: 0.6.0(eslint@8.57.0)
       eslint-plugin-mocha: 10.5.0(eslint@8.57.0)
       eslint-plugin-node: 11.1.0(eslint@8.57.0)
       eslint-plugin-package-json: 0.31.0(@types/estree@1.0.8)(eslint@8.57.0)(jsonc-eslint-parser@2.4.2)
       eslint-plugin-prefer-arrow: 1.2.3(eslint@8.57.0)
       eslint-plugin-promise: 6.6.0(eslint@8.57.0)
+      eslint-plugin-react: 7.37.5(eslint@8.57.0)
+      eslint-plugin-react-hooks: 6.1.1(eslint@8.57.0)
       eslint-plugin-sort-destructure-keys: 2.0.0(eslint@8.57.0)
       jsonc-eslint-parser: 2.4.2
     transitivePeerDependencies:
@@ -14217,7 +14223,7 @@ snapshots:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.0
-      get-tsconfig: 4.13.0
+      get-tsconfig: 4.14.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.16
@@ -14287,7 +14293,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       eslint: 8.57.0
       esquery: 1.7.0
-      semver: 7.7.3
+      semver: 7.8.5
       spdx-expression-parse: 3.0.1
     transitivePeerDependencies:
       - supports-color
@@ -14357,7 +14363,7 @@ snapshots:
       eslint-fix-utils: 0.2.1(@types/estree@1.0.8)(eslint@8.57.0)
       jsonc-eslint-parser: 2.4.2
       package-json-validator: 0.10.2
-      semver: 7.7.3
+      semver: 7.8.5
       sort-object-keys: 1.1.3
       sort-package-json: 3.6.0
       validate-npm-package-name: 6.0.2
@@ -14375,6 +14381,16 @@ snapshots:
   eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
+
+  eslint-plugin-react-hooks@6.1.1(eslint@8.57.0):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/parser': 7.29.7
+      eslint: 8.57.0
+      zod: 4.3.5
+      zod-validation-error: 4.0.2(zod@4.3.5)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react@7.37.5(eslint@8.57.0):
     dependencies:
@@ -14765,10 +14781,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
-
-  get-tsconfig@4.13.0:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -15412,7 +15424,7 @@ snapshots:
       acorn: 8.15.0
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
-      semver: 7.7.3
+      semver: 7.8.5
 
   jsonfile@6.2.0:
     dependencies:
@@ -15925,23 +15937,23 @@ snapshots:
 
   object.fromentries@2.0.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-abstract: 1.24.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   object.groupby@1.0.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-abstract: 1.24.1
 
   object.values@1.2.1:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   obug@2.1.1: {}
 
@@ -16981,7 +16993,7 @@ snapshots:
       detect-newline: 4.0.1
       git-hooks-list: 4.2.1
       is-plain-obj: 4.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       sort-object-keys: 2.1.0
       tinyglobby: 0.2.16
 
@@ -17136,10 +17148,10 @@ snapshots:
 
   string.prototype.trimend@1.0.9:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   string.prototype.trimstart@1.0.8:
     dependencies:
@@ -18368,6 +18380,10 @@ snapshots:
       '@speed-highlight/core': 1.2.14
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  zod-validation-error@4.0.2(zod@4.3.5):
+    dependencies:
+      zod: 4.3.5
 
   zod@3.22.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ minimumReleaseAge: 10080 # 7 days in minutes
 minimumReleaseAgeExclude:
   - "@hemilabs/*"
   - "@vetro-protocol/*"
+  - "eslint-config-bloq"
   - "viem-erc20"
   - "viem-erc4626"
 
@@ -46,4 +47,6 @@ trustPolicy: no-downgrade
 # version already present in the committed lockfile; allowlist it so installs
 # can resolve.
 trustPolicyExclude:
+  - "eslint-config-prettier@8.10.2"
+  - "eslint-import-resolver-typescript@3.10.1"
   - "semver@6.3.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,6 +47,10 @@ trustPolicy: no-downgrade
 # version already present in the committed lockfile; allowlist it so installs
 # can resolve.
 trustPolicyExclude:
+  # eslint-config-prettier and eslint-import-resolver-typescript are transitive
+  # dependencies of the eslint toolchain (eslint-config-bloq); their pinned
+  # versions are rejected by `trustPolicy: no-downgrade`, so allowlist them to
+  # let installs resolve.
   - "eslint-config-prettier@8.10.2"
   - "eslint-import-resolver-typescript@3.10.1"
   - "semver@6.3.1"

--- a/web/src/components/borrow/positionsTable.tsx
+++ b/web/src/components/borrow/positionsTable.tsx
@@ -127,7 +127,7 @@ export function PositionsTable({ marketIds }: Props) {
         cell({ row }) {
           const lltv = formatLtvAsPercentage(row.original.lltv);
           const ltv =
-            row.original.ltv != null
+            row.original.ltv !== null && row.original.ltv !== undefined
               ? formatLtvAsPercentage(row.original.ltv)
               : null;
           const value = formatHealthFactor(row.original.healthFactor);
@@ -156,7 +156,7 @@ export function PositionsTable({ marketIds }: Props) {
         cell: ({ row }) => (
           <div className="flex flex-col items-center">
             <span className="text-b-medium text-gray-900">
-              {row.original.ltv != null
+              {row.original.ltv !== null && row.original.ltv !== undefined
                 ? `${formatPercentage(formatLtvAsPercentage(row.original.ltv))}`
                 : "-"}
             </span>


### PR DESCRIPTION
### Description

Update `eslint-config-bloq` from 4.7.0 to 4.8.2, which pulls in the react, react-hooks and jsx-a11y plugins.

Adapt to the stricter rules by replacing `!= null` checks with explicit null/undefined comparisons in the internal dashboard and borrow positions table.

Ignore the whole `subgraph/` directory: it is AssemblyScript, not TypeScript, so the JS/TS rules don't apply there.

Allowlist `eslint-config-bloq` in `minimumReleaseAgeExclude` and add the required `trustPolicy` excludes so pnpm can resolve the install.

### Screenshots

N/A

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.