### PR TITLE
Add dev:fork with an auto-connecting dev wallet

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite",
+    "dev:fork": "node scripts/devFork.ts",
     "prepreview": "pnpm run build",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",

--- a/web/scripts/devFork.ts
+++ b/web/scripts/devFork.ts
@@ -1,0 +1,69 @@
+import { startAnvilFork } from "@hemilabs/anvil-fork-setup";
+import { TEST_ADDRESS } from "@hemilabs/anvil-fork-setup/utils";
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { mainnet } from "viem/chains";
+
+import { fundAccount } from "./fundAccount.ts";
+
+const webRoot = fileURLToPath(new URL("..", import.meta.url));
+
+// Vite only loads env files for the app; plain Node needs them loaded here.
+// loadEnvFile never overrides, so precedence is shell > .env.local > .env.
+const envLocal = new URL("../.env.local", import.meta.url);
+if (existsSync(envLocal)) {
+  process.loadEnvFile(envLocal);
+}
+process.loadEnvFile(new URL("../.env", import.meta.url));
+
+// The app and the dev wallet both read VITE_RPC_URL_MAINNET; vars set here
+// win because Vite never overwrites env vars inherited from the process.
+const startViteServer = (forkUrl: string): ChildProcess =>
+  spawn("pnpm", ["exec", "vite"], {
+    cwd: webRoot,
+    env: {
+      ...process.env,
+      VITE_DEV_WALLET: "true",
+      VITE_RPC_URL_MAINNET: forkUrl,
+    },
+    stdio: "inherit",
+  });
+
+const { stop, url } = await startAnvilFork({
+  chainId: mainnet.id,
+  forkUrl: process.env.VITE_RPC_URL_MAINNET ?? mainnet.rpcUrls.default.http[0],
+});
+
+// Fund only — scenario state (cooldown, redeem delay, time jumps, …) is
+// applied on demand: node web/scripts/<primitive>.ts against the live fork.
+try {
+  await fundAccount({ address: TEST_ADDRESS, forkUrl: url });
+} catch (error) {
+  await stop();
+  throw error;
+}
+
+console.log(`\nFork funded at ${url} — starting the dev server…`);
+console.log("The browser auto-connects the dev wallet. Ctrl-C to stop.\n");
+
+const vite = startViteServer(url);
+
+async function teardown() {
+  vite.kill("SIGTERM");
+  await stop();
+}
+
+// Memoised: the vite exit handler must await the same in-flight stop(), or
+// its process.exit() would orphan anvil on 8545.
+let shutdownPromise: Promise<void> | undefined;
+function shutdown() {
+  shutdownPromise ??= teardown();
+  return shutdownPromise;
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+vite.on("exit", function (code) {
+  void shutdown().then(() => process.exit(code ?? 0));
+});

--- a/web/scripts/devFork.ts
+++ b/web/scripts/devFork.ts
@@ -73,4 +73,10 @@ const shutdownAndExit = (code: number) =>
 
 process.on("SIGINT", () => shutdownAndExit(0));
 process.on("SIGTERM", () => shutdownAndExit(0));
+// A failed spawn emits "error" instead of "exit"; without this handler the
+// throw would go uncaught and leave anvil orphaned on 8545.
+vite.on("error", function (error) {
+  console.error(error);
+  shutdownAndExit(1);
+});
 vite.on("exit", (code) => shutdownAndExit(code ?? 0));

--- a/web/scripts/devFork.ts
+++ b/web/scripts/devFork.ts
@@ -62,8 +62,15 @@ function shutdown() {
   return shutdownPromise;
 }
 
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
-vite.on("exit", function (code) {
-  void shutdown().then(() => process.exit(code ?? 0));
-});
+const shutdownAndExit = (code: number) =>
+  shutdown().then(
+    () => process.exit(code),
+    function (error) {
+      console.error(error);
+      process.exit(1);
+    },
+  );
+
+process.on("SIGINT", () => shutdownAndExit(0));
+process.on("SIGTERM", () => shutdownAndExit(0));
+vite.on("exit", (code) => shutdownAndExit(code ?? 0));

--- a/web/src/dev-wallet/index.ts
+++ b/web/src/dev-wallet/index.ts
@@ -1,0 +1,33 @@
+import { TEST_PRIVATE_KEY } from "@hemilabs/anvil-fork-setup/utils";
+import {
+  MOCK_WALLET_INFO,
+  announceEip6963Provider,
+  createMockWalletProvider,
+} from "@vetro-protocol/mock-wallet";
+import { http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { mainnet } from "../networks/mainnet";
+
+// Defence in depth: main.tsx's DEV guard already strips this module from
+// production bundles; the throw makes a mistaken prod import loud.
+if (import.meta.env.PROD) {
+  throw new Error("dev-wallet must never be imported in a production build");
+}
+
+// The interactive counterpart to E2E's installMockWallet: a headless,
+// auto-signing EIP-6963 wallet as Anvil account #0 (the one the seed scripts
+// fund). Its transport rides the app's mainnet chain config, so writes hit
+// whatever VITE_RPC_URL_MAINNET points at — the fork under `dev:fork`.
+export function installDevWallet() {
+  const { request } = createMockWalletProvider({
+    account: privateKeyToAccount(TEST_PRIVATE_KEY),
+    chain: mainnet,
+    transports: { [mainnet.id]: http() },
+  });
+
+  announceEip6963Provider({
+    info: MOCK_WALLET_INFO,
+    provider: { on() {}, removeListener() {}, request },
+  });
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -13,6 +13,19 @@ import { Web3Provider } from "./providers/web3Provider";
 
 initializeI18n();
 
+// Dev-only headless wallet for the seeded fork (`dev:fork`); the DEV guard
+// keeps it out of production bundles. Awaited so the EIP-6963 announcement
+// precedes wagmi's reconnect-on-mount, which reconnects it across reloads.
+if (import.meta.env.DEV && import.meta.env.VITE_DEV_WALLET === "true") {
+  try {
+    await import("./dev-wallet").then((module) => module.installDevWallet());
+  } catch (error) {
+    // A broken dev wallet must not blank the whole app.
+    // eslint-disable-next-line no-console -- dev-only
+    console.error("Dev wallet failed to install:", error);
+  }
+}
+
 const handleReactError = reactErrorHandler();
 ReactDOM.createRoot(document.getElementById("root")!, {
   onCaughtError: handleReactError,


### PR DESCRIPTION
### Description

Adds a `pnpm dev:fork` command that boots the app against a local Anvil mainnet fork with a headless wallet already connected, so you can exercise write flows (mint, redeem, stake, borrow, bridge) end-to-end without a real wallet, real funds, or a live network.

The script spins up the Anvil fork, funds Anvil account #0, then launches Vite with `VITE_DEV_WALLET=true` and `VITE_RPC_URL_MAINNET` pointed at the fork. On startup, `main.tsx` (behind a `DEV`-only guard) installs a headless, auto-signing EIP-6963 wallet for that funded account — the interactive counterpart to the mock wallet used in E2E. Because it's announced before wagmi reconnects on mount, the wallet stays connected across reloads. Writes hit whatever `VITE_RPC_URL_MAINNET` points at, so under `dev:fork` they land on the fork.

The fork is only funded; scenario state (cooldowns, redeem delays, time jumps, …) is applied on demand by running the individual seed scripts against the live fork. Teardown is memoised so Ctrl-C (or a Vite exit) tears down Anvil cleanly instead of orphaning it on port 8545. A `PROD` throw in the dev-wallet module plus the `DEV` build guard keep it out of production bundles.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.