### PR TITLE
Split mock-wallet into a reusable provider core

### DIFF
--- a/packages/mock-wallet/src/eip6963.ts
+++ b/packages/mock-wallet/src/eip6963.ts
@@ -19,11 +19,13 @@ export const MOCK_WALLET_INFO = Object.freeze({
   rdns: "com.example.mock-wallet",
 } satisfies Eip6963ProviderInfo);
 
-// The EIP-1193 object a discovery UI connects to. The no-op event methods are
-// enough for RainbowKit/wagmi, which never subscribe to a mock wallet's events.
+// The EIP-1193 object a discovery UI connects to. The event methods accept any
+// args (method syntax, so typed EIP-1193 providers stay assignable), but no-op
+// implementations are enough for RainbowKit/wagmi, which never subscribe to a
+// mock wallet's events.
 export type Eip6963Provider = {
-  on: () => void;
-  removeListener: () => void;
+  on(...args: unknown[]): void;
+  removeListener(...args: unknown[]): void;
   request: (request: RpcRequest) => Promise<unknown>;
 };
 

--- a/packages/mock-wallet/src/eip6963.ts
+++ b/packages/mock-wallet/src/eip6963.ts
@@ -1,0 +1,54 @@
+import type { RpcRequest } from "./provider.ts";
+
+// Blank 24x24 SVG — wallet-discovery UIs require an icon, but the mock wallet
+// doesn't need a recognisable one.
+const ICON =
+  "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24'/>";
+
+export type Eip6963ProviderInfo = {
+  icon: string;
+  name: string;
+  rdns: string;
+};
+
+// Frozen: shared across every host — a consumer mutating it would silently
+// change the identity all other hosts announce.
+export const MOCK_WALLET_INFO = Object.freeze({
+  icon: ICON,
+  name: "Mock Wallet",
+  rdns: "com.example.mock-wallet",
+} satisfies Eip6963ProviderInfo);
+
+// The EIP-1193 object a discovery UI connects to. The no-op event methods are
+// enough for RainbowKit/wagmi, which never subscribe to a mock wallet's events.
+export type Eip6963Provider = {
+  on: () => void;
+  removeListener: () => void;
+  request: (request: RpcRequest) => Promise<unknown>;
+};
+
+// Announce an EIP-1193 provider to the page via EIP-6963 so wallet-discovery
+// (RainbowKit/wagmi) picks it up with no browser extension. Browser-only —
+// touches window — so call it from page code, not Node. The Playwright installer
+// inlines an equivalent announce inside addInitScript instead, because that
+// callback is serialised into the page and can't import this module.
+export function announceEip6963Provider({
+  info,
+  provider,
+}: {
+  info: Eip6963ProviderInfo;
+  provider: Eip6963Provider;
+}) {
+  const detail = Object.freeze({
+    info: { ...info, uuid: crypto.randomUUID() },
+    provider,
+  });
+  function announce() {
+    window.dispatchEvent(
+      new CustomEvent("eip6963:announceProvider", { detail }),
+    );
+  }
+  announce();
+  window.addEventListener("eip6963:requestProvider", announce);
+  window.addEventListener("DOMContentLoaded", announce);
+}

--- a/packages/mock-wallet/src/index.ts
+++ b/packages/mock-wallet/src/index.ts
@@ -1,126 +1,13 @@
-import type { Page } from "@playwright/test";
-import {
-  type Chain,
-  type Hex,
-  type LocalAccount,
-  type Transport,
-  createWalletClient,
-} from "viem";
-
-const REQUEST_BINDING = "__mockWalletRequest";
-
-type RpcRequest = { method: string; params?: unknown[] };
-
-// Methods that return a fixed value, independent of params. Keeping them out
-// of the switch keeps request()'s complexity within the lint threshold.
-const staticResponses: Record<string, unknown> = {
-  wallet_getPermissions: [],
-  wallet_requestPermissions: [{ parentCapability: "eth_accounts" }],
-  wallet_revokePermissions: [{ parentCapability: "eth_accounts" }],
-  // The fork is a single mainnet chain; accept switch requests so RainbowKit's
-  // connect flow doesn't error, but do not actually move.
-  wallet_switchEthereumChain: null,
-};
-
-type CreateWalletParams = {
-  account: LocalAccount;
-  chain: Chain;
-  transports: Record<number, Transport>;
-};
-
-type MockWallet = {
-  request: (request: RpcRequest) => Promise<unknown>;
-};
-
-function createWallet({
-  account,
-  chain,
-  transports,
-}: CreateWalletParams): MockWallet {
-  const transport = transports[chain.id];
-  if (!transport) {
-    // Never fall back to viem's default public RPC — a missing entry would
-    // silently point the wallet at the real network instead of the fork.
-    throw new Error(`No transport configured for chain ${chain.id}`);
-  }
-  const client = createWalletClient({
-    account,
-    chain,
-    transport,
-  });
-  return {
-    async request({ method, params }) {
-      if (Object.hasOwn(staticResponses, method)) {
-        return staticResponses[method];
-      }
-      switch (method) {
-        case "eth_accounts":
-        case "eth_requestAccounts":
-          return client.getAddresses();
-        case "personal_sign":
-          return client.signMessage({
-            message: { raw: (params as [Hex])[0] },
-          });
-        case "eth_sendTransaction": {
-          const [tx] = params as [
-            { data?: Hex; from: Hex; to: Hex; value?: Hex },
-          ];
-          if (tx.from.toLowerCase() !== account.address.toLowerCase()) {
-            throw new Error("Invalid from address");
-          }
-          return client.sendTransaction({
-            data: tx.data,
-            to: tx.to,
-            value: tx.value ? BigInt(tx.value) : undefined,
-          });
-        }
-        default:
-          // @ts-expect-error EIP-1193 passthrough — viem's request() is typed
-          // as a discriminated union of known methods.
-          return client.request({ method, params });
-      }
-    },
-  };
-}
-
-type InstallMockWalletParams = CreateWalletParams & { page: Page };
-
-export async function installMockWallet({
-  page,
-  ...walletParams
-}: InstallMockWalletParams) {
-  const wallet = createWallet(walletParams);
-
-  await page.exposeFunction(REQUEST_BINDING, (request: RpcRequest) =>
-    wallet.request(request),
-  );
-
-  await page.addInitScript(
-    function ({ bindingName }: { bindingName: string }) {
-      const request = (window as unknown as Record<string, unknown>)[
-        bindingName
-      ] as (req: { method: string; params?: unknown[] }) => Promise<unknown>;
-      const provider = {
-        on() {},
-        removeListener() {},
-        request,
-      };
-      const info = {
-        icon: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24'/>",
-        name: "Mock Wallet",
-        rdns: "com.example.mock-wallet",
-        uuid: crypto.randomUUID(),
-      };
-      const detail = Object.freeze({ info, provider });
-      function announce() {
-        window.dispatchEvent(
-          new CustomEvent("eip6963:announceProvider", { detail }),
-        );
-      }
-      announce();
-      window.addEventListener("eip6963:requestProvider", announce);
-      window.addEventListener("DOMContentLoaded", announce);
-    },
-    { bindingName: REQUEST_BINDING },
-  );
-}
+export {
+  type Eip6963Provider,
+  type Eip6963ProviderInfo,
+  MOCK_WALLET_INFO,
+  announceEip6963Provider,
+} from "./eip6963.ts";
+export { installMockWallet } from "./playwright.ts";
+export {
+  type CreateMockWalletProviderParams,
+  type MockWalletProvider,
+  type RpcRequest,
+  createMockWalletProvider,
+} from "./provider.ts";

--- a/packages/mock-wallet/src/playwright.ts
+++ b/packages/mock-wallet/src/playwright.ts
@@ -1,0 +1,61 @@
+import type { Page } from "@playwright/test";
+
+import { MOCK_WALLET_INFO, type Eip6963ProviderInfo } from "./eip6963.ts";
+import {
+  type CreateMockWalletProviderParams,
+  type RpcRequest,
+  createMockWalletProvider,
+} from "./provider.ts";
+
+const REQUEST_BINDING = "__mockWalletRequest";
+
+type InstallMockWalletParams = CreateMockWalletProviderParams & { page: Page };
+
+// Inject an EIP-6963-announcing EIP-1193 provider into the page before the dApp
+// scripts run, so RainbowKit connects to it silently — no extension popup, no
+// confirm clicks. The wallet client runs in Node (behind page.exposeFunction);
+// the page-side provider just forwards requests to it over that binding.
+export async function installMockWallet({
+  page,
+  ...walletParams
+}: InstallMockWalletParams) {
+  const wallet = createMockWalletProvider(walletParams);
+
+  await page.exposeFunction(REQUEST_BINDING, (request: RpcRequest) =>
+    wallet.request(request),
+  );
+
+  await page.addInitScript(
+    function ({
+      bindingName,
+      info,
+    }: {
+      bindingName: string;
+      info: Eip6963ProviderInfo;
+    }) {
+      const request = (window as unknown as Record<string, unknown>)[
+        bindingName
+      ] as (req: RpcRequest) => Promise<unknown>;
+      const provider = {
+        on() {},
+        removeListener() {},
+        request,
+      };
+      // This announce mirrors announceEip6963Provider, re-inlined because
+      // addInitScript serialises the callback into the page — it can't import.
+      const detail = Object.freeze({
+        info: { ...info, uuid: crypto.randomUUID() },
+        provider,
+      });
+      function announce() {
+        window.dispatchEvent(
+          new CustomEvent("eip6963:announceProvider", { detail }),
+        );
+      }
+      announce();
+      window.addEventListener("eip6963:requestProvider", announce);
+      window.addEventListener("DOMContentLoaded", announce);
+    },
+    { bindingName: REQUEST_BINDING, info: MOCK_WALLET_INFO },
+  );
+}

--- a/packages/mock-wallet/src/provider.ts
+++ b/packages/mock-wallet/src/provider.ts
@@ -1,0 +1,87 @@
+import {
+  type Chain,
+  type Hex,
+  type LocalAccount,
+  type Transport,
+  createWalletClient,
+  isAddressEqual,
+} from "viem";
+
+export type RpcRequest = { method: string; params?: unknown[] };
+
+// Methods that return a fixed value, independent of params. Keeping them out
+// of the switch keeps request()'s complexity within the lint threshold.
+const staticResponses: Record<string, unknown> = {
+  wallet_getPermissions: [],
+  wallet_requestPermissions: [{ parentCapability: "eth_accounts" }],
+  wallet_revokePermissions: [{ parentCapability: "eth_accounts" }],
+  // The fork is a single mainnet chain; accept switch requests so RainbowKit's
+  // connect flow doesn't error, but do not actually move.
+  wallet_switchEthereumChain: null,
+};
+
+export type CreateMockWalletProviderParams = {
+  account: LocalAccount;
+  chain: Chain;
+  transports: Record<number, Transport>;
+};
+
+export type MockWalletProvider = {
+  request: (request: RpcRequest) => Promise<unknown>;
+};
+
+// The EIP-1193 request handler shared by every host: it auto-approves accounts,
+// signs messages, and submits transactions with a viem wallet client, passing
+// every other method straight through to the transport. Runs unchanged wherever
+// it is called — in Node behind Playwright's page.exposeFunction (E2E) or in the
+// browser behind an injected EIP-6963 provider (dev wallet).
+export function createMockWalletProvider({
+  account,
+  chain,
+  transports,
+}: CreateMockWalletProviderParams): MockWalletProvider {
+  const transport = transports[chain.id];
+  if (!transport) {
+    // Never fall back to viem's default public RPC — a missing entry would
+    // silently point the wallet at the real network instead of the fork.
+    throw new Error(`No transport configured for chain ${chain.id}`);
+  }
+  const client = createWalletClient({
+    account,
+    chain,
+    transport,
+  });
+  return {
+    async request({ method, params }) {
+      if (Object.hasOwn(staticResponses, method)) {
+        return staticResponses[method];
+      }
+      switch (method) {
+        case "eth_accounts":
+        case "eth_requestAccounts":
+          return client.getAddresses();
+        case "personal_sign":
+          return client.signMessage({
+            message: { raw: (params as [Hex])[0] },
+          });
+        case "eth_sendTransaction": {
+          const [tx] = params as [
+            { data?: Hex; from: Hex; to: Hex; value?: Hex },
+          ];
+          if (!isAddressEqual(tx.from, account.address)) {
+            throw new Error("Invalid from address");
+          }
+          return client.sendTransaction({
+            data: tx.data,
+            to: tx.to,
+            value: tx.value ? BigInt(tx.value) : undefined,
+          });
+        }
+        default:
+          // @ts-expect-error EIP-1193 passthrough — viem's request() is typed
+          // as a discriminated union of known methods.
+          return client.request({ method, params });
+      }
+    },
+  };
+}

--- a/packages/mock-wallet/tsconfig.json
+++ b/packages/mock-wallet/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "lib": ["es2024", "DOM", "DOM.Iterable"],
     "noEmit": true


### PR DESCRIPTION
### Description

The mock wallet could only run inside a Playwright context: its single export, `installMockWallet`, bundled the EIP-1193 request handler, the Playwright injection, and the EIP-6963 announcement into one function that requires a `Page`, with the wallet living in Node behind `page.exposeFunction`. This change restructures the package so that same wallet implementation can also run **outside** Playwright — in a regular browser — which an upcoming in-browser dev wallet (seeded-fork dev environment) needs.

The split, with no behavior change:

- `provider.ts` — `createMockWalletProvider`, the EIP-1193 request handler (auto-approve accounts, sign, send, passthrough). Host-agnostic: runs in Node behind Playwright's `exposeFunction` or directly in a browser.
- `eip6963.ts` — `announceEip6963Provider` + the shared `MOCK_WALLET_INFO` identity (frozen). The Playwright installer keeps an inline announce copy because `addInitScript` serializes its callback into the page and can't import.
- `playwright.ts` — `installMockWallet`, now a thin consumer with an unchanged API and identical injected behavior.

Verified with the full web E2E suite (6/6 passing), which drives every wallet path through `installMockWallet`.

**Commits:**

335b5b5 Split mock-wallet into a reusable provider core

### Screenshots

N/A.

### Related issue(s)

N/A.

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.