### PR TITLE
Move applyBps to bigint utils

### DIFF
--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -21,7 +21,7 @@ import { useTotalMintFees } from "hooks/useTotalMintFees";
 import { type FormEvent, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
-import { applyBps } from "utils/fees";
+import { applyBps } from "utils/bigint";
 import { formatNumber } from "utils/format";
 import { getInputError } from "utils/inputError";
 import { formatAmount } from "utils/token";

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -21,7 +21,7 @@ import { useTotalRedeemFees } from "hooks/useTotalRedeemFees";
 import { type FormEvent, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
-import { applyBps } from "utils/fees";
+import { applyBps } from "utils/bigint";
 import { formatNumber } from "utils/format";
 import { getInputError } from "utils/inputError";
 import { formatAmount } from "utils/token";

--- a/web/src/components/swapForm/redeemQueue.tsx
+++ b/web/src/components/swapForm/redeemQueue.tsx
@@ -16,7 +16,7 @@ import { useTotalRedeemFees } from "hooks/useTotalRedeemFees";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TokenWithGateway } from "types";
-import { applyBps } from "utils/fees";
+import { applyBps } from "utils/bigint";
 import { getInputError } from "utils/inputError";
 import { formatAmount, parseTokenUnits } from "utils/token";
 import { formatUnits, isAddressEqual, parseUnits } from "viem";

--- a/web/src/fetchers/fetchTotalMintFees.ts
+++ b/web/src/fetchers/fetchTotalMintFees.ts
@@ -6,7 +6,8 @@ import { pricesOptions } from "hooks/usePrices";
 import { mintGasUnitsOptions } from "hooks/useSwapMintFees";
 import { config } from "providers/web3Provider";
 import type { TokenWithGateway } from "types";
-import { applyBps, weiToUsd } from "utils/fees";
+import { applyBps } from "utils/bigint";
+import { weiToUsd } from "utils/fees";
 import { getTokenPrice } from "utils/token";
 import { type Address, type Chain, type Client, formatUnits } from "viem";
 

--- a/web/src/fetchers/fetchTotalRedeemFees.ts
+++ b/web/src/fetchers/fetchTotalRedeemFees.ts
@@ -6,7 +6,8 @@ import { redeemFeeOptions } from "hooks/useRedeemFee";
 import { redeemGasUnitsOptions } from "hooks/useSwapRedeemFees";
 import { config } from "providers/web3Provider";
 import type { TokenWithGateway } from "types";
-import { applyBps, weiToUsd } from "utils/fees";
+import { applyBps } from "utils/bigint";
+import { weiToUsd } from "utils/fees";
 import { getTokenPrice } from "utils/token";
 import { type Address, type Chain, type Client, formatUnits } from "viem";
 

--- a/web/src/utils/bigint.ts
+++ b/web/src/utils/bigint.ts
@@ -1,3 +1,9 @@
+// Basis points: 100% expressed as a bigint
+const BPS_DENOMINATOR = 10000n;
+
+export const applyBps = (amount: bigint, bps: bigint) =>
+  (amount * bps) / BPS_DENOMINATOR;
+
 export const maxBigInt = (...values: bigint[]) =>
   values.reduce((max, v) => (v > max ? v : max));
 

--- a/web/src/utils/fees.ts
+++ b/web/src/utils/fees.ts
@@ -1,10 +1,5 @@
 import { formatUnits } from "viem";
 
-const BPS_DENOMINATOR = 10000n;
-
-export const applyBps = (amount: bigint, bps: bigint) =>
-  (amount * bps) / BPS_DENOMINATOR;
-
 export const sumFees = function (fees: (bigint | undefined)[]) {
   if (fees.every((fee): fee is bigint => fee !== undefined)) {
     return fees.reduce((sum, fee) => sum + fee, 0n);

--- a/web/test/utils/bigint.test.ts
+++ b/web/test/utils/bigint.test.ts
@@ -1,6 +1,28 @@
 import { describe, expect, it } from "vitest";
 
-import { maxBigInt, minBigInt } from "../../src/utils/bigint";
+import { applyBps, maxBigInt, minBigInt } from "../../src/utils/bigint";
+
+describe("applyBps", function () {
+  it("calculates 0.30% of 10000", function () {
+    expect(applyBps(10000n, 30n)).toBe(30n);
+  });
+
+  it("calculates 1% of 1000000", function () {
+    expect(applyBps(1000000n, 100n)).toBe(10000n);
+  });
+
+  it("returns 0 when amount is 0", function () {
+    expect(applyBps(0n, 50n)).toBe(0n);
+  });
+
+  it("returns 0 when bps is 0", function () {
+    expect(applyBps(1000n, 0n)).toBe(0n);
+  });
+
+  it("truncates when result is not whole", function () {
+    expect(applyBps(1n, 5000n)).toBe(0n);
+  });
+});
 
 describe("maxBigInt", function () {
   it("should return the value when given a single argument", function () {

--- a/web/test/utils/fees.test.ts
+++ b/web/test/utils/fees.test.ts
@@ -1,27 +1,5 @@
-import { applyBps, sumFees, weiToUsd } from "utils/fees";
+import { sumFees, weiToUsd } from "utils/fees";
 import { describe, expect, it } from "vitest";
-
-describe("applyBps", function () {
-  it("calculates 0.30% of 10000", function () {
-    expect(applyBps(10000n, 30n)).toBe(30n);
-  });
-
-  it("calculates 1% of 1000000", function () {
-    expect(applyBps(1000000n, 100n)).toBe(10000n);
-  });
-
-  it("returns 0 when amount is 0", function () {
-    expect(applyBps(0n, 50n)).toBe(0n);
-  });
-
-  it("returns 0 when bps is 0", function () {
-    expect(applyBps(1000n, 0n)).toBe(0n);
-  });
-
-  it("truncates when result is not whole", function () {
-    expect(applyBps(1n, 5000n)).toBe(0n);
-  });
-});
 
 describe("sumFees", function () {
   it("returns undefined when any fee is undefined", function () {


### PR DESCRIPTION
### Description

`applyBps` is a generic basis-points operation on a `bigint` — not fee-specific — and it's used by both the fee calculations and the upcoming slippage controls. This PR moves `applyBps` (and the shared `BPS_DENOMINATOR` constant) out of `utils/fees` into `utils/bigint`, alongside the other bigint helpers, and relocates its unit tests to match. The fee-specific helpers (`weiToUsd`, `sumFees`) stay in `utils/fees`, and all import sites are updated to the new location.

Pure refactor with no behavior change. It's split out from the slippage work so it can be reviewed on its own before the feature lands.

### Screenshots

N/A — no UI change, this only moves code between files.

### Related issue(s)

Related to #625

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.