### PR TITLE
Drop leading zeros in the slippage input

### DIFF
--- a/web/src/utils/slippage.ts
+++ b/web/src/utils/slippage.ts
@@ -33,7 +33,7 @@ export function sanitizeSlippage(raw: string) {
   if (raw === "") {
     return "";
   }
-  const value = raw.replace(",", ".");
+  const value = raw.replace(",", ".").replace(/^0+(?=\d)/, "");
   if (!/^\d+(\.\d?)?$/.test(value)) {
     return null;
   }

--- a/web/test/utils/slippage.test.ts
+++ b/web/test/utils/slippage.test.ts
@@ -62,6 +62,19 @@ describe("sanitizeSlippage", function () {
     expect(sanitizeSlippage("12,")).toBe("12.");
   });
 
+  it("drops leading zeros", function () {
+    expect(sanitizeSlippage("007")).toBe("7");
+    expect(sanitizeSlippage("00")).toBe("0");
+    expect(sanitizeSlippage("05.5")).toBe("5.5");
+    expect(sanitizeSlippage("00.5")).toBe("0.5");
+    expect(sanitizeSlippage("0100")).toBe("100");
+  });
+
+  it("keeps a lone zero while typing a decimal", function () {
+    expect(sanitizeSlippage("0")).toBe("0");
+    expect(sanitizeSlippage("0.")).toBe("0.");
+  });
+
   it("rejects a comma with more than one decimal digit", function () {
     expect(sanitizeSlippage("0,25")).toBeNull();
   });

--- a/web/test/utils/slippage.test.ts
+++ b/web/test/utils/slippage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { applySlippage, sanitizeSlippage } from "./slippage";
+import { applySlippage, sanitizeSlippage } from "../../src/utils/slippage";
 
 describe("applySlippage", function () {
   it("returns the full preview when slippage is 0 (auto)", function () {


### PR DESCRIPTION
### Description

`sanitizeSlippage` accepted inputs with leading zeros: typing `007` passed the `^\d+$` digit check and `Number("007") = 7` was within range, so the raw string was stored and the narrow (~28px) slippage field rendered `007`. The committed value was always `Number(draft)`, so the applied slippage was correct — this was cosmetic only.

The fix strips leading zeros in `sanitizeSlippage`. The lookahead in `/^0+(?=\d)/` only matches a zero followed by another digit, which is what keeps `0` and `0.` intact — both are intermediate states while typing a decimal like `0.5`. The `String(Number(raw))` normalization suggested in the issue would have collapsed `0.` to `0` and made decimals impossible to type.

The test file also moves from `web/src/utils/` to `web/test/utils/`, where every other test in this workspace lives.

**Commits:**

6c4ea92 Move slippage tests to web/test/utils
ac631ca Drop leading zeros in slippage input

### Screenshots

N/A — the change removes a rendering artifact, so there is nothing new to show. Verified in the browser instead: typing `007` renders `7`, `0.5` stays typeable per keystroke, and a pasted `0100` renders `100`.

### Related issue(s)

Closes #648

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
