### PR TITLE
Move setDraft out of the setIsAuto updater

### DIFF
--- a/web/src/components/swapForm/slippageSettings/index.tsx
+++ b/web/src/components/swapForm/slippageSettings/index.tsx
@@ -187,12 +187,10 @@ export function SlippageSettings({ onChange, slippage }: Props) {
   }
 
   function handleToggleAuto() {
-    setIsAuto(function (previous) {
-      if (!previous) {
-        setDraft("");
-      }
-      return !previous;
-    });
+    if (!isAuto) {
+      setDraft("");
+    }
+    setIsAuto((previous) => !previous);
   }
 
   function handleInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {


### PR DESCRIPTION
### Description

`handleToggleAuto` called `setDraft("")` from inside the `setIsAuto` updater function. State updater functions are expected to be pure, and React invokes them twice in dev/StrictMode to surface impurities — so the side effect ran twice. It was idempotent, so there was no user-visible bug, just an anti-pattern that could mislead future changes and trip up StrictMode debugging.

This reads `isAuto` from the render closure and calls both setters at the top level instead. Behavior is unchanged: `handleToggleAuto` is recreated on every render and `SlippagePanel` isn't memoized, so the closure's `isAuto` is always the same value the updater's `previous` held, and the handler only fires once per commit.

### Screenshots

N/A — no visual or behavioral change.

### Related issue(s)

Closes #649

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
