### PR TITLE
Sanitize amount input in claim redeem drawer

### DIFF
--- a/web/src/components/swapForm/redeemQueue.tsx
+++ b/web/src/components/swapForm/redeemQueue.tsx
@@ -2,6 +2,7 @@ import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import type { FetchStatus, QueryStatus } from "@tanstack/react-query";
 import { TopSection } from "components/base/table/topSection";
 import { useActivityTracking } from "hooks/useActivityTracking";
+import { useAmount } from "hooks/useAmount";
 import {
   type RedeemRequest,
   useGetRedeemRequests,
@@ -71,7 +72,7 @@ function ActiveRedeemDrawer({
     () => drawerWhitelistedTokens[0],
   );
   const [flowStatus, setFlowStatus] = useState<ClaimRedeemFlowStatus>("idle");
-  const [fromInputValue, setFromInputValue] = useState("0");
+  const [fromInputValue, onFromInputChange] = useAmount();
   const [slippage, setSlippage] = useState(DEFAULT_SLIPPAGE);
 
   const amountBigInt = parseTokenUnits(fromInputValue, peggedToken);
@@ -186,7 +187,7 @@ function ActiveRedeemDrawer({
   });
 
   const handleMaxClick = () =>
-    setFromInputValue(formatUnits(amountLocked, peggedToken.decimals));
+    onFromInputChange(formatUnits(amountLocked, peggedToken.decimals));
 
   const handleSubmit = function () {
     setFlowStatus("redeem-ready");
@@ -208,7 +209,7 @@ function ActiveRedeemDrawer({
       inputError={inputError}
       networkFee={networkFee}
       onClose={handleClose}
-      onInputChange={setFromInputValue}
+      onInputChange={onFromInputChange}
       onMaxClick={handleMaxClick}
       onSubmit={handleSubmit}
       onTokenChange={setToToken}


### PR DESCRIPTION
### Description

Typing a value viem cannot parse — the Sentry report shows `1-` — into the amount field of the redeem queue's claim drawer crashed the entire page. The drawer held its amount in a plain `useState`, so raw keystrokes from the `type="text"` input reached `parseTokenUnits` unvalidated, `parseUnits` threw during render, and the error boundary replaced the page with "Something went wrong".

Every other amount input in the app already routes keystrokes through `sanitizeAmount`, either via `useAmount` or a form reducer. This drawer was the only exception. Switching it to `useAmount` makes it ignore invalid input, so it now behaves like the rest of the forms.

Verified against a local Anvil fork: seeded a queued redeem, opened the claim drawer, and confirmed `1-` leaves the field at `0` instead of triggering the error boundary. Valid amounts, MAX, and a full redeem still work end to end (USDT 100 → 110, VUSD 100 → 90).

No unit test accompanies this. The fix lives in component state and `web` has no React Testing Library, so there is nothing to exercise it below the e2e layer — the two-step queue redeem spec in `web/e2e/swap.spec.ts` covers the flow.

### Screenshots

N/A

### Related issue(s)

Closes #652

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.