### PR TITLE
Round token amounts in toasts and notifications

### DIFF
--- a/web/src/components/appNotifications.tsx
+++ b/web/src/components/appNotifications.tsx
@@ -11,7 +11,8 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
 import { unixNowTimestamp } from "utils/date";
-import { formatAmount } from "utils/token";
+import { formatNumber } from "utils/format";
+import { formatUnits } from "viem";
 
 /**
  * Schedules a re-render the moment the soonest future timestamp in `items`
@@ -108,12 +109,9 @@ function RedeemNotification({
   const navigate = useI18nNavigate();
   const { t } = useTranslation();
 
-  const formattedAmount = formatAmount({
-    amount: amountLocked,
-    decimals: peggedToken.decimals,
-    isError: false,
-    symbol: peggedToken.symbol,
-  });
+  const formattedAmount = `${formatNumber(
+    formatUnits(amountLocked, peggedToken.decimals),
+  )} ${peggedToken.symbol}`;
 
   function handleClick() {
     const el = document.getElementById("redeem-queue");

--- a/web/src/components/borrow/borrowForm.tsx
+++ b/web/src/components/borrow/borrowForm.tsx
@@ -31,6 +31,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { getMaxBorrowable } from "utils/borrowLimit";
+import { formatNumber } from "utils/format";
 import { type Address, formatUnits, parseUnits } from "viem";
 import { useAccount } from "wagmi";
 
@@ -411,7 +412,7 @@ export function BorrowForm({
         <Toast
           closable
           description={t("pages.borrow.toast.description", {
-            amount: borrowInput,
+            amount: formatNumber(borrowInput),
             symbol: loanToken.symbol,
           })}
           onClose={() => setShowToast(false)}

--- a/web/src/components/borrow/borrowMoreForm.tsx
+++ b/web/src/components/borrow/borrowMoreForm.tsx
@@ -33,6 +33,7 @@ import { type FormEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { maxBigInt, minBigInt } from "utils/bigint";
 import { formatLtvAsPercentage } from "utils/borrowReview";
+import { formatNumber } from "utils/format";
 import { parseTokenUnits } from "utils/token";
 import { formatUnits } from "viem";
 import { useAccount } from "wagmi";
@@ -405,7 +406,7 @@ export function BorrowMoreForm({ market, onClose }: Props) {
         <Toast
           closable
           description={t("pages.borrow.toast.description", {
-            amount: borrowInput,
+            amount: formatNumber(borrowInput),
             symbol: loanToken.symbol,
           })}
           onClose={() => setShowToast(false)}

--- a/web/src/components/borrow/repayLoanForm.tsx
+++ b/web/src/components/borrow/repayLoanForm.tsx
@@ -34,6 +34,7 @@ import { useMainnet } from "hooks/useMainnet";
 import { type FormEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { formatLtvAsPercentage } from "utils/borrowReview";
+import { formatNumber } from "utils/format";
 import { parseTokenUnits } from "utils/token";
 import { useAccount } from "wagmi";
 
@@ -431,7 +432,7 @@ export function RepayLoanForm({ market, onClose }: Props) {
         <Toast
           closable
           description={t("pages.borrow.repay-loan-progress.toast-description", {
-            amount: repayInput,
+            amount: formatNumber(repayInput),
             symbol: loanToken.symbol,
           })}
           onClose={() => setShowToast(false)}

--- a/web/src/components/borrow/supplyCollateralForm.tsx
+++ b/web/src/components/borrow/supplyCollateralForm.tsx
@@ -34,6 +34,7 @@ import { useMainnet } from "hooks/useMainnet";
 import { type FormEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { formatLtvAsPercentage } from "utils/borrowReview";
+import { formatNumber } from "utils/format";
 import { parseTokenUnits } from "utils/token";
 import { useAccount } from "wagmi";
 
@@ -439,7 +440,7 @@ export function SupplyCollateralForm({ market, onClose }: Props) {
           description={t(
             "pages.borrow.supply-collateral-progress.toast-description",
             {
-              amount: collateralInput,
+              amount: formatNumber(collateralInput),
               symbol: collateralToken.symbol,
             },
           )}

--- a/web/src/components/borrow/withdrawCollateralForm.tsx
+++ b/web/src/components/borrow/withdrawCollateralForm.tsx
@@ -30,6 +30,7 @@ import { useMainnet } from "hooks/useMainnet";
 import { type FormEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { formatLtvAsPercentage } from "utils/borrowReview";
+import { formatNumber } from "utils/format";
 import { parseTokenUnits } from "utils/token";
 import { formatUnits } from "viem";
 import { useAccount } from "wagmi";
@@ -371,7 +372,7 @@ export function WithdrawCollateralForm({ market, onClose }: Props) {
           description={t(
             "pages.borrow.withdraw-collateral-progress.toast-description",
             {
-              amount: collateralInput,
+              amount: formatNumber(collateralInput),
               symbol: collateralToken.symbol,
             },
           )}

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -22,6 +22,7 @@ import { type FormEvent, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
 import { applyBps } from "utils/fees";
+import { formatNumber } from "utils/format";
 import { getInputError } from "utils/inputError";
 import { formatAmount } from "utils/token";
 import { parseUnits } from "viem";
@@ -169,9 +170,9 @@ export function Deposit({
         onCompleted();
         setFlowStatus("deposited");
         setToastData({
-          fromAmount: fromInputValue,
+          fromAmount: formatNumber(fromInputValue),
           fromSymbol: fromToken.symbol,
-          toAmount: outputValue,
+          toAmount: formatNumber(outputValue),
           toSymbol: toToken.symbol,
         });
         setShowToast(true);

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -22,6 +22,7 @@ import { type FormEvent, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
 import { applyBps } from "utils/fees";
+import { formatNumber } from "utils/format";
 import { getInputError } from "utils/inputError";
 import { formatAmount } from "utils/token";
 import { isAddressEqual, parseUnits } from "viem";
@@ -163,9 +164,9 @@ export function OneStepRedeem({
         onCompleted();
         setFlowStatus("redeemed");
         setToastData({
-          fromAmount: fromInputValue,
+          fromAmount: formatNumber(fromInputValue),
           fromSymbol: fromToken.symbol,
-          toAmount: outputValue,
+          toAmount: formatNumber(outputValue),
           toSymbol: toToken.symbol,
         });
         setShowToast(true);

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -19,6 +19,7 @@ import { useWithdrawalDelay } from "hooks/useWithdrawalDelay";
 import { type FormEvent, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
+import { formatNumber } from "utils/format";
 import { getInputError } from "utils/inputError";
 import { getTokenListParams } from "utils/tokenList";
 import { isAddressEqual } from "viem";
@@ -145,7 +146,10 @@ export function TwoStepRedeem({
       emitter.on("request-redeem-transaction-succeeded", function () {
         onCompleted();
         setFlowStatus("request-redeemed");
-        setToastData({ amount: fromInputValue, symbol: fromToken.symbol });
+        setToastData({
+          amount: formatNumber(fromInputValue),
+          symbol: fromToken.symbol,
+        });
         setShowToast(true);
         document
           .getElementById("redeem-queue")


### PR DESCRIPTION
### Description

Large / high-precision token amounts still rendered untrimmed in the transactional toasts and the "ready to redeem" app notification. PR #589 rounded the read-only DOM sites (redeem-queue table, token selector, earn withdrawal cell) with `DisplayAmount`, but explicitly left these two surfaces out because a React tooltip can't be interpolated into a plain i18n string.

This wraps those amounts with `formatNumber` (round-down) so they display trimmed, consistent with the rest of the app. The toasts interpolate the amount into plain i18n strings, so they get rounding only — no hover tooltip. The app notification builds its string the same way (no `DisplayAmount`/tooltip), since a tooltip on an already-clickable notification button would be awkward.

### Screenshots

Toasts now round

<img width="982" height="568" alt="image" src="https://github.com/user-attachments/assets/1f706785-25c2-4e4e-932b-dcc1caede4cd" />

Same with app notifications

<img width="730" height="284" alt="image" src="https://github.com/user-attachments/assets/10fb08da-5f9f-4bba-8a5a-b6d77062de49" />

### Related issue(s)

Closes #553

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.