### PR TITLE
Show treasury reserves as a single USD total

### DIFF
--- a/web/src/components/swapForm/treasuryReserves.tsx
+++ b/web/src/components/swapForm/treasuryReserves.tsx
@@ -1,30 +1,35 @@
-import { DisplayAmount } from "components/base/displayAmount";
 import { TokenLogo } from "components/tokenLogo";
+import { Tooltip } from "components/tooltip";
+import { usePrices } from "hooks/usePrices";
 import { useTreasuryReserves } from "hooks/useTreasuryReserves";
-import { Fragment, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import Skeleton from "react-loading-skeleton";
-import type { Token } from "types";
-import type { Address } from "viem";
+import { formatUsd, tokenAmountToUsd } from "utils/currency";
+import { formatNumber } from "utils/format";
+import { type Address, formatUnits } from "viem";
 
 type Props = {
   gatewayAddress: Address;
 };
 
-const tokenContainer = (token: Token) =>
-  Object.assign(
-    ({ children }: { children?: ReactNode }) => (
-      <span className="flex items-center gap-1">
-        <TokenLogo {...token} />
-        {children}
-      </span>
-    ),
-    { displayName: "TokenContainer" },
-  );
-
 export const TreasuryReserves = function ({ gatewayAddress }: Props) {
   const { t } = useTranslation();
-  const { data: treasuryTokens, isError } = useTreasuryReserves(gatewayAddress);
+  const { data: treasuryTokens, isError: isReservesError } =
+    useTreasuryReserves(gatewayAddress);
+  const { data: prices, isError: isPricesError } = usePrices();
+
+  const isError = isReservesError || isPricesError;
+
+  const value =
+    treasuryTokens && prices
+      ? formatUsd(
+          treasuryTokens.reduce(
+            (total, { amount, token }) =>
+              total + tokenAmountToUsd({ amount, prices, token }),
+            0,
+          ),
+        )
+      : undefined;
 
   return (
     <div className="mx-auto flex w-full items-center justify-between py-3 md:max-w-md">
@@ -33,23 +38,33 @@ export const TreasuryReserves = function ({ gatewayAddress }: Props) {
       </span>
       {isError ? (
         <span className="text-h5 text-gray-500">-</span>
-      ) : treasuryTokens !== undefined ? (
-        <span className="text-h5 flex items-center gap-x-3 text-gray-500">
-          {treasuryTokens.map(({ amount, token }, index) => (
-            <Fragment key={token.address}>
-              {index > 0 && (
-                <span className="h-2 w-0.5 rounded-full border border-gray-300" />
-              )}
-              <DisplayAmount
-                amount={amount}
-                container={tokenContainer(token)}
-                token={token}
-              />
-            </Fragment>
-          ))}
-        </span>
+      ) : value !== undefined && treasuryTokens !== undefined ? (
+        <Tooltip
+          content={
+            <div className="flex flex-col gap-1">
+              {treasuryTokens.map(({ amount, token }) => (
+                <div
+                  className="flex items-center gap-1 sm:min-w-40"
+                  key={token.address}
+                >
+                  <TokenLogo
+                    logoURI={token.logoURI}
+                    size="small"
+                    symbol={token.symbol}
+                  />
+                  <span className="text-xsm ml-auto font-medium text-white">
+                    {formatNumber(formatUnits(amount, token.decimals))}{" "}
+                    {token.symbol}
+                  </span>
+                </div>
+              ))}
+            </div>
+          }
+        >
+          <span className="text-h5 text-gray-500">{value}</span>
+        </Tooltip>
       ) : (
-        <Skeleton height={16} width={120} />
+        <Skeleton height={16} width={80} />
       )}
     </div>
   );


### PR DESCRIPTION
### Description

The Treasury reserves row on the swap form listed every whitelisted token inline (icon + amount + symbol). Once frxUSD was whitelisted this overflowed the fixed-width row, clipping tokens.

This replaces the inline list with a single USD figure — the sum of the gateway's reserves valued via token prices (`tokenAmountToUsd` + `formatUsd`, matching the aggregate-display convention used elsewhere). The per-token breakdown moves into a hover tooltip, where each row shows the token's logo, amount, and symbol. The layout now scales to any number of whitelisted tokens.

### Screenshots

https://github.com/user-attachments/assets/05f4a5cb-25c9-4241-9ae5-ca4457e6ead9

### Related issue(s)

Closes #500

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.