### PR TITLE
Keep drawer open when opening a modal inside it

### DIFF
--- a/web/src/hooks/useOverlay.ts
+++ b/web/src/hooks/useOverlay.ts
@@ -5,13 +5,43 @@ import {
   useChainModal,
   useConnectModal,
 } from "@rainbow-me/rainbowkit";
-import { type TransitionEvent, useEffect, useState } from "react";
+import { type TransitionEvent, useEffect, useRef, useState } from "react";
+
+// Overlays (Drawer, Modal, ...) each portal into document.body as siblings, so
+// a click inside a modal opened from within a drawer reads as "outside" the
+// drawer. Track mounted overlays so only the topmost one dismisses on
+// outside-click / Escape — a modal closes without taking the drawer beneath it
+// with it.
+//
+// Registration happens in an effect, so this reflects z-order only because a
+// nested overlay is always opened by user interaction (a later commit) than the
+// one beneath it — its effect runs after, landing it on top of the stack. React
+// runs effects child-before-parent, so this would invert if a nested overlay
+// ever mounted already-open in the same commit as its parent.
+const overlayStack: symbol[] = [];
 
 export function useOverlay<T extends HTMLElement>(onClose: VoidFunction) {
   const [isOpen, setIsOpen] = useState(false);
   const { accountModalOpen } = useAccountModal();
   const { chainModalOpen } = useChainModal();
   const { connectModalOpen } = useConnectModal();
+  const idRef = useRef<symbol | null>(null);
+  if (idRef.current === null) {
+    idRef.current = Symbol("overlay");
+  }
+
+  useEffect(function registerInStack() {
+    const id = idRef.current!;
+    overlayStack.push(id);
+    return function unregister() {
+      const index = overlayStack.indexOf(id);
+      if (index !== -1) {
+        overlayStack.splice(index, 1);
+      }
+    };
+  }, []);
+
+  const isTopmost = () => overlayStack.at(-1) === idRef.current;
 
   function handleClose() {
     if (accountModalOpen || chainModalOpen || connectModalOpen) {
@@ -20,11 +50,18 @@ export function useOverlay<T extends HTMLElement>(onClose: VoidFunction) {
     setIsOpen(false);
   }
 
-  const ref = useOnClickOutside<T>(handleClose);
+  function handleDismiss() {
+    if (!isTopmost()) {
+      return;
+    }
+    handleClose();
+  }
+
+  const ref = useOnClickOutside<T>(handleDismiss);
 
   useOnKeyUp(function (e) {
     if (e.key === "Escape") {
-      handleClose();
+      handleDismiss();
     }
   });
 


### PR DESCRIPTION
### Description

A modal opened from within a drawer (e.g. the token selector opened from the Redeem drawer) portals into `document.body` as a sibling of the drawer, so a click inside the modal read as "outside" the drawer and dismissed both at once.

This tracks mounted overlays (Drawer, Modal, ...) in a shared stack and only lets the topmost one dismiss on outside-click / Escape. Selecting a token now closes the modal while leaving the drawer open with the chosen token, as expected.

### Screenshots

https://github.com/user-attachments/assets/142ca085-7528-4950-b4cd-5437d4f5f492

### Related issue(s)

Closes #609

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.