### PR TITLE
Add sender name to contact ack email

### DIFF
--- a/api/src/contact.ts
+++ b/api/src/contact.ts
@@ -177,7 +177,7 @@ export const sendContactConfirmation = ({
   env,
 }: Omit<ContactForm, "message"> & { env: Env }) =>
   env.SEND_EMAIL.send({
-    from: env.CONTACT_FORM_SENDER!,
+    from: { email: env.CONTACT_FORM_SENDER!, name: "Vetro Support" },
     replyTo: env.CONTACT_FORM_RECIPIENT!,
     subject: "We received your message",
     text: `Hi,


### PR DESCRIPTION
### Description

Sets the `From` header of the contact form acknowledgement email (sent to the submitter) to display "Vetro Support" instead of the bare `noreply@forms.vetro.org` address, making the email easier to identify and nicer for users. Uses the `EmailAddress` object form (`{ email, name }`) of the `send_email` binding's `from` field. Only the acknowledgement email is affected — the internal support-notification email is unchanged.

### Screenshots

N/A

### Related issue(s)

Closes #607

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.