### PR TITLE
Move header to fixed bottom bar on mobile

### DIFF
--- a/web/src/components/base/stack.tsx
+++ b/web/src/components/base/stack.tsx
@@ -15,14 +15,17 @@ const STACK_OFFSET = 12;
 // Below `sm` the header moves to the bottom of the screen as a bar (h-16), so
 // bottom-anchored stacks are lifted by its height (4rem) plus the base 1rem gap
 // to clear it.
-// `z-0` keeps the stack below overlay backdrops (z-10+) so modals, drawers and
-// the mobile nav sheet cover it; it still paints above page content since it is
-// portaled to the end of `document.body`.
+// The bottom-center stack (ambient app notifications) uses `z-0` so overlay
+// backdrops (z-10+) — modals, drawers and the mobile nav sheet — cover it. The
+// bottom-right stack (transactional toasts) stays at `z-40` so success/error
+// toasts remain visible above a drawer that lingers after the flow completes.
+// Both still paint above page content since they are portaled to the end of
+// `document.body`.
 const positions = {
   "bottom-center":
     "fixed bottom-20 left-1/2 z-0 w-80 -translate-x-1/2 sm:bottom-4",
   "bottom-right":
-    "fixed inset-x-4 bottom-20 z-0 sm:bottom-4 md:inset-x-auto md:right-4 md:w-96",
+    "fixed inset-x-4 bottom-20 z-40 sm:bottom-4 md:inset-x-auto md:right-4 md:w-96",
 } as const;
 
 export type StackItem = {

--- a/web/src/components/base/stack.tsx
+++ b/web/src/components/base/stack.tsx
@@ -12,8 +12,9 @@ const GAP = 12;
 const SCALE_FACTOR = 0.05;
 const STACK_OFFSET = 12;
 
-// Below `sm` the header renders as a fixed bottom bar (h-16), so bottom-anchored
-// stacks are lifted by its height (4rem) plus the base 1rem gap to clear it.
+// Below `sm` the header moves to the bottom of the screen as a bar (h-16), so
+// bottom-anchored stacks are lifted by its height (4rem) plus the base 1rem gap
+// to clear it.
 // `z-0` keeps the stack below overlay backdrops (z-10+) so modals, drawers and
 // the mobile nav sheet cover it; it still paints above page content since it is
 // portaled to the end of `document.body`.

--- a/web/src/components/base/stack.tsx
+++ b/web/src/components/base/stack.tsx
@@ -12,10 +12,16 @@ const GAP = 12;
 const SCALE_FACTOR = 0.05;
 const STACK_OFFSET = 12;
 
+// Below `sm` the header renders as a fixed bottom bar (h-16), so bottom-anchored
+// stacks are lifted by its height (4rem) plus the base 1rem gap to clear it.
+// `z-0` keeps the stack below overlay backdrops (z-10+) so modals, drawers and
+// the mobile nav sheet cover it; it still paints above page content since it is
+// portaled to the end of `document.body`.
 const positions = {
-  "bottom-center": "fixed bottom-4 left-1/2 z-40 w-80 -translate-x-1/2",
+  "bottom-center":
+    "fixed bottom-20 left-1/2 z-0 w-80 -translate-x-1/2 sm:bottom-4",
   "bottom-right":
-    "fixed inset-x-4 bottom-4 z-40 md:inset-x-auto md:right-4 md:w-96",
+    "fixed inset-x-4 bottom-20 z-0 sm:bottom-4 md:inset-x-auto md:right-4 md:w-96",
 } as const;
 
 export type StackItem = {

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -41,7 +41,7 @@ export function Header() {
 
   return (
     <>
-      <div className="flex h-16 items-center gap-x-3 border-b border-gray-200 px-6 md:justify-between">
+      <div className="flex h-16 items-center gap-x-3 border-b border-gray-200 px-6 max-sm:order-last max-sm:border-t max-sm:border-b-0 max-sm:bg-white max-sm:px-4 md:justify-between">
         <HeaderStart />
         <div className="hidden flex-1 justify-center xl:flex">
           <NavBarLinks />


### PR DESCRIPTION
### Description

On viewports below the `sm` breakpoint (640px), the header now renders as a fixed bar at the **bottom** of the screen instead of the top, keeping navigation within thumb reach. The bar keeps the same contents (logo, help menu, wallet button, and hamburger that opens the nav sheet) — only its position, border side, and background change. At `≥ 640px` the header is unchanged.

Bottom-anchored notification stacks (`Stack`) are lifted above the new bar by its height, and their z-index is dropped below overlay backdrops so modals, drawers, and the mobile nav sheet cover them instead of showing through.

### Screenshots

https://github.com/user-attachments/assets/b531c7ef-e855-45a0-88b5-598a5c986f5a

### Related issue(s)

Closes #404

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A. (N/A — CSS-only change)
- [x] Documentation updated, or N/A. (N/A)
- [x] Environment variables set in CI, or N/A. (N/A)