### PR TITLE
Reduce slippage input width

### DIFF
--- a/web/src/components/swapForm/slippageSettings/index.tsx
+++ b/web/src/components/swapForm/slippageSettings/index.tsx
@@ -114,7 +114,7 @@ function SlippagePanel({
             }`}
           >
             <input
-              className="w-11 bg-transparent text-right outline-none"
+              className="w-7 bg-transparent text-right outline-none"
               inputMode="decimal"
               onChange={(e) => onInputChange(e.target.value)}
               onKeyDown={onInputKeyDown}


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

On #656 I enlarged the Slippage input to allow decimals, but this caused the "Max Slippage" to overflow in 2 lines.

Reverting back as the largest number possible still enters, so a bigger input wasn't needed at all

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->

Before

<img width="832" height="390" alt="image" src="https://github.com/user-attachments/assets/7f43834f-1b88-4d12-9af7-be722f60c3e9" />

After

<img width="618" height="278" alt="image" src="https://github.com/user-attachments/assets/135806ad-87f2-4341-a9a3-c26d1be0fdf5" />

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #653

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
