### PR TITLE
Block sanctioned addresses

### DIFF
--- a/web/src/components/addressRestriction.tsx
+++ b/web/src/components/addressRestriction.tsx
@@ -24,11 +24,11 @@ export function AddressRestriction() {
       className="font-geist fixed inset-0 z-9999 overflow-hidden bg-gray-50"
       role="alertdialog"
     >
-      <div className="relative mx-4 h-full border-x border-gray-200 lg:mx-auto lg:max-w-[1024px]">
-        <div className="relative flex h-[160px] items-center justify-center overflow-hidden lg:h-[152px]">
+      <div className="relative mx-4 h-full border-x border-gray-200 lg:mx-auto lg:max-w-5xl">
+        <div className="relative flex h-40 items-center justify-center overflow-hidden lg:h-[152px]">
           <img
             alt=""
-            className="pointer-events-none absolute top-1/2 left-1/2 hidden h-[240px] w-[1365px] -translate-x-1/2 translate-y-[-20%] opacity-3 lg:block"
+            className="pointer-events-none absolute top-1/2 left-1/2 hidden h-60 w-[1365px] -translate-x-1/2 translate-y-[-20%] opacity-3 lg:block"
             src={vetroLogo}
           />
           <img alt="Vetro" className="relative z-10 h-10" src={vetroLogo} />
@@ -46,7 +46,7 @@ export function AddressRestriction() {
           />
         </div>
       </div>
-      <div className="pointer-events-none fixed bottom-0 left-1/2 w-[calc(100%-2rem)] -translate-x-1/2 lg:max-w-[1024px]">
+      <div className="pointer-events-none fixed bottom-0 left-1/2 w-[calc(100%-2rem)] -translate-x-1/2 lg:max-w-5xl">
         <GlobeIllustration />
       </div>
     </div>

--- a/web/src/components/addressRestriction.tsx
+++ b/web/src/components/addressRestriction.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from "react-i18next";
+import { useDisconnect } from "wagmi";
+
+import { useIsSanctioned } from "../hooks/useIsSanctioned";
+
+import { Button } from "./base/button";
+import { StatusMessage } from "./base/statusMessage";
+import { GlobeIllustration } from "./globeIllustration";
+import vetroLogo from "./icons/vetroLogo.svg";
+import { WarningCircleIcon } from "./icons/warningCircleIcon";
+
+export function AddressRestriction() {
+  const isSanctioned = useIsSanctioned();
+  const { disconnect } = useDisconnect();
+  const { t } = useTranslation();
+
+  if (!isSanctioned) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-modal="true"
+      className="font-geist fixed inset-0 z-9999 overflow-hidden bg-gray-50"
+      role="alertdialog"
+    >
+      <div className="relative mx-4 h-full border-x border-gray-200 lg:mx-auto lg:max-w-[1024px]">
+        <div className="relative flex h-[160px] items-center justify-center overflow-hidden lg:h-[152px]">
+          <img
+            alt=""
+            className="pointer-events-none absolute top-1/2 left-1/2 hidden h-[240px] w-[1365px] -translate-x-1/2 translate-y-[-20%] opacity-3 lg:block"
+            src={vetroLogo}
+          />
+          <img alt="Vetro" className="relative z-10 h-10" src={vetroLogo} />
+        </div>
+        <div className="flex flex-col items-center justify-center border-y border-gray-200 bg-white py-20">
+          <StatusMessage
+            action={
+              <Button onClick={() => disconnect()} size="xSmall">
+                {t("pages.wallet.disconnect-wallet")}
+              </Button>
+            }
+            description={t("common.restriction-description")}
+            icon={<WarningCircleIcon />}
+            title={t("common.address-restriction-title")}
+          />
+        </div>
+      </div>
+      <div className="pointer-events-none fixed bottom-0 left-1/2 w-[calc(100%-2rem)] -translate-x-1/2 lg:max-w-[1024px]">
+        <GlobeIllustration />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/base/appLayout.tsx
+++ b/web/src/components/base/appLayout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { useLocation } from "react-router";
 
+import { GlobeIllustration } from "../globeIllustration";
+
 import "react-loading-skeleton/dist/skeleton.css";
 
 export function MainContent({
@@ -26,16 +28,7 @@ export function MainContent({
 
 export const AppLayout = ({ children }: { children: ReactNode }) => (
   <MainContent
-    bottom={
-      <div className="relative border-x border-gray-200 pt-18">
-        <img alt="" src="/pageBackground.svg" />
-        <img
-          alt=""
-          className="absolute right-0 bottom-0 left-0"
-          src="/squareDotsBackground.svg"
-        />
-      </div>
-    }
+    bottom={<GlobeIllustration className="border-x border-gray-200 pt-18" />}
   >
     {children}
   </MainContent>

--- a/web/src/components/base/statusMessage.tsx
+++ b/web/src/components/base/statusMessage.tsx
@@ -11,7 +11,7 @@ export const StatusMessage = ({ action, description, icon, title }: Props) => (
   <div className="flex max-w-60 flex-col items-center gap-3 text-center">
     <div className="size-7">{icon}</div>
     <div className="flex flex-col gap-1">
-      <h5 className="text-h5 text-gray-900">{title}</h5>
+      <h5 className="text-gray-900">{title}</h5>
       <p className="text-b-regular text-gray-500">{description}</p>
     </div>
     {action}

--- a/web/src/components/base/statusMessage.tsx
+++ b/web/src/components/base/statusMessage.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+type Props = {
+  action?: ReactNode;
+  description: string;
+  icon: ReactNode;
+  title: string;
+};
+
+export const StatusMessage = ({ action, description, icon, title }: Props) => (
+  <div className="flex max-w-60 flex-col items-center gap-3 text-center">
+    <div className="size-7">{icon}</div>
+    <div className="flex flex-col gap-1">
+      <h5 className="text-h5 text-gray-900">{title}</h5>
+      <p className="text-b-regular text-gray-500">{description}</p>
+    </div>
+    {action}
+  </div>
+);

--- a/web/src/components/geoRestrictionRibbon.tsx
+++ b/web/src/components/geoRestrictionRibbon.tsx
@@ -11,7 +11,7 @@ export function GeoRestrictionRibbon() {
         <span>{t("common.geo-restriction-title")}.</span>
         <span className="text-white/64 max-md:hidden">
           {" "}
-          {t("common.geo-restriction-description")}
+          {t("common.restriction-description")}
         </span>
       </p>
     </div>

--- a/web/src/components/globeIllustration.tsx
+++ b/web/src/components/globeIllustration.tsx
@@ -1,0 +1,10 @@
+export const GlobeIllustration = ({ className }: { className?: string }) => (
+  <div className={`relative ${className ?? ""}`}>
+    <img alt="" src="/pageBackground.svg" />
+    <img
+      alt=""
+      className="absolute right-0 bottom-0 left-0"
+      src="/squareDotsBackground.svg"
+    />
+  </div>
+);

--- a/web/src/hooks/useIsSanctioned.ts
+++ b/web/src/hooks/useIsSanctioned.ts
@@ -1,0 +1,53 @@
+import { useQuery } from "@tanstack/react-query";
+import type { Address, Client } from "viem";
+import { readContract } from "viem/actions";
+import { useAccount } from "wagmi";
+
+import { useEthereumClient } from "./useEthereumClient";
+
+// The sanctions oracle is a contract deployed on Ethereum mainnet
+const sanctionsOracleAddress =
+  "0x40C57923924B5c5c5455c48D93317139ADDaC8fb" as const;
+
+const sanctionsOracleAbi = [
+  {
+    inputs: [{ name: "addr", type: "address" }],
+    name: "isSanctioned",
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+const fetchIsSanctioned = ({
+  address,
+  client,
+}: {
+  address: Address;
+  client: Client;
+}) =>
+  readContract(client, {
+    abi: sanctionsOracleAbi,
+    address: sanctionsOracleAddress,
+    args: [address],
+    functionName: "isSanctioned",
+  });
+
+export const useIsSanctioned = function () {
+  const { address, isConnected } = useAccount();
+  const client = useEthereumClient();
+
+  // Fail-open: RPC errors resolve as unrestricted so the app remains usable. It
+  // seems likely that RPC errors will also prevent any use of the app so this
+  // is a reasonable tradeoff.
+  const { data: isSanctioned = false } = useQuery({
+    enabled: isConnected && !!address && !!client,
+    queryFn: () => fetchIsSanctioned({ address: address!, client: client! }),
+    // The oracle lives on mainnet and the result is chain-agnostic, so
+    // address alone is a sufficient cache key.
+    queryKey: ["is-sanctioned", address],
+    retry: false,
+  });
+
+  return isConnected && isSanctioned;
+};

--- a/web/src/hooks/useIsSanctioned.ts
+++ b/web/src/hooks/useIsSanctioned.ts
@@ -47,6 +47,9 @@ export const useIsSanctioned = function () {
     // address alone is a sufficient cache key.
     queryKey: ["is-sanctioned", address],
     retry: false,
+    // Sanction status changes very infrequently; avoid unnecessary mainnet RPC
+    // calls on remounts and window refocus.
+    staleTime: 1000 * 60 * 60,
   });
 
   return isConnected && isSanctioned;

--- a/web/src/hooks/useIsSanctioned.ts
+++ b/web/src/hooks/useIsSanctioned.ts
@@ -34,14 +34,14 @@ const fetchIsSanctioned = ({
   });
 
 export const useIsSanctioned = function () {
-  const { address, isConnected } = useAccount();
+  const { address } = useAccount();
   const client = useEthereumClient();
 
   // Fail-open: RPC errors resolve as unrestricted so the app remains usable. It
   // seems likely that RPC errors will also prevent any use of the app so this
   // is a reasonable tradeoff.
   const { data: isSanctioned = false } = useQuery({
-    enabled: isConnected && !!address && !!client,
+    enabled: !!address && !!client,
     queryFn: () => fetchIsSanctioned({ address: address!, client: client! }),
     // The oracle lives on mainnet and the result is chain-agnostic, so
     // address alone is a sufficient cache key.
@@ -52,5 +52,5 @@ export const useIsSanctioned = function () {
     staleTime: 1000 * 60 * 60,
   });
 
-  return isConnected && isSanctioned;
+  return isSanctioned;
 };

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "address-restriction-title": "Vetro isn't available for your wallet",
     "amount-too-small-to-bridge": "Amount too small to bridge",
     "approve-10x": "Approve 10x",
     "approve-10x-tooltip": "Approves up to 10× your transaction amount, reducing future approval steps. You can revoke it anytime.",
@@ -15,7 +16,6 @@
     "connect-wallet": "Connect wallet",
     "enter-amount": "Enter an amount",
     "exceeds-debt": "Amount exceeds debt",
-    "geo-restriction-description": "Due to regulations, we're unable to offer access at this time.",
     "geo-restriction-title": "Vetro isn't available in your country",
     "insufficient-balance": "Insufficient balance",
     "insufficient-collateral": "Insufficient collateral",
@@ -25,6 +25,7 @@
     "network-fee": "Network Fee",
     "no-results-found": "No tokens found",
     "oracle": "Oracle",
+    "restriction-description": "Due to regulations, we're unable to offer you access at this time.",
     "search": "Search",
     "search-token-placeholder": "Search by name or symbol",
     "select-token": "Select a token",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "address-restriction-title": "Vetro no está disponible para su billetera",
     "amount-too-small-to-bridge": "Cantidad demasiado pequeña para transferir",
     "approve-10x": "Aprobar 10x",
     "approve-10x-tooltip": "Apruebe hasta 10× el monto de su transacción, reduciendo futuros pasos de aprobación. Puede revocarlo en cualquier momento.",
@@ -15,7 +16,6 @@
     "connect-wallet": "Conectar billetera",
     "enter-amount": "Ingrese un monto",
     "exceeds-debt": "El monto excede la deuda",
-    "geo-restriction-description": "Debido a regulaciones, no podemos ofrecer acceso en este momento.",
     "geo-restriction-title": "Vetro no está disponible en su país",
     "insufficient-balance": "Saldo insuficiente",
     "insufficient-collateral": "Garantía insuficiente",
@@ -25,6 +25,7 @@
     "network-fee": "Tarifa de Red",
     "no-results-found": "No se encontraron tokens",
     "oracle": "Oráculo",
+    "restriction-description": "Debido a regulaciones, no podemos ofrecerle acceso en este momento.",
     "search": "Buscar",
     "search-token-placeholder": "Buscar por nombre o símbolo",
     "select-token": "Seleccionar un token",

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { App } from "./app";
+import { AddressRestriction } from "./components/addressRestriction";
 import { Web3Provider } from "./providers/web3Provider";
 
 initializeI18n();
@@ -20,6 +21,7 @@ ReactDOM.createRoot(document.getElementById("root")!, {
 }).render(
   <React.StrictMode>
     <Web3Provider>
+      <AddressRestriction />
       <App />
     </Web3Provider>
   </React.StrictMode>,


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR adds logic to detect and block OFAC sanctioned addresses, on top of sanctioned and restricted countries. It will display a full-screen modal right after wallet connection if the address is sanctioned.

#### Details

This pull request introduces a wallet-based sanctions check and restriction UI to the application, ensuring users with sanctioned addresses are blocked from using the app and shown an appropriate message. It also refactors background illustration code for reuse and updates translation strings for consistency.

**Sanctions enforcement and restriction UI:**

- Added a new `useIsSanctioned` hook that queries an on-chain sanctions oracle to determine if the connected wallet address is sanctioned, blocking access if so.
- Introduced the `AddressRestriction` component, which overlays the app with a restriction dialog when a sanctioned address is detected, including a disconnect wallet action. This component is now rendered at the app root. [[1]](diffhunk://#diff-b865019bcbba92ea86f43de9775b7297fa810158e3654828a6c5373cdaa1815dR1-R54) [[2]](diffhunk://#diff-20da45cb8443d5036aea448ba7f0379ca304c43e1136ca82d9d43d731a37311eR11) [[3]](diffhunk://#diff-20da45cb8443d5036aea448ba7f0379ca304c43e1136ca82d9d43d731a37311eR24)

**UI component improvements:**

- Created a reusable `StatusMessage` component for displaying alert dialogs with icon, title, description, and action.
- Refactored the globe illustration and background into a new `GlobeIllustration` component, updating `AppLayout` to use it. [[1]](diffhunk://#diff-11bbde8b6777448179439b079a0bcd5e4cfa483e4e514b7d69dcc53f2af608abR1-R10) [[2]](diffhunk://#diff-6854d4f4c26bbf2f807f0523266858d2789b9731bbbb9572e74b40320bcfcb31R4-R5) [[3]](diffhunk://#diff-6854d4f4c26bbf2f807f0523266858d2789b9731bbbb9572e74b40320bcfcb31L29-R31)

**Localization updates:**

- Added and unified translation keys for address and geo restrictions, ensuring consistent messaging in both English and Spanish. [[1]](diffhunk://#diff-0ef18c6cbc913ab585ed021069cf18aadb3777fd596a23b18e90d6afd4680895R3) [[2]](diffhunk://#diff-0ef18c6cbc913ab585ed021069cf18aadb3777fd596a23b18e90d6afd4680895L18) [[3]](diffhunk://#diff-0ef18c6cbc913ab585ed021069cf18aadb3777fd596a23b18e90d6afd4680895R28) [[4]](diffhunk://#diff-6362fcecd648c0e6ceb3f9a11087ba350f1aa30224c7dcac382d2bd7c9cc4f6bR3) [[5]](diffhunk://#diff-6362fcecd648c0e6ceb3f9a11087ba350f1aa30224c7dcac382d2bd7c9cc4f6bL18) [[6]](diffhunk://#diff-6362fcecd648c0e6ceb3f9a11087ba350f1aa30224c7dcac382d2bd7c9cc4f6bR28)
- Updated `GeoRestrictionRibbon` to use the new unified restriction description key.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/5709f102-e443-4a90-bf72-681b8c93771a

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Closes #549

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
