### PR TITLE
Allow slippage with decimals

### DIFF
--- a/web/src/components/swapForm/slippageSettings/index.tsx
+++ b/web/src/components/swapForm/slippageSettings/index.tsx
@@ -11,7 +11,11 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { DEFAULT_SLIPPAGE, isHighSlippage, MAX_SLIPPAGE } from "utils/slippage";
+import {
+  DEFAULT_SLIPPAGE,
+  isHighSlippage,
+  sanitizeSlippage,
+} from "utils/slippage";
 
 import { HighSlippageModal } from "./highSlippageModal";
 
@@ -21,16 +25,6 @@ type Props = {
   onChange: (slippage: number) => void;
   slippage: number;
 };
-
-function sanitizeSlippage(raw: string) {
-  if (raw === "") {
-    return "";
-  }
-  if (!/^\d+$/.test(raw)) {
-    return null;
-  }
-  return Number(raw) > MAX_SLIPPAGE ? null : raw;
-}
 
 type TriggerProps = {
   onClick: VoidFunction;
@@ -120,8 +114,8 @@ function SlippagePanel({
             }`}
           >
             <input
-              className="w-7 bg-transparent text-right outline-none"
-              inputMode="numeric"
+              className="w-11 bg-transparent text-right outline-none"
+              inputMode="decimal"
               onChange={(e) => onInputChange(e.target.value)}
               onKeyDown={onInputKeyDown}
               placeholder="0"

--- a/web/src/utils/slippage.test.ts
+++ b/web/src/utils/slippage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { applySlippage } from "./slippage";
+import { applySlippage, sanitizeSlippage } from "./slippage";
 
 describe("applySlippage", function () {
   it("returns the full preview when slippage is 0 (auto)", function () {
@@ -14,6 +14,19 @@ describe("applySlippage", function () {
     expect(applySlippage({ preview: 1_000_000n, slippage: 50 })).toBe(500_000n);
   });
 
+  it("reduces the preview by a fractional percent", function () {
+    expect(applySlippage({ preview: 1_000_000n, slippage: 0.1 })).toBe(
+      999_000n,
+    );
+    expect(applySlippage({ preview: 1_000_000n, slippage: 0.3 })).toBe(
+      997_000n,
+    );
+    expect(applySlippage({ preview: 1_000_000n, slippage: 0.5 })).toBe(
+      995_000n,
+    );
+    expect(applySlippage({ preview: 1_000_000n, slippage: 99.9 })).toBe(1_000n);
+  });
+
   it("returns 0 when slippage is 100", function () {
     expect(applySlippage({ preview: 1_000_000n, slippage: 100 })).toBe(0n);
   });
@@ -21,5 +34,51 @@ describe("applySlippage", function () {
   it("truncates toward zero instead of rounding up", function () {
     // 12345 * 9900 / 10000 = 12221.55 -> 12221
     expect(applySlippage({ preview: 12_345n, slippage: 1 })).toBe(12_221n);
+  });
+});
+
+describe("sanitizeSlippage", function () {
+  it("accepts an empty value", function () {
+    expect(sanitizeSlippage("")).toBe("");
+  });
+
+  it("accepts integers within range", function () {
+    expect(sanitizeSlippage("0")).toBe("0");
+    expect(sanitizeSlippage("5")).toBe("5");
+    expect(sanitizeSlippage("100")).toBe("100");
+  });
+
+  it("accepts a single decimal digit", function () {
+    expect(sanitizeSlippage("0.2")).toBe("0.2");
+    expect(sanitizeSlippage("12.5")).toBe("12.5");
+  });
+
+  it("accepts a trailing dot while typing", function () {
+    expect(sanitizeSlippage("0.")).toBe("0.");
+  });
+
+  it("normalizes a comma separator to a dot", function () {
+    expect(sanitizeSlippage("0,2")).toBe("0.2");
+    expect(sanitizeSlippage("12,")).toBe("12.");
+  });
+
+  it("rejects a comma with more than one decimal digit", function () {
+    expect(sanitizeSlippage("0,25")).toBeNull();
+  });
+
+  it("rejects more than one decimal digit", function () {
+    expect(sanitizeSlippage("0.25")).toBeNull();
+  });
+
+  it("rejects values above the maximum", function () {
+    expect(sanitizeSlippage("101")).toBeNull();
+    expect(sanitizeSlippage("100.1")).toBeNull();
+  });
+
+  it("rejects non-numeric values", function () {
+    expect(sanitizeSlippage("abc")).toBeNull();
+    expect(sanitizeSlippage("-1")).toBeNull();
+    expect(sanitizeSlippage(".5")).toBeNull();
+    expect(sanitizeSlippage("1.2.3")).toBeNull();
   });
 });

--- a/web/src/utils/slippage.ts
+++ b/web/src/utils/slippage.ts
@@ -4,15 +4,15 @@ export const DEFAULT_SLIPPAGE = 0;
 
 export const HIGH_SLIPPAGE_THRESHOLD = 6;
 
-export const MAX_SLIPPAGE = 100;
+const MAX_SLIPPAGE = 100;
 
-const PERCENT_TO_BPS = 100n;
+const TENTHS_TO_BPS = 10n;
 
 /**
  * Reduces an expected output amount by the given slippage tolerance, returning
  * the minimum amount the user is willing to accept: `preview × (1 − slippage%)`.
- * Slippage is an integer percent in [0, 100]. BigInt division truncates toward
- * zero, so the minimum is always floored (never rounded up).
+ * Slippage is a percent in [0, 100] with at most one decimal. BigInt division
+ * truncates toward zero, so the minimum is always floored (never rounded up).
  */
 export const applySlippage = ({
   preview,
@@ -20,7 +20,22 @@ export const applySlippage = ({
 }: {
   preview: bigint;
   slippage: number;
-}) => applyBps(preview, BPS_DENOMINATOR - BigInt(slippage) * PERCENT_TO_BPS);
+}) =>
+  applyBps(
+    preview,
+    BPS_DENOMINATOR - BigInt(Math.round(slippage * 10)) * TENTHS_TO_BPS,
+  );
 
 export const isHighSlippage = (slippage: number) =>
   slippage >= HIGH_SLIPPAGE_THRESHOLD;
+
+export function sanitizeSlippage(raw: string) {
+  if (raw === "") {
+    return "";
+  }
+  const value = raw.replace(",", ".");
+  if (!/^\d+(\.\d?)?$/.test(value)) {
+    return null;
+  }
+  return Number(value) > MAX_SLIPPAGE ? null : value;
+}


### PR DESCRIPTION
### Description

Slippage was capped to whole percents, so a user could not pick a tolerance below 1%. This accepts one decimal digit — `0.1` and `0.2` are valid, `0.25` is not.

`applySlippage` now converts through tenths of a percent (`Math.round(slippage * 10) * 10n` bps) instead of whole percents, which keeps the `BigInt()` conversion exact for every one-decimal value in `[0, 100]` — passing `0.2` straight to `BigInt()` would have thrown a `RangeError`.

`sanitizeSlippage` moves out of the component into `utils/slippage.ts` so it can be unit tested, and its regex now allows a single decimal digit plus the intermediate trailing dot while typing. The input switches to `inputMode="decimal"` and gets a bit wider to fit the extra characters. A comma typed on the decimal keypad is normalized to a dot, so entering a fractional slippage also works for users whose mobile locale uses a comma separator.

### Screenshots

https://github.com/user-attachments/assets/23925a8e-f6b9-4d82-87e5-ccf83d3ac8c9

### Related issue(s)

Closes #653

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
