### PR TITLE
Add vetro-cli package with read-only swap commands

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,8 @@
 {
   "extends": ["bloq", "prettier"],
   "ignorePatterns": [
+    "**/_esm/**/*",
+    "**/_types/**/*",
     "api/.wrangler/**/*",
     "internal-dashboard/dist/**/*",
     "subgraph/**/*",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,39 @@
+# @vetro-protocol/cli
+
+> [!NOTE]
+> This CLI is still under development. Docs may not reflect the actual state, but the future one.
+
+`vetro-cli` — a command-line interface that sits on top of the `@vetro-protocol/*` packages so agents and users can read Vetro state and generate transaction calldata.
+
+## Local development
+
+To test it locally, bundle and then consume it from the terminal.
+
+```sh
+pnpm --filter @vetro-protocol/cli bundle   # produces _esm/cli.js (the vetro-cli bin)
+node packages/cli/_esm/cli.js swap pegged-token --gateway 0x...
+```
+
+## Configuration
+
+The following env variables can be set.
+
+- `RPC_URL` — Ethereum mainnet RPC endpoint used for reads. Falls back to a public RPC when unset.
+
+## Output
+
+All output is JSON, so it's directly consumable by an agent.
+
+- Addresses and other strings are emitted as JSON strings; booleans as JSON booleans.
+- `uint256` on-chain values are serialized as decimal strings, since `bigint` can't be represented in JSON.
+
+## Commands
+
+This is the list of commands available
+
+### `swap` — whitelisted ↔ pegged token
+
+| Command                                        | Reads            | Returns                        |
+| ---------------------------------------------- | ---------------- | ------------------------------ |
+| `vetro-cli swap pegged-token --gateway <addr>` | `getPeggedToken` | Gateway's pegged-token address |
+| `vetro-cli swap treasury --gateway <addr>`     | `getTreasury`    | Gateway's treasury address     |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,7 +1,7 @@
 # @vetro-protocol/cli
 
 > [!NOTE]
-> This CLI is still under development. Docs may not reflect the actual state, but the future one.
+> This CLI is still under development. Docs may not reflect the actual state yet.
 
 `vetro-cli` — a command-line interface that sits on top of the `@vetro-protocol/*` packages so agents and users can read Vetro state and generate transaction calldata.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,10 +22,15 @@ The following env variables can be set.
 
 ## Output
 
-All output is JSON, so it's directly consumable by an agent.
+Successful output is JSON on stdout, so it's directly consumable by an agent.
 
 - Addresses and other strings are emitted as JSON strings; booleans as JSON booleans.
 - `uint256` on-chain values are serialized as decimal strings, since `bigint` can't be represented in JSON.
+
+Failures always exit non-zero, but come in two shapes:
+
+- **Runtime errors** (RPC failure, contract revert) are JSON on stderr: `{ "error": "..." }`.
+- **Usage errors** (invalid or missing flags, unknown commands) are written by the CLI parser as plain text on stderr.
 
 ## Commands
 

--- a/packages/cli/esbuild.ts
+++ b/packages/cli/esbuild.ts
@@ -1,0 +1,13 @@
+import { build } from "esbuild";
+
+await build({
+  // Provide a real `require` so bundled CommonJS deps (commander) work in ESM output.
+  banner: {
+    js: "import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);",
+  },
+  bundle: true,
+  entryPoints: ["src/cli.ts"],
+  format: "esm",
+  outfile: "_esm/cli.js",
+  platform: "node",
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@vetro-protocol/cli",
+  "version": "1.0.0-beta.1",
+  "description": "CLI to read and operate on Vetro.",
+  "license": "MIT",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "_esm"
+  ],
+  "bin": {
+    "vetro-cli": "./_esm/cli.js"
+  },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "bundle": "node esbuild.ts",
+    "clean": "rm -rf ./_esm",
+    "prepack": "cp ../../LICENSE LICENSE",
+    "postpack": "rm -f LICENSE",
+    "prepublishOnly": "pnpm clean && pnpm bundle",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@vetro-protocol/gateway": "workspace:*",
+    "commander": "15.0.0",
+    "viem": "2.44.4"
+  },
+  "devDependencies": {
+    "@tsconfig/node24": "24.0.4",
+    "@types/node": "24.1.0",
+    "esbuild": "0.27.3",
+    "typescript": "5.9.3",
+    "vitest": "4.1.9"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "private": true,
+  "type": "module"
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import { Command } from "commander";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { register as swap } from "./features/swap/index.js";
+import { printError } from "./lib/output.js";
+
+const packageJsonPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "package.json",
+);
+const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+  bin: Record<string, string>;
+  description: string;
+  version: string;
+};
+
+const program = new Command();
+
+program
+  // The CLI name is the bin key (vetro-cli), not the scoped package name.
+  .name(Object.keys(pkg.bin)[0])
+  .description(pkg.description)
+  .version(pkg.version);
+
+const features = [swap];
+
+features.forEach((register) => register(program));
+
+program.parseAsync(process.argv).catch(printError);

--- a/packages/cli/src/features/swap/commands/peggedToken.ts
+++ b/packages/cli/src/features/swap/commands/peggedToken.ts
@@ -1,0 +1,21 @@
+import { getPeggedToken } from "@vetro-protocol/gateway/actions";
+import { type Command } from "commander";
+import { type Address } from "viem";
+
+import { parseGateway } from "../../../lib/args.js";
+import { createVetroClient } from "../../../lib/client.js";
+import { printResult } from "../../../lib/output.js";
+
+export function register(swap: Command) {
+  swap
+    .command("pegged-token")
+    .description("Print the gateway's pegged-token address")
+    .requiredOption("--gateway <addr>", "Gateway address", parseGateway)
+    .action(async function (options: { gateway: Address }) {
+      const client = createVetroClient();
+      const peggedToken = await getPeggedToken(client, {
+        address: options.gateway,
+      });
+      printResult(peggedToken);
+    });
+}

--- a/packages/cli/src/features/swap/commands/treasury.ts
+++ b/packages/cli/src/features/swap/commands/treasury.ts
@@ -1,0 +1,21 @@
+import { getTreasury } from "@vetro-protocol/gateway/actions";
+import { type Command } from "commander";
+import { type Address } from "viem";
+
+import { parseGateway } from "../../../lib/args.js";
+import { createVetroClient } from "../../../lib/client.js";
+import { printResult } from "../../../lib/output.js";
+
+export function register(swap: Command) {
+  swap
+    .command("treasury")
+    .description("Print the gateway's treasury address")
+    .requiredOption("--gateway <addr>", "Gateway address", parseGateway)
+    .action(async function (options: { gateway: Address }) {
+      const client = createVetroClient();
+      const treasury = await getTreasury(client, {
+        address: options.gateway,
+      });
+      printResult(treasury);
+    });
+}

--- a/packages/cli/src/features/swap/index.ts
+++ b/packages/cli/src/features/swap/index.ts
@@ -1,0 +1,14 @@
+import { type Command } from "commander";
+
+import { register as peggedToken } from "./commands/peggedToken.js";
+import { register as treasury } from "./commands/treasury.js";
+
+const swapCommands = [peggedToken, treasury];
+
+export function register(program: Command) {
+  const swap = program
+    .command("swap")
+    .description("Swap operations (whitelisted ↔ pegged token)");
+
+  swapCommands.forEach((registerCommand) => registerCommand(swap));
+}

--- a/packages/cli/src/lib/args.ts
+++ b/packages/cli/src/lib/args.ts
@@ -1,0 +1,19 @@
+import { gatewayAddresses } from "@vetro-protocol/gateway";
+import { InvalidArgumentError } from "commander";
+import { getAddress, isAddressEqual } from "viem";
+
+export function parseAddress(value: string) {
+  try {
+    return getAddress(value);
+  } catch {
+    throw new InvalidArgumentError(`Invalid address: "${value}"`);
+  }
+}
+
+export function parseGateway(value: string) {
+  const address = parseAddress(value);
+  if (!gatewayAddresses.some((gateway) => isAddressEqual(gateway, address))) {
+    throw new InvalidArgumentError(`Not an enabled gateway: "${value}"`);
+  }
+  return address;
+}

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -1,0 +1,10 @@
+import { createPublicClient, http } from "viem";
+import { mainnet } from "viem/chains";
+
+// TODO extend custom RPC https://github.com/vetro-protocol/vetro-monorepo/issues/445#issuecomment-5062771972
+// For the time being, for development, let's allow overriding with env vars
+export const createVetroClient = () =>
+  createPublicClient({
+    chain: mainnet,
+    transport: http(process.env.RPC_URL),
+  });

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -5,8 +5,18 @@ export function printResult(value: unknown) {
   process.stdout.write(`${json}\n`);
 }
 
+function sanitize(message: string) {
+  let sanitized = message;
+  // TODO extend custom RPC https://github.com/vetro-protocol/vetro-monorepo/issues/445#issuecomment-5062771972
+  const rpcUrl = process.env.RPC_URL;
+  if (rpcUrl) {
+    sanitized = sanitized.replaceAll(rpcUrl, "[redacted]");
+  }
+  return sanitized;
+}
+
 export function printError(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`${JSON.stringify({ error: message })}\n`);
+  process.stderr.write(`${JSON.stringify({ error: sanitize(message) })}\n`);
   process.exitCode = 1;
 }

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -1,0 +1,12 @@
+export function printResult(value: unknown) {
+  const json = JSON.stringify(value ?? null, (_key, val) =>
+    typeof val === "bigint" ? val.toString() : val,
+  );
+  process.stdout.write(`${json}\n`);
+}
+
+export function printError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${JSON.stringify({ error: message })}\n`);
+  process.exitCode = 1;
+}

--- a/packages/cli/test/args.test.ts
+++ b/packages/cli/test/args.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAddress, parseGateway } from "../src/lib/args.js";
+
+describe("parseAddress", function () {
+  it("returns the checksummed address for valid lowercase input", function () {
+    expect(parseAddress("0xdad503f8b9d42bb7af3afc588358d30163e4416f")).toBe(
+      "0xDaD503f8B9d42bb7af3AfC588358D30163e4416F",
+    );
+  });
+
+  it("throws a clean error for an invalid address", function () {
+    expect(() => parseAddress("not-an-address")).toThrow(
+      'Invalid address: "not-an-address"',
+    );
+  });
+});
+
+describe("parseGateway", function () {
+  it("returns the checksummed address for an enabled gateway", function () {
+    expect(parseGateway("0xdad503f8b9d42bb7af3afc588358d30163e4416f")).toBe(
+      "0xDaD503f8B9d42bb7af3AfC588358D30163e4416F",
+    );
+  });
+
+  it("throws for a valid address that is not an enabled gateway", function () {
+    expect(() =>
+      parseGateway("0x0000000000000000000000000000000000000001"),
+    ).toThrow(
+      'Not an enabled gateway: "0x0000000000000000000000000000000000000001"',
+    );
+  });
+
+  it("throws for a malformed address", function () {
+    expect(() => parseGateway("nope")).toThrow('Invalid address: "nope"');
+  });
+});

--- a/packages/cli/test/output.test.ts
+++ b/packages/cli/test/output.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { printResult } from "../src/lib/output.js";
+import { printError, printResult } from "../src/lib/output.js";
 
 const captureStdout = () =>
   vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+const captureStderr = () =>
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
 describe("printResult", function () {
   it("serializes bigint values as decimal strings", function () {
@@ -38,5 +41,39 @@ describe("printResult", function () {
     const spy = captureStdout();
     printResult(undefined);
     expect(spy).toHaveBeenCalledWith("null\n");
+  });
+});
+
+describe("printError", function () {
+  const originalRpcUrl = process.env.RPC_URL;
+
+  afterEach(function () {
+    if (originalRpcUrl === undefined) {
+      delete process.env.RPC_URL;
+    } else {
+      process.env.RPC_URL = originalRpcUrl;
+    }
+    process.exitCode = 0;
+  });
+
+  it("redacts the configured RPC_URL so a key doesn't leak", function () {
+    process.env.RPC_URL = "https://eth-mainnet.example/v2/SECRET_KEY";
+    const spy = captureStderr();
+    printError(
+      new Error(
+        "HTTP request failed. URL: https://eth-mainnet.example/v2/SECRET_KEY",
+      ),
+    );
+    expect(spy).toHaveBeenCalledWith(
+      '{"error":"HTTP request failed. URL: [redacted]"}\n',
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("passes the message through when RPC_URL is unset", function () {
+    delete process.env.RPC_URL;
+    const spy = captureStderr();
+    printError(new Error("boom"));
+    expect(spy).toHaveBeenCalledWith('{"error":"boom"}\n');
   });
 });

--- a/packages/cli/test/output.test.ts
+++ b/packages/cli/test/output.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { printResult } from "../src/lib/output.js";
+
+const captureStdout = () =>
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+describe("printResult", function () {
+  it("serializes bigint values as decimal strings", function () {
+    const spy = captureStdout();
+    printResult(120n);
+    expect(spy).toHaveBeenCalledWith('"120"\n');
+  });
+
+  it("serializes addresses as bare JSON strings", function () {
+    const spy = captureStdout();
+    printResult("0xDaD503f8B9d42bb7af3AfC588358D30163e4416F");
+    expect(spy).toHaveBeenCalledWith(
+      '"0xDaD503f8B9d42bb7af3AfC588358D30163e4416F"\n',
+    );
+  });
+
+  it("serializes booleans as-is", function () {
+    const spy = captureStdout();
+    printResult(false);
+    expect(spy).toHaveBeenCalledWith("false\n");
+  });
+
+  it("serializes nested bigints inside objects", function () {
+    const spy = captureStdout();
+    printResult({ amountLocked: 1000n, status: "cooldown" });
+    expect(spy).toHaveBeenCalledWith(
+      '{"amountLocked":"1000","status":"cooldown"}\n',
+    );
+  });
+
+  it("serializes undefined as null to stay valid JSON", function () {
+    const spy = captureStdout();
+    printResult(undefined);
+    expect(spy).toHaveBeenCalledWith("null\n");
+  });
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "erasableSyntaxOnly": true,
+    "noEmit": true
+  },
+  "exclude": ["node_modules", "_esm"],
+  "extends": "@tsconfig/node24/tsconfig.json",
+  "include": ["**/*.ts"]
+}

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    clearMocks: true,
+    restoreMocks: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,7 +143,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.23.1
-        version: 1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260329.1)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+        version: 1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260205.0)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@cloudflare/workers-types':
         specifier: 4.20260504.1
         version: 4.20260504.1
@@ -208,6 +208,34 @@ importers:
       viem:
         specifier: 2.44.4
         version: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      vitest:
+        specifier: 4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+
+  packages/cli:
+    dependencies:
+      '@vetro-protocol/gateway':
+        specifier: workspace:*
+        version: link:../gateway
+      commander:
+        specifier: 15.0.0
+        version: 15.0.0
+      viem:
+        specifier: 2.44.4
+        version: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+    devDependencies:
+      '@tsconfig/node24':
+        specifier: 24.0.4
+        version: 24.0.4
+      '@types/node':
+        specifier: 24.1.0
+        version: 24.1.0
+      esbuild:
+        specifier: 0.27.3
+        version: 0.27.3
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
       vitest:
         specifier: 4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
@@ -437,7 +465,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.23.1
-        version: 1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260205.0)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+        version: 1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))(workerd@1.20260329.1)(wrangler@4.63.0(@cloudflare/workers-types@4.20260504.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@cloudflare/workers-types':
         specifier: 4.20260504.1
         version: 4.20260504.1
@@ -3438,9 +3466,6 @@ packages:
   '@types/node@24.10.13':
     resolution: {integrity: sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==, tarball: https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz}
 
-  '@types/node@24.12.0':
-    resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==, tarball: https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz}
-
   '@types/node@25.0.9':
     resolution: {integrity: sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==, tarball: https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz}
 
@@ -4439,6 +4464,14 @@ packages:
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==, tarball: https://registry.npmjs.org/commander/-/commander-14.0.2.tgz}
     engines: {node: '>=20'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==, tarball: https://registry.npmjs.org/commander/-/commander-14.0.3.tgz}
+    engines: {node: '>=20'}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==, tarball: https://registry.npmjs.org/commander/-/commander-15.0.0.tgz}
+    engines: {node: '>=22.12.0'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==, tarball: https://registry.npmjs.org/commander/-/commander-2.20.3.tgz}
@@ -11228,7 +11261,7 @@ snapshots:
   '@solana/errors@2.3.0(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
-      commander: 14.0.2
+      commander: 14.0.3
       typescript: 5.9.3
 
   '@solana/errors@5.4.0(typescript@5.9.3)':
@@ -11839,7 +11872,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 24.10.13
 
   '@types/d3-array@3.2.2': {}
 
@@ -11899,10 +11932,6 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@24.12.0':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/node@25.0.9':
     dependencies:
       undici-types: 7.16.0
@@ -11927,11 +11956,11 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 24.10.13
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 24.10.13
 
   '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint@8.57.0)(typescript@6.0.2)':
     dependencies:
@@ -12169,7 +12198,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
 
   '@vitest/eslint-plugin@1.6.6(eslint@8.57.0)(typescript@6.0.2)(vitest@4.1.9)':
     dependencies:
@@ -13475,6 +13504,10 @@ snapshots:
 
   commander@14.0.2: {}
 
+  commander@14.0.3: {}
+
+  commander@15.0.0: {}
+
   commander@2.20.3: {}
 
   comment-parser@1.3.1: {}
@@ -14239,13 +14272,14 @@ snapshots:
       esquery: 1.7.0
       jsonc-eslint-parser: 2.4.2
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.1(eslint@8.57.0)(typescript@6.0.2)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@6.0.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14266,7 +14300,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
### Description

Introduces `@vetro-protocol/cli` (bin: `vetro-cli`), a commander-based CLI that sits on top of the `@vetro-protocol/*` packages so agents and users can read Vetro state as JSON.

This is part 1 of the CLI: the read-only slice of `swap` — `swap pegged-token` and `swap treasury`, each taking a `--gateway` validated against the enabled gateways. All output is JSON so it's directly consumable by agents (`uint256` values as decimal strings). Package actions are called directly as `actionFn(client, params)` rather than via viem's `.extend()`.

Example:

```sh
node packages/cli/_esm/cli.js swap pegged-token --gateway 0xCBA2Ffa0AC52d7871a4221a871793Eb788013faB
"0xf196C68233464A16CFDa319a47c21f4cECa62001"
```

The CLI is bundled with esbuild into a single self-contained ESM file (Node 24+), since it depends on workspace TypeScript packages that can't run under bare `node`. Also adds `_esm`/`_types` build-output ignores to eslint.

Write operations (mint/redeem/approve) and the Earn, Bridge, and Borrow features will follow in later PRs.

### Screenshots

_To be added._

### Related issue(s)

Related to #445

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
