### PR TITLE
Translate "slippage" to "deslizamiento" in es locale

### DIFF
--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -470,13 +470,13 @@
         "auto": "Auto",
         "cancel": "Cancelar",
         "continue-anyway": "Continuar de todos modos",
-        "high-slippage": "Slippage alto",
-        "high-value": "Slippage alto {{value}}%",
-        "max-slippage": "Slippage máximo",
+        "high-slippage": "Deslizamiento alto",
+        "high-value": "Deslizamiento alto {{value}}%",
+        "max-slippage": "Deslizamiento máximo",
         "title": "Configuración avanzada",
-        "value": "Slippage {{value}}%",
-        "warning-description": "<highlight>Su slippage está por encima del {{threshold}}%.</highlight> Esto aumenta su exposición al impacto de precio. Podría recibir significativamente menos tokens de los cotizados.",
-        "warning-title": "Advertencia de slippage alto"
+        "value": "Deslizamiento {{value}}%",
+        "warning-description": "<highlight>Su deslizamiento está por encima del {{threshold}}%.</highlight> Esto aumenta su exposición al impacto de precio. Podría recibir significativamente menos tokens de los cotizados.",
+        "warning-title": "Advertencia de deslizamiento alto"
       },
       "title": "Intercambie sus tokens por activos de Vetro",
       "toast": {


### PR DESCRIPTION
### Description

The Spanish translations for the Swap slippage controls left the term "slippage" untranslated (`Slippage máximo`, `Slippage alto`, …). This switches them to "deslizamiento", the established Spanish term used by the standard reference glossaries (Binance Academy, Kraken, Bit2Me) and traditional finance.

Only the `pages.swap.slippage.*` keys in `web/src/i18n/locales/es/translation.json` change; `en` is untouched, and `auto` needs no change.

### Screenshots

<img width="448" height="247" alt="image" src="https://github.com/user-attachments/assets/cab0b498-7998-49ad-b5dc-0e4f10a4b9f6" />

<img width="289" height="129" alt="image" src="https://github.com/user-attachments/assets/81af561a-9f20-4368-92d4-e9a0c97229d0" />

(Nahuel was ok with this being on 2 lines)

### Related issue(s)

Closes #650

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
