### PR TITLE
Highlight dropzone with blue-500 on drag

### DIFF
--- a/web/src/components/base/fileDropzone/index.tsx
+++ b/web/src/components/base/fileDropzone/index.tsx
@@ -84,7 +84,7 @@ export function FileDropzone({
       <div
         aria-describedby={errorMessage ? errorId : undefined}
         className={`flex flex-col items-center justify-center gap-2 rounded-xl border border-dashed bg-gray-50 px-3 py-6 transition-colors ${
-          dragging ? "border-gray-400" : "border-gray-200"
+          dragging ? "border-blue-500" : "border-gray-200"
         }`}
         onDragLeave={handleDragLeave}
         onDragOver={handleDragOver}


### PR DESCRIPTION
### Description

Swap the subtle `gray-400` border change for `blue-500` while dragging files over the dropzone, so the drop target is clearly noticeable. Addresses review feedback from PR #615.

### Screenshots

https://github.com/user-attachments/assets/2433607f-d90a-46f9-bbee-dd8d09075317

### Related issue(s)

Related to #550

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.