### PR TITLE
Make web seed scripts runnable under bare node

### DIFF
--- a/.claude/skills/run-checks/SKILL.md
+++ b/.claude/skills/run-checks/SKILL.md
@@ -95,6 +95,3 @@ Run it when a web change warrants a full assertive pass.
   workspace and only ignores `web/scripts/*` as a path (see
   [`.knip.json`](../../../.knip.json)). Run it in a whole-repo pass or leave it to
   CI, not every tight loop.
-- Run e2e **through Playwright**, never `node scripts/*.ts` — anything importing
-  `web/src/utils/tokenList.ts` pulls the `@vetro-protocol/earn` barrel whose
-  `.js`-extension imports Node's native TS loader can't resolve.

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,9 @@
     "internal-dashboard/dist/**/*",
     "subgraph/**/*",
     "web/dist/**/*",
-    "web/storybook-static/**/*"
+    "web/playwright-report/**/*",
+    "web/storybook-static/**/*",
+    "web/test-results/**/*"
   ],
   "overrides": [
     {

--- a/packages/earn/package.json
+++ b/packages/earn/package.json
@@ -55,6 +55,10 @@
         "default": "./_esm/actions/index.js",
         "types": "./_types/actions/index.d.ts"
       },
+      "./addresses": {
+        "default": "./_esm/stakingVaultAddresses.js",
+        "types": "./_types/stakingVaultAddresses.d.ts"
+      },
       "./package.json": "./package.json"
     },
     "main": "./_esm/index.js",
@@ -70,6 +74,10 @@
     "./actions": {
       "types": "./src/actions/index.ts",
       "default": "./src/actions/index.ts"
+    },
+    "./addresses": {
+      "types": "./src/stakingVaultAddresses.ts",
+      "default": "./src/stakingVaultAddresses.ts"
     },
     "./package.json": "./package.json"
   },

--- a/web/src/utils/tokenList.ts
+++ b/web/src/utils/tokenList.ts
@@ -1,4 +1,4 @@
-import { sVetBtcAddress, sVusdAddress } from "@vetro-protocol/earn";
+import { sVetBtcAddress, sVusdAddress } from "@vetro-protocol/earn/addresses";
 import type { Token } from "types";
 import { arbitrum, base, bsc, hemi, mainnet, optimism } from "viem/chains";
 


### PR DESCRIPTION
### Description

Two small local-tooling fixes:

- `web/src/utils/tokenList.ts` imported the whole `@vetro-protocol/earn` barrel just to read two share-token addresses. The barrel's `.js`-extension imports point at `.ts` sources, which Node's native TS loader can't resolve, so anything importing `tokenList` — every `web/scripts/*` seed CLI — crashed under plain `node` with `ERR_MODULE_NOT_FOUND`. This adds a `./addresses` subpath export to `@vetro-protocol/earn` (a clean leaf module with just the vault address constants) and repoints `tokenList` to it, so the seed scripts now run standalone. The run-checks skill gotcha documenting the old limitation is removed accordingly.
- Adds Playwright's generated output dirs (`web/playwright-report`, `web/test-results`) to ESLint's `ignorePatterns` so e2e artifacts aren't linted.

**Commits:**

2939e71 Make seed scripts runnable under bare node
0a90469 Ignore Playwright output dirs in ESLint

### Screenshots

N/A.

### Related issue(s)

N/A.

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.