### PR TITLE
Simplify props forwarding in drawer wrappers

### DIFF
--- a/web/src/components/borrow/borrowDrawer.tsx
+++ b/web/src/components/borrow/borrowDrawer.tsx
@@ -2,10 +2,8 @@ import { Drawer } from "components/base/drawer";
 import { DrawerLoader } from "components/base/drawer/drawerLoader";
 import { type Step, stepStatus } from "components/base/verticalStepper";
 import { useCloseOnSuccess } from "hooks/useCloseOnSuccess";
-import { Suspense, lazy } from "react";
+import { type ComponentProps, Suspense, lazy } from "react";
 import { useTranslation } from "react-i18next";
-import type { Token } from "types";
-import type { Hash } from "viem";
 
 const BorrowProgressDrawer = lazy(() =>
   import("./borrowProgressDrawer").then((m) => ({
@@ -68,27 +66,18 @@ const getBorrowStepStatus = function (
 };
 
 type Props = {
-  borrowAmount: string;
-  borrowToken: Token;
-  collateralAmount: string;
-  collateralToken: Token;
   flowStatus: Exclude<BorrowFlowStatus, "idle">;
-  marketId: Hash;
   onClose: VoidFunction;
   onRetry: VoidFunction;
   showApproveStep: boolean;
-};
+} & Omit<ComponentProps<typeof BorrowProgressDrawer>, "onRetry" | "steps">;
 
 export function BorrowDrawer({
-  borrowAmount,
-  borrowToken,
-  collateralAmount,
-  collateralToken,
   flowStatus,
-  marketId,
   onClose,
   onRetry,
   showApproveStep,
+  ...props
 }: Props) {
   const { t } = useTranslation();
   useCloseOnSuccess({ onClose, success: flowStatus === "borrowed" });
@@ -123,11 +112,7 @@ export function BorrowDrawer({
     <Drawer onClose={onClose}>
       <Suspense fallback={<DrawerLoader />}>
         <BorrowProgressDrawer
-          borrowAmount={borrowAmount}
-          borrowToken={borrowToken}
-          collateralAmount={collateralAmount}
-          collateralToken={collateralToken}
-          marketId={marketId}
+          {...props}
           onRetry={isError ? onRetry : undefined}
           steps={steps}
         />

--- a/web/src/components/swapForm/claimRedeemDrawer.tsx
+++ b/web/src/components/swapForm/claimRedeemDrawer.tsx
@@ -1,15 +1,10 @@
 import { Drawer } from "components/base/drawer";
 import { DrawerLoader } from "components/base/drawer/drawerLoader";
 import { type Step, stepStatus } from "components/base/verticalStepper";
-import type { InputError } from "components/tokenInput/utils";
 import { useCloseOnSuccess } from "hooks/useCloseOnSuccess";
-import { type ComponentProps, type ReactNode, Suspense, lazy } from "react";
+import { type ComponentProps, Suspense, lazy } from "react";
 import { useTranslation } from "react-i18next";
-import type { TokenWithGateway } from "types";
-import type { Address } from "viem";
 
-import type { UnitPreview } from "./outputLabel";
-import type { SwapFees } from "./swapFees";
 import { type ClaimRedeemFlowStatus } from "./types";
 
 const ClaimRedeemProgressDrawer = lazy(() =>
@@ -27,56 +22,11 @@ const confirmStepStatuses: Record<ClaimRedeemFlowStatus, Step["status"]> = {
 };
 
 type Props = {
-  amountBigInt: bigint;
-  amountLocked: bigint;
-  flowStatus: ClaimRedeemFlowStatus;
-  fromAmount: string;
-  fromToken: TokenWithGateway;
-  inputError: InputError | undefined;
-  isLoading: boolean;
-  isPreviewError: boolean;
   onClose: VoidFunction;
-  onInputChange: (value: string) => void;
-  onMaxClick: VoidFunction;
-  onSubmit: VoidFunction;
-  onTokenChange: (token: TokenWithGateway) => void;
-  oracleToken: Address;
-  outputBigInt: bigint | undefined;
-  outputValue: string;
-  slippageControl: ReactNode;
-  toToken: TokenWithGateway;
-  unitPreview: UnitPreview;
-  whitelistedTokens: TokenWithGateway[];
-} & Pick<
-  ComponentProps<typeof SwapFees>,
-  "networkFee" | "protocolFee" | "totalFees"
->;
+} & Omit<ComponentProps<typeof ClaimRedeemProgressDrawer>, "onRetry" | "steps">;
 
-export function ClaimRedeemDrawer({
-  amountBigInt,
-  amountLocked,
-  flowStatus,
-  fromAmount,
-  fromToken,
-  inputError,
-  isLoading,
-  isPreviewError,
-  networkFee,
-  onClose,
-  onInputChange,
-  onMaxClick,
-  onSubmit,
-  onTokenChange,
-  oracleToken,
-  outputBigInt,
-  outputValue,
-  protocolFee,
-  slippageControl,
-  totalFees,
-  toToken,
-  unitPreview,
-  whitelistedTokens,
-}: Props) {
+export function ClaimRedeemDrawer({ onClose, ...props }: Props) {
+  const { flowStatus, onSubmit } = props;
   const { t } = useTranslation();
   useCloseOnSuccess({ onClose, success: flowStatus === "redeemed" });
 
@@ -94,30 +44,9 @@ export function ClaimRedeemDrawer({
     <Drawer onClose={onClose}>
       <Suspense fallback={<DrawerLoader />}>
         <ClaimRedeemProgressDrawer
-          amountBigInt={amountBigInt}
-          amountLocked={amountLocked}
-          flowStatus={flowStatus}
-          fromAmount={fromAmount}
-          fromToken={fromToken}
-          inputError={inputError}
-          isLoading={isLoading}
-          isPreviewError={isPreviewError}
-          networkFee={networkFee}
-          onInputChange={onInputChange}
-          onMaxClick={onMaxClick}
+          {...props}
           onRetry={isError ? onSubmit : undefined}
-          onSubmit={onSubmit}
-          onTokenChange={onTokenChange}
-          oracleToken={oracleToken}
-          outputBigInt={outputBigInt}
-          outputValue={outputValue}
-          protocolFee={protocolFee}
-          slippageControl={slippageControl}
           steps={steps}
-          toToken={toToken}
-          totalFees={totalFees}
-          unitPreview={unitPreview}
-          whitelistedTokens={whitelistedTokens}
         />
       </Suspense>
     </Drawer>

--- a/web/src/components/swapForm/swapDepositDrawer.tsx
+++ b/web/src/components/swapForm/swapDepositDrawer.tsx
@@ -70,18 +70,10 @@ type Props = {
 
 export function SwapDepositDrawer({
   flowStatus,
-  fromAmount,
-  fromToken,
-  networkFee,
   onClose,
   onRetry,
-  oracleToken,
-  outputValue,
-  protocolFee,
   showApproveStep,
-  totalFees,
-  toToken,
-  unitPreview,
+  ...props
 }: Props) {
   const { t } = useTranslation();
   useCloseOnSuccess({ onClose, success: flowStatus === "deposited" });
@@ -109,17 +101,9 @@ export function SwapDepositDrawer({
     <Drawer onClose={onClose}>
       <Suspense fallback={<DrawerLoader />}>
         <SwapProgressDrawer
-          fromAmount={fromAmount}
-          fromToken={fromToken}
-          networkFee={networkFee}
+          {...props}
           onRetry={isError ? onRetry : undefined}
-          oracleToken={oracleToken}
-          outputValue={outputValue}
-          protocolFee={protocolFee}
           steps={steps}
-          toToken={toToken}
-          totalFees={totalFees}
-          unitPreview={unitPreview}
         />
       </Suspense>
     </Drawer>

--- a/web/src/components/swapForm/swapRedeemDrawer.tsx
+++ b/web/src/components/swapForm/swapRedeemDrawer.tsx
@@ -70,18 +70,10 @@ type Props = {
 
 export function SwapRedeemDrawer({
   flowStatus,
-  fromAmount,
-  fromToken,
-  networkFee,
   onClose,
   onRetry,
-  oracleToken,
-  outputValue,
-  protocolFee,
   showApproveStep,
-  totalFees,
-  toToken,
-  unitPreview,
+  ...props
 }: Props) {
   const { t } = useTranslation();
   useCloseOnSuccess({ onClose, success: flowStatus === "redeemed" });
@@ -109,17 +101,9 @@ export function SwapRedeemDrawer({
     <Drawer onClose={onClose}>
       <Suspense fallback={<DrawerLoader />}>
         <SwapProgressDrawer
-          fromAmount={fromAmount}
-          fromToken={fromToken}
-          networkFee={networkFee}
+          {...props}
           onRetry={isError ? onRetry : undefined}
-          oracleToken={oracleToken}
-          outputValue={outputValue}
-          protocolFee={protocolFee}
           steps={steps}
-          toToken={toToken}
-          totalFees={totalFees}
-          unitPreview={unitPreview}
         />
       </Suspense>
     </Drawer>

--- a/web/src/components/swapForm/swapRequestRedeemDrawer.tsx
+++ b/web/src/components/swapForm/swapRequestRedeemDrawer.tsx
@@ -65,15 +65,10 @@ type Props = {
 
 export function SwapRequestRedeemDrawer({
   flowStatus,
-  fromAmount,
-  fromToken,
-  networkFee,
   onClose,
   onRetry,
-  protocolFee,
   showApproveStep,
-  subtitle,
-  totalFees,
+  ...props
 }: Props) {
   const { t } = useTranslation();
   useCloseOnSuccess({ onClose, success: flowStatus === "request-redeemed" });
@@ -101,14 +96,9 @@ export function SwapRequestRedeemDrawer({
     <Drawer onClose={onClose}>
       <Suspense fallback={<DrawerLoader />}>
         <SwapProgressDrawer
-          fromAmount={fromAmount}
-          fromToken={fromToken}
-          networkFee={networkFee}
+          {...props}
           onRetry={isError ? onRetry : undefined}
-          protocolFee={protocolFee}
           steps={steps}
-          subtitle={subtitle}
-          totalFees={totalFees}
         />
       </Suspense>
     </Drawer>


### PR DESCRIPTION
### Description

These drawers are thin wrappers: they build `steps`, derive `onRetry`, and hand everything else straight to their progress drawer. Naming each prop three times — in the type, in the destructure, and in the JSX — carried no information, so they now spread the forwarded props instead.

`ClaimRedeemDrawer` and `BorrowDrawer` derive their `Props` from the child via `ComponentProps`, so adding a prop to the progress drawer no longer means touching the wrapper.

No behavior change — this is a pure refactor.

### Screenshots

N/A — no UI changes.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
