### PR TITLE
Use dynamic viewport height for app container

### DIFF
--- a/web/src/components/base/appViewport.tsx
+++ b/web/src/components/base/appViewport.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
 
 export const AppViewport = ({ children }: { children: ReactNode }) => (
-  <div className="font-geist flex h-screen flex-col bg-gray-50">{children}</div>
+  <div className="font-geist flex h-dvh flex-col bg-gray-50">{children}</div>
 );


### PR DESCRIPTION
### Description

The app container used `h-screen` (`100vh`), which on mobile browsers is computed against the *largest* viewport — it ignores the browser's own chrome (address bar / navbar). As a result the bottom-fixed navbar introduced in #404 was pushed behind the mobile browser UI and hidden.

Switching to `h-dvh` (`100dvh`) makes the container track the *dynamic* viewport height, so it accounts for the browser chrome and the navbar stays visible on mobile.

### Screenshots

On my phone

<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/24bd6822-eb13-4a1e-b260-ac7b3050ba3f" />


### Related issue(s)

Closes #631

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.