### PR TITLE
Minor improvements to the dev fork scripts

### DIFF
--- a/web/scripts/devFork.ts
+++ b/web/scripts/devFork.ts
@@ -3,6 +3,7 @@ import { TEST_ADDRESS } from "@hemilabs/anvil-fork-setup/utils";
 import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
 import { mainnet } from "viem/chains";
 
 import { fundAccount } from "./fundAccount.ts";
@@ -30,9 +31,19 @@ const startViteServer = (forkUrl: string): ChildProcess =>
     stdio: "inherit",
   });
 
+const { values } = parseArgs({
+  options: {
+    "fork-url": { short: "f", type: "string" },
+  },
+  strict: true,
+});
+
 const { stop, url } = await startAnvilFork({
   chainId: mainnet.id,
-  forkUrl: process.env.VITE_RPC_URL_MAINNET ?? mainnet.rpcUrls.default.http[0],
+  forkUrl:
+    values["fork-url"] ??
+    process.env.VITE_RPC_URL_MAINNET ??
+    mainnet.rpcUrls.default.http[0],
 });
 
 // Fund only — scenario state (cooldown, redeem delay, time jumps, …) is

--- a/web/scripts/fastForwardTime.ts
+++ b/web/scripts/fastForwardTime.ts
@@ -48,7 +48,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
 
   if (!values.seconds || !/^\d+$/.test(values.seconds)) {
     console.error(
-      "Seconds is invalid. Usage: node web/scripts/fastForwardTime.ts --seconds 120",
+      "Seconds is invalid. Usage: node web/scripts/fastForwardTime.ts --seconds 120 [--fork-url …]",
     );
     process.exit(1);
   }

--- a/web/scripts/fastForwardTime.ts
+++ b/web/scripts/fastForwardTime.ts
@@ -16,10 +16,10 @@ import { mainnet } from "viem/chains";
  * @returns The fork's new block.timestamp (unix seconds) after the jump.
  */
 export async function fastForwardTime({
-  forkUrl,
+  forkUrl = "http://127.0.0.1:8545",
   seconds,
 }: {
-  forkUrl: string;
+  forkUrl?: string;
   seconds: number;
 }) {
   const testClient = createTestClient({
@@ -36,7 +36,7 @@ export async function fastForwardTime({
 }
 
 // Allow running as a standalone script:
-//   node web/scripts/fastForwardTime.ts --fork-url http://127.0.0.1:8545 --seconds 120
+//   node web/scripts/fastForwardTime.ts --seconds 120 [--fork-url …]
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const { values } = parseArgs({
     options: {
@@ -48,14 +48,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
 
   if (!values.seconds || !/^\d+$/.test(values.seconds)) {
     console.error(
-      "Seconds is invalid. Usage: node web/scripts/fastForwardTime.ts --fork-url http://127.0.0.1:8545 --seconds 120",
-    );
-    process.exit(1);
-  }
-
-  if (!values["fork-url"]) {
-    console.error(
-      "Fork URL is required. Usage: node web/scripts/fastForwardTime.ts --fork-url http://127.0.0.1:8545 --seconds 120",
+      "Seconds is invalid. Usage: node web/scripts/fastForwardTime.ts --seconds 120",
     );
     process.exit(1);
   }
@@ -66,6 +59,6 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   });
 
   console.log(
-    `Fast-forwarded ${values.seconds}s on ${values["fork-url"]} (new block.timestamp: ${timestamp}).`,
+    `Fast-forwarded ${values.seconds}s (new block.timestamp: ${timestamp}).`,
   );
 }


### PR DESCRIPTION
### Description

A few small improvements to the `web/scripts` dev-fork tooling, mostly for consistency between the scripts:

- `devFork.ts` now accepts a `--fork-url` (`-f`) flag to override the RPC it forks from, falling back to `VITE_RPC_URL_MAINNET` and then to the default mainnet RPC, as before.
- `fastForwardTime.ts` keeps `--fork-url` as an option, but it's no longer required: it now defaults to the local anvil endpoint (`http://127.0.0.1:8545`), which is what it's pointed at in practice.

More minor script improvements are likely to follow in subsequent PRs.

### Screenshots

N/A

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
