### PR TITLE
Add Umami analytics for page views and wallets

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -8,14 +8,16 @@ Built with React, Viem, Wagmi, and Tailwind CSS.
 
 Vite only exposes variables prefixed with `VITE_` to the client bundle. Set these in `web/.env` (or a `.env.local` override) before running `dev` or `build`.
 
-| Variable                         | Required | Description                                                                                    |
-| -------------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `VITE_DEPLOY_ENV`                | No       | Set to `"production"` to hide source maps from browsers. Any other value serves them publicly. |
-| `VITE_PORTAL_API_URL`            | Yes      | Hemi Portal API base URL (used for token prices).                                              |
-| `VITE_RPC_URL_MAINNET`           | No       | RPC URL for Ethereum mainnet. Falls back to viem's default when unset.                         |
-| `VITE_SENTRY_DSN`                | No       | Sentry DSN. When unset, Sentry is disabled.                                                    |
-| `VITE_WALLET_CONNECT_PROJECT_ID` | No       | WalletConnect project ID.                                                                      |
-| `VITE_VETRO_API_URL`             | Yes      | Vetro backend API base URL (analytics, APR history, exit tickets, rewards, etc.).              |
+| Variable                         | Required | Description                                                                                                 |
+| -------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `VITE_ANALYTICS_URL`             | No       | Umami tracker script URL. Analytics (page views) is enabled only when this and the website ID are both set. |
+| `VITE_ANALYTICS_WEBSITE_ID`      | No       | Umami website ID.                                                                                           |
+| `VITE_DEPLOY_ENV`                | No       | Set to `"production"` to hide source maps from browsers. Any other value serves them publicly.              |
+| `VITE_PORTAL_API_URL`            | Yes      | Hemi Portal API base URL (used for token prices).                                                           |
+| `VITE_RPC_URL_MAINNET`           | No       | RPC URL for Ethereum mainnet. Falls back to viem's default when unset.                                      |
+| `VITE_SENTRY_DSN`                | No       | Sentry DSN. When unset, Sentry is disabled.                                                                 |
+| `VITE_WALLET_CONNECT_PROJECT_ID` | No       | WalletConnect project ID.                                                                                   |
+| `VITE_VETRO_API_URL`             | Yes      | Vetro backend API base URL (analytics, APR history, exit tickets, rewards, etc.).                           |
 
 The following variables are read at build time (not baked into the bundle) and only matter in CI/CD:
 

--- a/web/global.d.ts
+++ b/web/global.d.ts
@@ -1,0 +1,10 @@
+interface Window {
+  umami?: {
+    track: {
+      (
+        payload: (props: Record<string, unknown>) => Record<string, unknown>,
+      ): void;
+      (eventName: string, eventData?: Record<string, unknown>): void;
+    };
+  };
+}

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/react";
+import { AnalyticsTracker } from "components/analyticsTracker";
 import { AppLayout, MainContent } from "components/base/appLayout";
 import { AppViewport } from "components/base/appViewport";
 import { ErrorBoundary } from "components/base/errorBoundary";
@@ -28,6 +29,10 @@ import {
 import { isGeoRestricted } from "utils/geoRestriction";
 
 const SentryRoutes = Sentry.withSentryReactRouterV7Routing(Routes);
+
+const analyticsEnabled =
+  !!import.meta.env.VITE_ANALYTICS_URL &&
+  !!import.meta.env.VITE_ANALYTICS_WEBSITE_ID;
 
 const AppNotifications = lazy(() =>
   import("components/appNotifications").then((m) => ({
@@ -102,6 +107,7 @@ function LanguageRoutes() {
 export const App = () => (
   <BrowserRouter>
     <NuqsAdapter>
+      {analyticsEnabled && <AnalyticsTracker />}
       <AppViewport>
         <SentryRoutes>
           {/* Redirect root to English */}

--- a/web/src/components/analyticsTracker.tsx
+++ b/web/src/components/analyticsTracker.tsx
@@ -1,0 +1,39 @@
+import * as Sentry from "@sentry/react";
+import { normalizePath } from "i18n/path";
+import { useCallback, useEffect } from "react";
+import { useLocation } from "react-router";
+import { type Connector, useAccountEffect } from "wagmi";
+
+export function AnalyticsTracker() {
+  const { pathname } = useLocation();
+  const url = normalizePath(pathname);
+
+  useEffect(
+    function trackPageView() {
+      if (url !== "/") {
+        window.umami?.track((props) => ({ ...props, url }));
+      }
+    },
+    [url],
+  );
+
+  useAccountEffect({
+    onConnect: useCallback(function ({
+      connector,
+      isReconnected,
+    }: {
+      connector: Connector;
+      isReconnected: boolean;
+    }) {
+      Sentry.setTag("evm wallet", connector.name);
+      if (!isReconnected) {
+        window.umami?.track("evm connected", { wallet: connector.name });
+      }
+    }, []),
+    onDisconnect: useCallback(function () {
+      Sentry.setTag("evm wallet", undefined);
+    }, []),
+  });
+
+  return null;
+}

--- a/web/src/i18n/config.tsx
+++ b/web/src/i18n/config.tsx
@@ -6,7 +6,7 @@ import { useNavigate, useParams } from "react-router";
 import { resources } from "./resources";
 
 const fallbackLng = "en";
-const supportedLngs = ["en", "es"];
+export const supportedLngs = ["en", "es"];
 
 export const initializeI18n = () =>
   i18n.use(initReactI18next).init({

--- a/web/src/i18n/path.test.ts
+++ b/web/src/i18n/path.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizePath } from "./path";
+
+describe("normalizePath", function () {
+  it("strips the locale prefix", function () {
+    expect(normalizePath("/en/swap")).toBe("/swap");
+    expect(normalizePath("/es/earn")).toBe("/earn");
+  });
+
+  it("preserves nested segments after the locale", function () {
+    expect(normalizePath("/en/borrow/0xabc")).toBe("/borrow/0xabc");
+  });
+
+  it("removes a trailing slash", function () {
+    expect(normalizePath("/en/swap/")).toBe("/swap");
+  });
+
+  it("collapses the root and locale-only paths to /", function () {
+    expect(normalizePath("/")).toBe("/");
+    expect(normalizePath("/en")).toBe("/");
+    expect(normalizePath("/es/")).toBe("/");
+  });
+
+  it("leaves paths without a supported locale untouched", function () {
+    expect(normalizePath("/borrow")).toBe("/borrow");
+    expect(normalizePath("/fr/swap")).toBe("/fr/swap");
+  });
+
+  it("does not strip a segment that merely starts with a locale", function () {
+    expect(normalizePath("/ensure")).toBe("/ensure");
+    expect(normalizePath("/english/swap")).toBe("/english/swap");
+  });
+});

--- a/web/src/i18n/path.ts
+++ b/web/src/i18n/path.ts
@@ -1,0 +1,11 @@
+import { supportedLngs } from "./config";
+
+export function normalizePath(pathname: string) {
+  const locale = supportedLngs.find(
+    (candidate) =>
+      pathname === `/${candidate}` || pathname.startsWith(`/${candidate}/`),
+  );
+  const withoutLocale = locale ? pathname.slice(locale.length + 1) : pathname;
+  const withoutTrailingSlash = withoutLocale.replace(/\/$/, "");
+  return withoutTrailingSlash || "/";
+}

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -53,12 +53,15 @@ const walletFrameSrc = [
   "https://keys.coinbase.com",
 ].join(" ");
 
+const analyticsOrigin = getUrlOrigin(import.meta.env.VITE_ANALYTICS_URL);
+
 const allUrls: (string | undefined)[] = [
   import.meta.env.VITE_PORTAL_API_URL,
   import.meta.env.VITE_VETRO_API_URL,
   ...rpcUrls,
   ...walletConnectUrls,
   import.meta.env.VITE_SENTRY_DSN,
+  import.meta.env.VITE_ANALYTICS_URL,
   "https://cloudflareinsights.com", // Cloudflare Web Beacon analytics.
 ];
 
@@ -78,6 +81,7 @@ const buildScriptSrc = (nonce: string) =>
     "'self'",
     "https://static.cloudflareinsights.com", // Web Analytics beacon.
     "https://challenges.cloudflare.com", // Cloudflare bot management / challenge widget.
+    ...(analyticsOrigin ? [analyticsOrigin] : []),
     ...(import.meta.env.DEV ? ["'unsafe-inline'"] : [`'nonce-${nonce}'`]),
   ].join(" ");
 

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -7,6 +7,7 @@
   },
   "include": [
     "e2e",
+    "global.d.ts",
     "playwright.config.ts",
     "reset.d.ts",
     "scripts",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,8 +2,43 @@ import { cloudflare } from "@cloudflare/vite-plugin";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig, type UserConfig } from "vite";
+import { defineConfig, type Plugin, type UserConfig } from "vite";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
+
+function injectUmamiIfEnabled() {
+  let env: Record<string, string> = {};
+  return {
+    configResolved(config) {
+      env = config.env;
+    },
+    name: "umami-analytics",
+    transformIndexHtml: {
+      handler(html) {
+        const src = env.VITE_ANALYTICS_URL;
+        const websiteId = env.VITE_ANALYTICS_WEBSITE_ID;
+        if (!src || !websiteId) {
+          return html;
+        }
+        return {
+          html,
+          tags: [
+            {
+              attrs: {
+                "data-auto-track": "false",
+                "data-website-id": websiteId,
+                defer: true,
+                src,
+              },
+              injectTo: "head",
+              tag: "script",
+            },
+          ],
+        };
+      },
+      order: "post",
+    },
+  } satisfies Plugin;
+}
 
 const config = {
   build: {
@@ -20,6 +55,7 @@ const config = {
       include: ["http", "https"],
     }),
     tailwindcss(),
+    injectUmamiIfEnabled(),
   ],
   resolve: {
     tsconfigPaths: true,


### PR DESCRIPTION
### Description

Enables analytics with Umami (issue #614): locale-stripped page views on route change, and explicit EVM wallet connections. The tracker is injected into `index.html` at build time by a Vite plugin, only when both `VITE_ANALYTICS_URL` and `VITE_ANALYTICS_WEBSITE_ID` are set; the worker CSP is widened to allow the tracker origin (`script-src` + `connect-src`).

**These env vars are intentionally not configured yet, so this can be merged and released safely — analytics stays fully disabled (no tracker injected, no tracking component mounted, CSP unchanged) until the vars are set.**

### Screenshots

N/A — no UI changes.

### Related issue(s)

Closes #614

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A. — intentionally deferred; feature ships disabled until configured.