### PR TITLE
Remove no-op vi.mocked() calls in package tests

### DIFF
--- a/packages/gateway/test/public/getMaxMint.test.ts
+++ b/packages/gateway/test/public/getMaxMint.test.ts
@@ -60,8 +60,6 @@ describe("getMaxMint", function () {
   });
 
   it("should call readContract if all parameters are valid", async function () {
-    vi.mocked(readContract);
-
     await getMaxMint(client, validParameters);
 
     expect(readContract).toHaveBeenCalledWith(client, {

--- a/packages/gateway/test/public/getMaxWithdraw.test.ts
+++ b/packages/gateway/test/public/getMaxWithdraw.test.ts
@@ -100,8 +100,6 @@ describe("getMaxWithdraw", function () {
   });
 
   it("should call readContract if all parameters are valid", async function () {
-    vi.mocked(readContract);
-
     await getMaxWithdraw(client, validParameters);
 
     expect(readContract).toHaveBeenCalledWith(client, {

--- a/packages/gateway/test/public/getRedeemRequest.test.ts
+++ b/packages/gateway/test/public/getRedeemRequest.test.ts
@@ -96,8 +96,6 @@ describe("getRedeemRequest", function () {
   });
 
   it("should call readContract if parameters are valid", async function () {
-    vi.mocked(readContract);
-
     await getRedeemRequest(client, validParameters);
 
     expect(readContract).toHaveBeenCalledWith(client, {

--- a/packages/gateway/test/public/getTreasury.test.ts
+++ b/packages/gateway/test/public/getTreasury.test.ts
@@ -60,8 +60,6 @@ describe("getTreasury", function () {
   });
 
   it("should call readContract if all parameters are valid", async function () {
-    vi.mocked(readContract);
-
     await getTreasury(client, validParameters);
 
     expect(readContract).toHaveBeenCalledWith(client, {

--- a/packages/gateway/test/public/getWithdrawalDelay.test.ts
+++ b/packages/gateway/test/public/getWithdrawalDelay.test.ts
@@ -60,8 +60,6 @@ describe("getWithdrawalDelay", function () {
   });
 
   it("should call readContract if all parameters are valid", async function () {
-    vi.mocked(readContract);
-
     await getWithdrawalDelay(client, validParameters);
 
     expect(readContract).toHaveBeenCalledWith(client, {

--- a/packages/gateway/test/public/getWithdrawalDelayEnabled.test.ts
+++ b/packages/gateway/test/public/getWithdrawalDelayEnabled.test.ts
@@ -60,8 +60,6 @@ describe("getWithdrawalDelayEnabled", function () {
   });
 
   it("should call readContract if parameters are valid", async function () {
-    vi.mocked(readContract);
-
     await getWithdrawalDelayEnabled(client, validParameters);
 
     expect(readContract).toHaveBeenCalledWith(client, {

--- a/packages/gateway/test/public/isInstantRedeemWhitelisted.test.ts
+++ b/packages/gateway/test/public/isInstantRedeemWhitelisted.test.ts
@@ -96,8 +96,6 @@ describe("isInstantRedeemWhitelisted", function () {
   });
 
   it("should call readContract if parameters are valid", async function () {
-    vi.mocked(readContract);
-
     await isInstantRedeemWhitelisted(client, validParameters);
 
     expect(readContract).toHaveBeenCalledWith(client, {

--- a/packages/treasury/test/public/getPrice.test.ts
+++ b/packages/treasury/test/public/getPrice.test.ts
@@ -76,8 +76,6 @@ describe("getPrice", function () {
   });
 
   it("should call readContract if all parameters are valid", async function () {
-    vi.mocked(readContract);
-
     await getPrice(client, validParameters);
 
     expect(readContract).toHaveBeenCalledWith(client, {

--- a/packages/treasury/test/public/getTokenConfig.test.ts
+++ b/packages/treasury/test/public/getTokenConfig.test.ts
@@ -76,8 +76,6 @@ describe("getTokenConfig", function () {
   });
 
   it("should call readContract if all parameters are valid", async function () {
-    vi.mocked(readContract);
-
     await getTokenConfig(client, validParameters);
 
     expect(readContract).toHaveBeenCalledWith(client, {

--- a/packages/treasury/test/public/getWhitelistedTokens.test.ts
+++ b/packages/treasury/test/public/getWhitelistedTokens.test.ts
@@ -60,8 +60,6 @@ describe("getWhitelistedTokens", function () {
   });
 
   it("should call readContract if all parameters are valid", async function () {
-    vi.mocked(readContract);
-
     await getWhitelistedTokens(client, validParameters);
 
     expect(readContract).toHaveBeenCalledWith(client, {

--- a/packages/treasury/test/public/getWithdrawable.test.ts
+++ b/packages/treasury/test/public/getWithdrawable.test.ts
@@ -76,8 +76,6 @@ describe("getWithdrawable", function () {
   });
 
   it("should call readContract if all parameters are valid", async function () {
-    vi.mocked(readContract);
-
     await getWithdrawable(client, validParameters);
 
     expect(readContract).toHaveBeenCalledWith(client, {


### PR DESCRIPTION
### Description

`vi.mocked()` is a type helper — it only does its work through the value it returns. Called on its own, without chaining `.mockReturnValue()` or similar, it is a pure no-op. Eleven test files had such a standalone line sitting at the top of their "should call readContract" test, where it did nothing at all.

Issue #669 named two gateway tests. A repo-wide sweep turned up the same line in eleven files — seven in `gateway`, four in `treasury` — and all of them are removed here.

The tests pass unchanged: `readContract` is already mocked with `vi.fn()` at the top of each file, and each of these tests only asserts on the call arguments, never on a resolved value. Nothing else in the files was touched, and no imports were orphaned (`vi` and `readContract` are both still used everywhere).

**Files (2 deleted lines each — the call plus its trailing blank line):**

- `gateway`: `getMaxMint`, `getMaxWithdraw`, `getRedeemRequest`, `getTreasury`, `getWithdrawalDelay`, `getWithdrawalDelayEnabled`, `isInstantRedeemWhitelisted`
- `treasury`: `getPrice`, `getTokenConfig`, `getWhitelistedTokens`, `getWithdrawable`

### Screenshots

N/A — no UI changes.

### Related issue(s)

Closes #669

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
