### PR TITLE
Drop TURNSTILE_ALLOWED_HOSTNAMES on staging

### DIFF
--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -58,7 +58,6 @@
         "ORIGINS": "https://*.letshamsterdance.xyz,https://*-vetro-web-staging.hemilabs.workers.dev",
         "SUBGRAPH_ID": "7vnTMFYNE6Nv7RTeoaog4QgqQ3bwZTFoPUGv2gcmTxJ6",
         "SUBGRAPH_URL_TEMPLATE": "https://gateway.thegraph.com/api/$API_KEY/subgraphs/id/$ID",
-        "TURNSTILE_ALLOWED_HOSTNAMES": "vetro.letshamsterdance.xyz",
         "TURNSTILE_SECRET_KEY": "1x0000000000000000000000000000000AA",
         "WEBSITE_URL": "https://vetro.letshamsterdance.xyz/",
       },


### PR DESCRIPTION
### Description

Staging uses Cloudflare's Turnstile test key, whose siteverify response always reports hostname `example.com`. With the allow-list set to `vetro.letshamsterdance.xyz`, verification failed the hostname check and returned "Captcha verification failed" on the contact form. Removing the var leaves the hostname check unset, which the middleware skips by design for non-prod environments — restoring captcha verification on staging.

### Screenshots

N/A — configuration-only change.

### Related issue(s)

Related to #550

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.