### PR TITLE
Fix corrupt email attachments from double-encoding

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -312,9 +312,10 @@ set, the hostname reported by siteverify must also match one of its entries.
 
 Attachments are optional. Each file must be `image/png` or `image/jpeg`; at most
 5 files may be attached, and their combined size must not exceed 3.5 MB. Valid
-attachments are base64-encoded and sent along with the support email (they are
-not included in the submitter's confirmation email). The limit leaves headroom
-under Cloudflare's 5 MiB total-message cap once the content is base64-encoded.
+attachments are sent along with the support email as raw binary; the mail
+binding base64-encodes them into the message (they are not included in the
+submitter's confirmation email). The limit leaves headroom under Cloudflare's
+5 MiB total-message cap once the content is base64-encoded.
 
 #### Response
 

--- a/api/src/contact.ts
+++ b/api/src/contact.ts
@@ -1,8 +1,9 @@
 import type { Context, Next } from "hono";
 
-// Already base64-encoded and shaped for the SEND_EMAIL binding's attachments.
+// Shaped for the SEND_EMAIL binding's attachments. Content is raw binary; the
+// binding base64-encodes it into the MIME part itself.
 type Attachment = {
-  content: string;
+  content: ArrayBuffer;
   disposition: "attachment";
   filename: string;
   type: string;
@@ -64,13 +65,14 @@ function validateAttachments(files: File[]) {
   return undefined;
 }
 
-// Base64-encodes each file for the SEND_EMAIL binding. Deferred until after the
-// captcha passes so an unverified request can't force multi-MB reads + encoding.
-export const encodeAttachments = (files: File[]): Promise<Attachment[]> =>
+// Reads each file into an ArrayBuffer for the SEND_EMAIL binding, which does the
+// base64 encoding itself — pre-encoding here would double-encode and corrupt the
+// attachment. Deferred until after the captcha passes so an unverified request
+// can't force multi-MB reads.
+export const buildAttachments = (files: File[]): Promise<Attachment[]> =>
   Promise.all(
     files.map(async (file) => ({
-      // Standard base64 (not base64url) — MIME attachments require it.
-      content: Buffer.from(await file.arrayBuffer()).toString("base64"),
+      content: await file.arrayBuffer(),
       disposition: "attachment" as const,
       filename: file.name,
       type: file.type,

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -8,8 +8,8 @@ import type { Address } from "viem";
 import { getApyHistory } from "./apy-history.ts";
 import * as borrow from "./borrow.ts";
 import {
+  buildAttachments,
   contactFeatureToggle,
-  encodeAttachments,
   sendContactConfirmation,
   sendContactEmail,
   validateContactForm,
@@ -400,8 +400,8 @@ app.post(
   verifyTurnstile,
   async function (c) {
     const { category, email, files, message } = c.get("contactForm");
-    // Encode only now that the captcha has passed (verifyTurnstile ran).
-    const attachments = await encodeAttachments(files);
+    // Read files only now that the captcha has passed (verifyTurnstile ran).
+    const attachments = await buildAttachments(files);
     await sendContactEmail({
       attachments,
       category,

--- a/api/test/contact.test.ts
+++ b/api/test/contact.test.ts
@@ -2,8 +2,8 @@ import type { Context } from "hono";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
-  contactFeatureToggle,
   buildAttachments,
+  contactFeatureToggle,
   validateContactForm,
   verifyTurnstile,
 } from "../src/contact.ts";

--- a/api/test/contact.test.ts
+++ b/api/test/contact.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   contactFeatureToggle,
-  encodeAttachments,
+  buildAttachments,
   validateContactForm,
   verifyTurnstile,
 } from "../src/contact.ts";
@@ -445,29 +445,32 @@ describe("verifyTurnstile", function () {
   });
 });
 
-describe("encodeAttachments", function () {
-  it("base64-encodes each file for the SEND_EMAIL binding", async function () {
-    const attachments = await encodeAttachments([
+describe("buildAttachments", function () {
+  const decode = (content: ArrayBuffer) => Buffer.from(content).toString();
+
+  it("passes raw file bytes for the SEND_EMAIL binding to encode", async function () {
+    const attachments = await buildAttachments([
       new File(["hi"], "shot.png", { type: "image/png" }),
     ]);
 
     expect(attachments).toEqual([
       {
-        // Buffer.from("hi").toString("base64") === "aGk="
-        content: "aGk=",
+        // Raw bytes, not base64 — the binding base64-encodes them itself.
+        content: expect.any(ArrayBuffer),
         disposition: "attachment",
         filename: "shot.png",
         type: "image/png",
       },
     ]);
+    expect(decode(attachments[0].content)).toBe("hi");
   });
 
   it("returns an empty array when there are no files", async function () {
-    expect(await encodeAttachments([])).toEqual([]);
+    expect(await buildAttachments([])).toEqual([]);
   });
 
-  it("encodes multiple files in order", async function () {
-    const attachments = await encodeAttachments([
+  it("reads multiple files in order", async function () {
+    const attachments = await buildAttachments([
       new File(["hi"], "first.png", { type: "image/png" }),
       new File(["yo"], "second.jpg", { type: "image/jpeg" }),
     ]);
@@ -476,10 +479,8 @@ describe("encodeAttachments", function () {
       "first.png",
       "second.jpg",
     ]);
-    // Buffer.from("hi") === "aGk=", Buffer.from("yo") === "eW8="
-    expect(attachments.map((attachment) => attachment.content)).toEqual([
-      "aGk=",
-      "eW8=",
-    ]);
+    expect(attachments.map((attachment) => decode(attachment.content))).toEqual(
+      ["hi", "yo"],
+    );
   });
 });


### PR DESCRIPTION
### Description

The contact form's screenshot attachments arrived corrupt: mail clients showed the correct filename and `image/png` type, but the preview failed and the downloaded file was unopenable — its contents were the base64 *text* of the image (`iVBORw0KGgo...`) rather than the decoded bytes.

The cause was double base64-encoding. Cloudflare's `SEND_EMAIL` binding takes attachment `content` as raw binary and base64-encodes it into the MIME part itself, but we were pre-encoding each file to a base64 string first. The binding then encoded that string again, so a mail client decoding the attachment once got the base64 text back.

The fix passes the raw `ArrayBuffer` from `file.arrayBuffer()` and lets the binding do the encoding. `encodeAttachments` is renamed to `buildAttachments` since it no longer encodes.

Note: this could only be caught on staging — Cloudflare's email sending doesn't work locally (`wrangler dev` can't serialize binary attachments without remote bindings, and the contact form is disabled locally), so the bug only surfaced once a real email went out from a deployed worker.

### Screenshots

N/A — API change.

### Related issue(s)

Related to #550

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.