### PR TITLE
Add Hemi Earn monitoring tab to internal dashboard

### DIFF
--- a/internal-dashboard/src/app.tsx
+++ b/internal-dashboard/src/app.tsx
@@ -5,6 +5,7 @@ import { Header } from "./components/header";
 import { Layout } from "./components/layout";
 import { DexPage } from "./pages/dex";
 import { DexPoolPage } from "./pages/dexPool";
+import { EarnAgentPage } from "./pages/earnAgent";
 
 const queryClient = new QueryClient();
 
@@ -18,6 +19,7 @@ export const App = () => (
             <Route element={<DexPoolPage />} path="/dex/:poolId" />
             <Route element={<Navigate replace to="/dex" />} path="/" />
             <Route element={<DexPage />} path="/dex" />
+            <Route element={<EarnAgentPage />} path="/hemi-earn" />
             <Route element={<Navigate replace to="/dex" />} path="*" />
           </Routes>
         </Layout>

--- a/internal-dashboard/src/components/earnAgent/cooldownStatusBadge.tsx
+++ b/internal-dashboard/src/components/earnAgent/cooldownStatusBadge.tsx
@@ -1,0 +1,11 @@
+export const CooldownStatusBadge = ({ isBehind }: { isBehind: boolean }) => (
+  <span
+    className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
+      isBehind
+        ? "bg-amber-50 text-amber-700 ring-amber-600/20"
+        : "bg-emerald-50 text-emerald-700 ring-emerald-600/20"
+    }`}
+  >
+    {isBehind ? "Keeper behind" : "Clear"}
+  </span>
+);

--- a/internal-dashboard/src/components/earnAgent/cooldownTable.tsx
+++ b/internal-dashboard/src/components/earnAgent/cooldownTable.tsx
@@ -1,0 +1,100 @@
+import { formatUnits } from "viem";
+
+import { type VaultCooldownPosition } from "../../fetchers/fetchEarnAgentStatus";
+import { summarizeCooldown } from "../../lib/cooldownSummary";
+import { formatDuration, formatTokenAmount } from "../../lib/format";
+import { ExplorerLink } from "../dex/explorerLink";
+
+import { CooldownStatusBadge } from "./cooldownStatusBadge";
+
+type Props = {
+  nowSeconds: number;
+  vaults: VaultCooldownPosition[];
+};
+
+// Amounts are in the vault's underlying pegged token (that's what the vault
+// locks during cooldown), so they carry the underlying's symbol, not the
+// share's.
+const formatBucket = function ({
+  bucket,
+  underlying,
+}: {
+  bucket: { assets: bigint; count: number };
+  underlying: VaultCooldownPosition["underlying"];
+}) {
+  if (bucket.count === 0) {
+    return "—";
+  }
+  const amount = formatTokenAmount(
+    Number(formatUnits(bucket.assets, underlying.decimals)),
+  );
+  const requestLabel = bucket.count === 1 ? "request" : "requests";
+  return `${bucket.count} ${requestLabel} · ${amount} ${underlying.symbol}`;
+};
+
+export const CooldownTable = ({ nowSeconds, vaults }: Props) => (
+  <div className="overflow-x-auto">
+    <table className="w-full border-collapse text-sm">
+      <thead>
+        <tr className="border-b border-neutral-200 text-xs font-medium text-neutral-500">
+          <th className="py-2 pr-4 text-left font-medium">Vault</th>
+          <th className="py-2 pr-4 text-right font-medium">In cooldown</th>
+          <th className="py-2 pr-4 text-right font-medium">Ready to claim</th>
+          <th className="py-2 pr-4 text-right font-medium">
+            Oldest ready{" "}
+            <span className="font-normal text-neutral-400">
+              (since maturity)
+            </span>
+          </th>
+          <th className="py-2 text-right font-medium">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {vaults.map(function (vault) {
+          const summary = summarizeCooldown({
+            nowSeconds,
+            requests: vault.requests,
+          });
+          return (
+            <tr className="border-b border-neutral-100" key={vault.address}>
+              <td className="py-3 pr-4">
+                <div className="flex items-center gap-x-2">
+                  <span className="font-medium text-neutral-950">
+                    {vault.symbol}
+                  </span>
+                  <span className="text-xs">
+                    <ExplorerLink address={vault.address} />
+                  </span>
+                </div>
+              </td>
+              <td className="py-3 pr-4 text-right font-medium text-neutral-950">
+                {formatBucket({
+                  bucket: summary.inCooldown,
+                  underlying: vault.underlying,
+                })}
+              </td>
+              <td className="py-3 pr-4 text-right font-medium text-neutral-950">
+                {formatBucket({
+                  bucket: summary.ready,
+                  underlying: vault.underlying,
+                })}
+              </td>
+              <td
+                className={`py-3 pr-4 text-right font-medium ${
+                  summary.isKeeperBehind ? "text-amber-600" : "text-neutral-950"
+                }`}
+              >
+                {summary.oldestReadySeconds !== undefined
+                  ? formatDuration(summary.oldestReadySeconds)
+                  : "—"}
+              </td>
+              <td className="py-3 text-right">
+                <CooldownStatusBadge isBehind={summary.isKeeperBehind} />
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  </div>
+);

--- a/internal-dashboard/src/components/headerTabs.tsx
+++ b/internal-dashboard/src/components/headerTabs.tsx
@@ -24,5 +24,6 @@ const Tab = ({ children, to }: Props) => (
 export const HeaderTabs = () => (
   <nav className="mb-12 flex items-center gap-x-2 border-y border-solid border-y-neutral-300/55 p-4">
     <Tab to="/dex">DEX</Tab>
+    <Tab to="/hemi-earn">Hemi Earn</Tab>
   </nav>
 );

--- a/internal-dashboard/src/config/earnAgent.ts
+++ b/internal-dashboard/src/config/earnAgent.ts
@@ -1,0 +1,38 @@
+import { type Address, type Hex } from "viem";
+
+// The Hemi Earn agent — executor contract on Ethereum that processes
+// cross-chain deposit/redeem requests bridged from Hemi, staking into and
+// redeeming from the Vetro Earn vaults. Everything else about it (keepers,
+// owner, implementation, proxy admin) is read live from the chain.
+export const earnAgentAddress: Address =
+  "0xFd07A07505F73C63A6F8FF03B7474a90C0B3c5Ce";
+
+export const earnAgentAbi = [
+  {
+    inputs: [],
+    name: "getKeepers",
+    outputs: [{ name: "", type: "address[]" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "owner",
+    outputs: [{ name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "pendingOwner",
+    outputs: [{ name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+// Standard ERC-1967 storage slots (eip1967.proxy.implementation / .admin).
+export const erc1967AdminSlot: Hex =
+  "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103";
+export const erc1967ImplementationSlot: Hex =
+  "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";

--- a/internal-dashboard/src/fetchers/fetchEarnAgentStatus.ts
+++ b/internal-dashboard/src/fetchers/fetchEarnAgentStatus.ts
@@ -22,7 +22,7 @@ export type VaultCooldownPosition = {
   underlying: { decimals: number; symbol: string };
 };
 
-export type EarnAgentStatus = {
+type EarnAgentStatus = {
   implementation: Address | undefined;
   keepers: Address[];
   owner: Address;

--- a/internal-dashboard/src/fetchers/fetchEarnAgentStatus.ts
+++ b/internal-dashboard/src/fetchers/fetchEarnAgentStatus.ts
@@ -1,0 +1,93 @@
+import { stakingVaultAddresses } from "@vetro-protocol/earn";
+import { getPendingRequests } from "@vetro-protocol/earn/actions";
+import { type Address, type Hex, getAddress } from "viem";
+import { getStorageAt, readContract } from "viem/actions";
+import { decimals, symbol } from "viem-erc20/actions";
+import { asset } from "viem-erc4626/actions";
+
+import {
+  earnAgentAbi,
+  earnAgentAddress,
+  erc1967AdminSlot,
+  erc1967ImplementationSlot,
+} from "../config/earnAgent";
+import { client } from "../lib/client";
+import { type CooldownRequest } from "../lib/cooldownSummary";
+import { normalizeAddress } from "../lib/format";
+
+export type VaultCooldownPosition = {
+  address: Address;
+  requests: CooldownRequest[];
+  symbol: string;
+  underlying: { decimals: number; symbol: string };
+};
+
+export type EarnAgentStatus = {
+  implementation: Address | undefined;
+  keepers: Address[];
+  owner: Address;
+  pendingOwner: Address | undefined;
+  proxyAdmin: Address | undefined;
+  vaults: VaultCooldownPosition[];
+};
+
+// An ERC-1967 slot holds the address right-aligned in 32 bytes; an unset slot
+// comes back as zero (or "0x" from some RPCs), which normalizes to undefined.
+const slotToAddress = (slotValue: Hex | undefined) =>
+  normalizeAddress(slotValue ? `0x${slotValue.slice(-40)}` : undefined);
+
+const agentContract = {
+  abi: earnAgentAbi,
+  address: earnAgentAddress,
+} as const;
+
+const fetchVaultCooldownPosition = async function (vaultAddress: Address) {
+  const address = getAddress(vaultAddress);
+  const [[requestIds, assets, claimableAt], vaultSymbol, assetAddress] =
+    await Promise.all([
+      getPendingRequests(client, { account: earnAgentAddress, address }),
+      symbol(client, { address }),
+      asset(client, { address }),
+    ]);
+  const [underlyingDecimals, underlyingSymbol] = await Promise.all([
+    decimals(client, { address: assetAddress }),
+    symbol(client, { address: assetAddress }),
+  ]);
+  return {
+    address,
+    requests: requestIds.map((requestId, index) => ({
+      assets: assets[index],
+      claimableAt: claimableAt[index],
+      requestId,
+    })),
+    symbol: vaultSymbol,
+    underlying: { decimals: underlyingDecimals, symbol: underlyingSymbol },
+  } satisfies VaultCooldownPosition;
+};
+
+export const fetchEarnAgentStatus = async function () {
+  const [keepers, owner, pendingOwner, implementationSlot, adminSlot, vaults] =
+    await Promise.all([
+      readContract(client, { ...agentContract, functionName: "getKeepers" }),
+      readContract(client, { ...agentContract, functionName: "owner" }),
+      readContract(client, { ...agentContract, functionName: "pendingOwner" }),
+      getStorageAt(client, {
+        address: earnAgentAddress,
+        slot: erc1967ImplementationSlot,
+      }),
+      getStorageAt(client, {
+        address: earnAgentAddress,
+        slot: erc1967AdminSlot,
+      }),
+      Promise.all(stakingVaultAddresses.map(fetchVaultCooldownPosition)),
+    ]);
+
+  return {
+    implementation: slotToAddress(implementationSlot),
+    keepers: keepers.map((keeper) => getAddress(keeper)),
+    owner: getAddress(owner),
+    pendingOwner: normalizeAddress(pendingOwner),
+    proxyAdmin: slotToAddress(adminSlot),
+    vaults,
+  } satisfies EarnAgentStatus;
+};

--- a/internal-dashboard/src/fetchers/fetchEarnAgentStatus.ts
+++ b/internal-dashboard/src/fetchers/fetchEarnAgentStatus.ts
@@ -31,10 +31,16 @@ type EarnAgentStatus = {
   vaults: VaultCooldownPosition[];
 };
 
-// An ERC-1967 slot holds the address right-aligned in 32 bytes; an unset slot
-// comes back as zero (or "0x" from some RPCs), which normalizes to undefined.
+// An ERC-1967 slot holds the address right-aligned in a full 32-byte word; an
+// unset slot comes back as zero — or "0x" from some RPCs — both normalizing to
+// undefined. Guard on the full-word length so a bare "0x" doesn't slice into
+// "0x0x" and make getAddress throw.
 const slotToAddress = (slotValue: Hex | undefined) =>
-  normalizeAddress(slotValue ? `0x${slotValue.slice(-40)}` : undefined);
+  normalizeAddress(
+    slotValue && slotValue.length === 66
+      ? `0x${slotValue.slice(-40)}`
+      : undefined,
+  );
 
 const agentContract = {
   abi: earnAgentAbi,

--- a/internal-dashboard/src/hooks/useEarnAgentStatus.ts
+++ b/internal-dashboard/src/hooks/useEarnAgentStatus.ts
@@ -1,0 +1,12 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+
+import { fetchEarnAgentStatus } from "../fetchers/fetchEarnAgentStatus";
+
+const earnAgentStatusOptions = () =>
+  queryOptions({
+    queryFn: fetchEarnAgentStatus,
+    queryKey: ["earn-agent-status"],
+    refetchInterval: 60_000,
+  });
+
+export const useEarnAgentStatus = () => useQuery(earnAgentStatusOptions());

--- a/internal-dashboard/src/lib/cooldownSummary.test.ts
+++ b/internal-dashboard/src/lib/cooldownSummary.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type CooldownRequest,
+  keeperBehindThresholdSeconds,
+  summarizeCooldown,
+} from "./cooldownSummary";
+
+const nowSeconds = 1_784_000_000;
+
+const request = ({
+  assets = 1000n,
+  claimableAt,
+  requestId = 1n,
+}: {
+  assets?: bigint;
+  claimableAt: number;
+  requestId?: bigint;
+}): CooldownRequest => ({
+  assets,
+  claimableAt: BigInt(claimableAt),
+  requestId,
+});
+
+describe("summarizeCooldown", function () {
+  it("returns empty buckets and no signal without requests", function () {
+    const summary = summarizeCooldown({ nowSeconds, requests: [] });
+    expect(summary.inCooldown).toEqual({ assets: 0n, count: 0 });
+    expect(summary.ready).toEqual({ assets: 0n, count: 0 });
+    expect(summary.oldestReadySeconds).toBeUndefined();
+    expect(summary.isKeeperBehind).toBe(false);
+  });
+
+  it("puts future requests in cooldown and stays clear", function () {
+    const summary = summarizeCooldown({
+      nowSeconds,
+      requests: [
+        request({ assets: 100n, claimableAt: nowSeconds + 10 }),
+        request({ assets: 200n, claimableAt: nowSeconds + 86400 }),
+      ],
+    });
+    expect(summary.inCooldown).toEqual({ assets: 300n, count: 2 });
+    expect(summary.ready).toEqual({ assets: 0n, count: 0 });
+    expect(summary.oldestReadySeconds).toBeUndefined();
+    expect(summary.isKeeperBehind).toBe(false);
+  });
+
+  it("splits mixed requests and sums assets per bucket", function () {
+    const summary = summarizeCooldown({
+      nowSeconds,
+      requests: [
+        request({ assets: 100n, claimableAt: nowSeconds - 30 }),
+        request({ assets: 200n, claimableAt: nowSeconds + 30 }),
+        request({ assets: 400n, claimableAt: nowSeconds - 10 }),
+      ],
+    });
+    expect(summary.inCooldown).toEqual({ assets: 200n, count: 1 });
+    expect(summary.ready).toEqual({ assets: 500n, count: 2 });
+  });
+
+  it("counts a request maturing exactly now as ready", function () {
+    const summary = summarizeCooldown({
+      nowSeconds,
+      requests: [request({ claimableAt: nowSeconds })],
+    });
+    expect(summary.ready.count).toBe(1);
+    expect(summary.oldestReadySeconds).toBe(0);
+  });
+
+  it("measures the oldest ready request, not the newest", function () {
+    const summary = summarizeCooldown({
+      nowSeconds,
+      requests: [
+        request({ claimableAt: nowSeconds - 60 }),
+        request({ claimableAt: nowSeconds - 7200 }),
+        request({ claimableAt: nowSeconds - 600 }),
+      ],
+    });
+    expect(summary.oldestReadySeconds).toBe(7200);
+  });
+
+  it("stays clear at exactly the threshold", function () {
+    const summary = summarizeCooldown({
+      nowSeconds,
+      requests: [
+        request({ claimableAt: nowSeconds - keeperBehindThresholdSeconds }),
+      ],
+    });
+    expect(summary.isKeeperBehind).toBe(false);
+  });
+
+  it("flags the keeper behind past the threshold", function () {
+    const summary = summarizeCooldown({
+      nowSeconds,
+      requests: [
+        request({ claimableAt: nowSeconds - keeperBehindThresholdSeconds - 1 }),
+      ],
+    });
+    expect(summary.isKeeperBehind).toBe(true);
+  });
+});

--- a/internal-dashboard/src/lib/cooldownSummary.ts
+++ b/internal-dashboard/src/lib/cooldownSummary.ts
@@ -1,0 +1,50 @@
+export const keeperBehindThresholdSeconds = 3600;
+
+export type CooldownRequest = {
+  assets: bigint;
+  claimableAt: bigint;
+  requestId: bigint;
+};
+
+type Bucket = {
+  assets: bigint;
+  count: number;
+};
+
+const sumBucket = (requests: CooldownRequest[]): Bucket => ({
+  assets: requests.reduce((total, request) => total + request.assets, 0n),
+  count: requests.length,
+});
+
+export const summarizeCooldown = function ({
+  nowSeconds,
+  requests,
+}: {
+  nowSeconds: number;
+  requests: CooldownRequest[];
+}) {
+  const now = BigInt(nowSeconds);
+  const ready = requests.filter((request) => request.claimableAt <= now);
+  const inCooldown = requests.filter((request) => request.claimableAt > now);
+
+  const oldestReadySeconds =
+    ready.length > 0
+      ? Number(
+          now -
+            ready.reduce(
+              (oldest, request) =>
+                request.claimableAt < oldest ? request.claimableAt : oldest,
+              ready[0].claimableAt,
+            ),
+        )
+      : undefined;
+
+  return {
+    inCooldown: sumBucket(inCooldown),
+    isKeeperBehind:
+      oldestReadySeconds !== undefined &&
+      oldestReadySeconds > keeperBehindThresholdSeconds,
+    oldestReadySeconds,
+    ready: sumBucket(ready),
+  };
+};

--- a/internal-dashboard/src/lib/format.test.ts
+++ b/internal-dashboard/src/lib/format.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDuration } from "./format";
+
+describe("formatDuration", function () {
+  it("floors sub-minute durations to <1m", function () {
+    expect(formatDuration(0)).toBe("<1m");
+    expect(formatDuration(59)).toBe("<1m");
+  });
+
+  it("formats minutes", function () {
+    expect(formatDuration(60)).toBe("1m");
+    expect(formatDuration(45 * 60 + 30)).toBe("45m");
+  });
+
+  it("formats minutes right up to the hour boundary", function () {
+    expect(formatDuration(59 * 60 + 59)).toBe("59m");
+    expect(formatDuration(90 * 60)).toBe("1h 30m");
+  });
+
+  it("formats hours with minutes", function () {
+    expect(formatDuration(3 * 3600 + 12 * 60)).toBe("3h 12m");
+    expect(formatDuration(3600)).toBe("1h");
+  });
+
+  it("formats hours right up to the day boundary", function () {
+    expect(formatDuration(23 * 3600 + 59 * 60)).toBe("23h 59m");
+  });
+
+  it("formats days with hours, dropping minutes", function () {
+    expect(formatDuration(2 * 86400 + 4 * 3600 + 59 * 60)).toBe("2d 4h");
+    expect(formatDuration(86400)).toBe("1d");
+  });
+
+  it("drops sub-hour remainders once days are present", function () {
+    expect(formatDuration(86400 + 30 * 60)).toBe("1d");
+    expect(formatDuration(10 * 86400 + 5 * 3600)).toBe("10d 5h");
+  });
+
+  it("treats negative durations as sub-minute", function () {
+    expect(formatDuration(-30)).toBe("<1m");
+    expect(formatDuration(-3600)).toBe("<1m");
+  });
+});

--- a/internal-dashboard/src/lib/format.ts
+++ b/internal-dashboard/src/lib/format.ts
@@ -26,6 +26,23 @@ export const formatPrice = (value: number) =>
 export const formatRate = (value: number) =>
   value.toLocaleString("en-US", { maximumSignificantDigits: 6 });
 
+export const formatDuration = function (seconds: number) {
+  const totalMinutes = Math.floor(seconds / 60);
+  if (totalMinutes < 1) {
+    return "<1m";
+  }
+  const days = Math.floor(totalMinutes / (60 * 24));
+  const hours = Math.floor(totalMinutes / 60) % 24;
+  const minutes = totalMinutes % 60;
+  if (days > 0) {
+    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  }
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  return `${minutes}m`;
+};
+
 export const shortenAddress = (address: Address) =>
   shorten(address, { length: 4, prefixes: ["0x"] });
 

--- a/internal-dashboard/src/pages/earnAgent.tsx
+++ b/internal-dashboard/src/pages/earnAgent.tsx
@@ -1,0 +1,141 @@
+import { type ReactNode } from "react";
+import { type Address } from "viem";
+
+import { ExplorerLink } from "../components/dex/explorerLink";
+import { StateMessage } from "../components/dex/stateMessage";
+import { CooldownStatusBadge } from "../components/earnAgent/cooldownStatusBadge";
+import { CooldownTable } from "../components/earnAgent/cooldownTable";
+import { earnAgentAddress } from "../config/earnAgent";
+import { useEarnAgentStatus } from "../hooks/useEarnAgentStatus";
+import { summarizeCooldown } from "../lib/cooldownSummary";
+
+const AddressRow = ({
+  address,
+  label,
+  method,
+}: {
+  address: Address | undefined;
+  label: string;
+  method?: string;
+}) => (
+  <div className="flex items-center justify-between gap-x-4 py-2 text-sm">
+    <span className="flex items-center gap-x-2 text-neutral-600">
+      {label}
+      {method ? <code className="text-neutral-400">{method}</code> : null}
+    </span>
+    {address ? (
+      <ExplorerLink address={address} />
+    ) : (
+      <span className="text-neutral-400">—</span>
+    )}
+  </div>
+);
+
+const Section = ({
+  children,
+  description,
+  title,
+}: {
+  children: ReactNode;
+  description?: ReactNode;
+  title: ReactNode;
+}) => (
+  <div>
+    <h3 className="flex items-center gap-x-2 text-lg font-semibold text-neutral-950">
+      {title}
+    </h3>
+    {description ? (
+      <p className="mt-1 text-sm text-neutral-600">{description}</p>
+    ) : null}
+    <div className="mt-4">{children}</div>
+  </div>
+);
+
+export const EarnAgentPage = function () {
+  const { data, status } = useEarnAgentStatus();
+  const nowSeconds = Math.floor(Date.now() / 1000);
+
+  return (
+    <section className="flex flex-col gap-y-10">
+      <header>
+        <h2 className="text-2xl font-semibold text-neutral-950">Hemi Earn</h2>
+        <p className="mt-1 text-sm font-medium text-neutral-600">
+          Health of the Hemi Earn agent — the Ethereum executor that processes
+          cross-chain deposits &amp; redeems bridged from Hemi into the Vetro
+          Earn vaults.
+        </p>
+        <div className="mt-3 divide-y divide-neutral-100">
+          <AddressRow address={earnAgentAddress} label="Agent address" />
+        </div>
+      </header>
+
+      {status === "pending" ? (
+        <StateMessage>Loading agent state…</StateMessage>
+      ) : null}
+      {status === "error" ? (
+        <StateMessage>
+          Couldn&apos;t load agent state. Try again later.
+        </StateMessage>
+      ) : null}
+
+      {status === "success" ? (
+        <>
+          <Section title="Authorized keepers">
+            {data.keepers.length === 0 ? (
+              <p className="text-sm text-neutral-600">No keepers authorized.</p>
+            ) : (
+              <div className="divide-y divide-neutral-100">
+                {data.keepers.map((keeper, index) => (
+                  <AddressRow
+                    address={keeper}
+                    key={keeper}
+                    label={`Keeper ${index + 1}`}
+                  />
+                ))}
+              </div>
+            )}
+          </Section>
+
+          <Section title="Ownership & implementation">
+            <div className="divide-y divide-neutral-100">
+              <AddressRow address={data.owner} label="Owner" method="owner()" />
+              <AddressRow
+                address={data.pendingOwner}
+                label="Pending owner"
+                method="pendingOwner()"
+              />
+              <AddressRow
+                address={data.implementation}
+                label="Implementation"
+              />
+              <AddressRow address={data.proxyAdmin} label="Proxy admin" />
+            </div>
+          </Section>
+
+          <Section
+            description={
+              <>
+                The agent&apos;s unstake requests in each vault —{" "}
+                <code>getPendingRequests(agent)</code>.
+              </>
+            }
+            title={
+              <>
+                Vault cooldown position
+                {data.vaults.some(
+                  (vault) =>
+                    summarizeCooldown({ nowSeconds, requests: vault.requests })
+                      .isKeeperBehind,
+                ) ? (
+                  <CooldownStatusBadge isBehind />
+                ) : null}
+              </>
+            }
+          >
+            <CooldownTable nowSeconds={nowSeconds} vaults={data.vaults} />
+          </Section>
+        </>
+      ) : null}
+    </section>
+  );
+};


### PR DESCRIPTION
### Description

New **"Hemi Earn"** tab (route `/hemi-earn`) in `internal-dashboard/` — Phase 1 of #622. It does Ethereum-only on-chain reads of the **Agent** executor contract, reusing the dashboard's existing shared viem `client` and `@vetro-protocol/earn` dependency, with no new infrastructure (no second chain client, subgraph, or cron).

The guiding principle is that the contract is the source of truth: state is shown as shortened explorer links for a human to cross-check, with no hardcoded baselines to diff against. The only status signal is one the chain itself yields.

Sections:
- **Authorized keepers** — `Agent.getKeepers()`, the addresses allowed to process/retry/cancel.
- **Ownership & implementation** — `owner()`, `pendingOwner()`, and the ERC-1967 implementation / proxy-admin slots.
- **Vault cooldown position** — per staking vault, `getPendingRequests(agent)` split into *in cooldown* vs *ready to claim*, plus an *oldest ready (since maturity)* signal that only warns past 1h so a just-matured request doesn't cry wolf.

Named "Hemi Earn" rather than "Earn Agent" because a follow-up (subgraph) phase will also monitor the Router on Hemi. That phase is out of scope here and will be filed as its own issue.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

https://github.com/user-attachments/assets/d0af921b-7377-46a3-8c4c-0c5df04c143b

### Related issue(s)

Closes #622

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
