### PR TITLE
Enable knip for internal-dashboard

### DIFF
--- a/.knip.json
+++ b/.knip.json
@@ -1,7 +1,6 @@
 {
   "ignore": ["web/scripts/*"],
   "ignoreDependencies": ["eslint-config-prettier"],
-  "ignoreWorkspaces": ["internal-dashboard"],
   "workspaces": {
     "api": {
       "ignoreDependencies": ["@sentry/cli"]

--- a/internal-dashboard/src/lib/curveApi.ts
+++ b/internal-dashboard/src/lib/curveApi.ts
@@ -75,7 +75,7 @@ export const fetchGauges = (): Promise<CurveGaugeInfo[]> =>
     })),
   );
 
-export type CurvePoolStats = {
+type CurvePoolStats = {
   liquidityFee24h: number;
   tradingFee24h: number;
   tradingVolume24h: number;

--- a/internal-dashboard/src/lib/distribution.ts
+++ b/internal-dashboard/src/lib/distribution.ts
@@ -6,7 +6,7 @@ import { type TrackedPool, type TrackedToken } from "./types";
 // well beyond the 2 decimals of percentage the UI renders.
 const SHARE_SCALE = 1_000_000n;
 
-export type DistributionSlice = {
+type DistributionSlice = {
   balance: bigint; // raw on-chain units
   pool: TrackedPool;
   share: number; // 0..1 of the token's total tracked liquidity


### PR DESCRIPTION
### Description

Removes \`internal-dashboard\` from knip's \`ignoreWorkspaces\` so it gets linted like the rest of the monorepo. Fixes the two findings this surfaces by making \`CurvePoolStats\` and \`DistributionSlice\` local, since they were exported but only used within their own files.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #474

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.