### PR TITLE
Throw when a fork setup transaction reverts

### DIFF
--- a/web/scripts/redeemDelay.ts
+++ b/web/scripts/redeemDelay.ts
@@ -13,13 +13,14 @@ import {
   readContract,
   setBalance,
   stopImpersonatingAccount,
-  waitForTransactionReceipt,
   writeContract,
 } from "viem/actions";
 import { mainnet } from "viem/chains";
 
 import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
 import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts";
+
+import { confirmTransaction } from "./utils.ts";
 
 const WITHDRAWAL_DELAY_SECONDS = 72n;
 
@@ -72,7 +73,7 @@ export async function setRedeemDelay({
           args: [true],
           functionName: "setWithdrawalDelayEnabled",
         });
-        await waitForTransactionReceipt(publicClient, { hash });
+        await confirmTransaction({ client: publicClient, hash });
       }
 
       const [, isWhitelisted] = await Promise.all([
@@ -82,7 +83,7 @@ export async function setRedeemDelay({
           address: gateway,
           args: [WITHDRAWAL_DELAY_SECONDS],
           functionName: "updateWithdrawalDelay",
-        }).then((hash) => waitForTransactionReceipt(publicClient, { hash })),
+        }).then((hash) => confirmTransaction({ client: publicClient, hash })),
         readContract(publicClient, {
           abi: gatewayAbi,
           address: gateway,
@@ -99,7 +100,7 @@ export async function setRedeemDelay({
           args: [address],
           functionName: "removeFromInstantRedeemWhitelist",
         });
-        await waitForTransactionReceipt(publicClient, { hash });
+        await confirmTransaction({ client: publicClient, hash });
       }
     } else if (delayEnabledBefore) {
       const hash = await writeContract(testClient, {
@@ -109,7 +110,7 @@ export async function setRedeemDelay({
         args: [false],
         functionName: "setWithdrawalDelayEnabled",
       });
-      await waitForTransactionReceipt(publicClient, { hash });
+      await confirmTransaction({ client: publicClient, hash });
     }
 
     const [delayEnabledAfter, delay] = await Promise.all([

--- a/web/scripts/redeemDelay.ts
+++ b/web/scripts/redeemDelay.ts
@@ -6,7 +6,9 @@ import {
   createTestClient,
   http,
   isAddress,
+  keccak256,
   parseEther,
+  stringToBytes,
 } from "viem";
 import {
   impersonateAccount,
@@ -23,6 +25,31 @@ import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts
 import { confirmTransaction } from "./utils.ts";
 
 const WITHDRAWAL_DELAY_SECONDS = 72n;
+
+const MAINTAINER_ROLE = keccak256(stringToBytes("MAINTAINER_ROLE"));
+
+const accessControlAbi = [
+  {
+    inputs: [
+      { name: "role", type: "bytes32" },
+      { name: "account", type: "address" },
+    ],
+    name: "grantRole",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { name: "role", type: "bytes32" },
+      { name: "account", type: "address" },
+    ],
+    name: "hasRole",
+    outputs: [{ type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
 
 // Enable or disable the gateway's withdrawal delay by impersonating its owner.
 // When enabling, also remove the address from the instant-redeem whitelist so it
@@ -47,11 +74,16 @@ export async function setRedeemDelay({
     transport,
   });
 
-  const [owner, delayEnabledBefore] = await Promise.all([
+  const [owner, treasury, delayEnabledBefore] = await Promise.all([
     readContract(publicClient, {
       abi: gatewayAbi,
       address: gateway,
       functionName: "owner",
+    }),
+    readContract(publicClient, {
+      abi: gatewayAbi,
+      address: gateway,
+      functionName: "treasury",
     }),
     readContract(publicClient, {
       abi: gatewayAbi,
@@ -64,6 +96,24 @@ export async function setRedeemDelay({
   await setBalance(testClient, { address: owner, value: parseEther("1") });
 
   try {
+    const ownerHasRole = await readContract(publicClient, {
+      abi: accessControlAbi,
+      address: treasury,
+      args: [MAINTAINER_ROLE, owner],
+      functionName: "hasRole",
+    });
+
+    if (!ownerHasRole) {
+      const grantHash = await writeContract(testClient, {
+        abi: accessControlAbi,
+        account: owner,
+        address: treasury,
+        args: [MAINTAINER_ROLE, owner],
+        functionName: "grantRole",
+      });
+      await confirmTransaction({ client: publicClient, hash: grantHash });
+    }
+
     if (enableDelay) {
       if (!delayEnabledBefore) {
         const hash = await writeContract(testClient, {

--- a/web/scripts/requestRedeem.ts
+++ b/web/scripts/requestRedeem.ts
@@ -12,7 +12,6 @@ import {
   impersonateAccount,
   readContract,
   stopImpersonatingAccount,
-  waitForTransactionReceipt,
   writeContract,
 } from "viem/actions";
 import { mainnet } from "viem/chains";
@@ -20,6 +19,8 @@ import { approve, decimals } from "viem-erc20/actions";
 
 import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
 import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts";
+
+import { confirmTransaction } from "./utils.ts";
 
 // Send `peggedTokenAmount` to the gateway's redeem queue on behalf of `address`
 // by impersonating it, so a queued redeem can be set up without driving the
@@ -60,7 +61,7 @@ export async function requestRedeem({
       amount: peggedTokenAmount,
       spender: gateway,
     });
-    await waitForTransactionReceipt(publicClient, { hash: approveHash });
+    await confirmTransaction({ client: publicClient, hash: approveHash });
 
     const requestHash = await writeContract(testClient, {
       abi: gatewayAbi,
@@ -68,7 +69,7 @@ export async function requestRedeem({
       args: [peggedTokenAmount],
       functionName: "requestRedeem",
     });
-    await waitForTransactionReceipt(publicClient, { hash: requestHash });
+    await confirmTransaction({ client: publicClient, hash: requestHash });
   } finally {
     await stopImpersonatingAccount(testClient, { address });
   }

--- a/web/scripts/setCooldownEnabled.ts
+++ b/web/scripts/setCooldownEnabled.ts
@@ -13,13 +13,14 @@ import {
   readContract,
   setBalance,
   stopImpersonatingAccount,
-  waitForTransactionReceipt,
   writeContract,
 } from "viem/actions";
 import { mainnet } from "viem/chains";
 
 import { stakingVaultAbi } from "../../packages/earn/src/abi/stakingVaultAbi.ts";
 import { sVusdAddress } from "../../packages/earn/src/stakingVaultAddresses.ts";
+
+import { confirmTransaction } from "./utils.ts";
 
 // The StakingVault is Ownable2Step, so its owner-only setters can be called
 // directly after impersonating owner() — no role grant needed (see
@@ -60,7 +61,7 @@ export async function setCooldownEnabled({
       args: [true],
       functionName: "updateCooldownEnabled",
     });
-    await waitForTransactionReceipt(publicClient, { hash: enableHash });
+    await confirmTransaction({ client: publicClient, hash: enableHash });
   } finally {
     await stopImpersonatingAccount(testClient, { address: owner });
   }

--- a/web/scripts/setMaxMint.ts
+++ b/web/scripts/setMaxMint.ts
@@ -14,7 +14,6 @@ import {
   readContract,
   setBalance,
   stopImpersonatingAccount,
-  waitForTransactionReceipt,
   writeContract,
 } from "viem/actions";
 import { mainnet } from "viem/chains";
@@ -22,6 +21,8 @@ import { decimals } from "viem-erc20/actions";
 
 import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
 import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts";
+
+import { confirmTransaction } from "./utils.ts";
 
 export async function setMaxMint({
   forkUrl,
@@ -73,7 +74,7 @@ export async function setMaxMint({
       args: [mintLimitAfter],
       functionName: "updateMintLimit",
     });
-    await waitForTransactionReceipt(publicClient, { hash });
+    await confirmTransaction({ client: publicClient, hash });
 
     const maxMintAfter = await readContract(publicClient, {
       abi: gatewayAbi,

--- a/web/scripts/tokenActive.ts
+++ b/web/scripts/tokenActive.ts
@@ -14,7 +14,6 @@ import {
   readContract,
   setBalance,
   stopImpersonatingAccount,
-  waitForTransactionReceipt,
   writeContract,
 } from "viem/actions";
 import { mainnet } from "viem/chains";
@@ -22,6 +21,8 @@ import { mainnet } from "viem/chains";
 import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
 import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts";
 import { treasuryAbi } from "../../packages/treasury/src/abi/treasuryAbi.ts";
+
+import { confirmTransaction } from "./utils.ts";
 
 const KEEPER_ROLE = keccak256(stringToBytes("KEEPER_ROLE"));
 
@@ -149,7 +150,7 @@ export async function setTokenActive({
         args: [KEEPER_ROLE, owner],
         functionName: "grantRole",
       });
-      await waitForTransactionReceipt(publicClient, { hash: grantHash });
+      await confirmTransaction({ client: publicClient, hash: grantHash });
     }
 
     const hash = await writeContract(testClient, {
@@ -159,7 +160,7 @@ export async function setTokenActive({
       args: [token, active],
       functionName: setterNames[flag],
     });
-    await waitForTransactionReceipt(publicClient, { hash });
+    await confirmTransaction({ client: publicClient, hash });
   } finally {
     await stopImpersonatingAccount(testClient, { address: owner });
   }

--- a/web/scripts/updateMintFee.ts
+++ b/web/scripts/updateMintFee.ts
@@ -13,13 +13,14 @@ import {
   impersonateAccount,
   readContract,
   setBalance,
-  waitForTransactionReceipt,
   writeContract,
 } from "viem/actions";
 import { mainnet } from "viem/chains";
 
 import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
 import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts";
+
+import { confirmTransaction } from "./utils.ts";
 
 const grantRoleAbi = [
   {
@@ -101,7 +102,7 @@ const grantRoleHash = await writeContract(testClient, {
   functionName: "grantRole",
 });
 
-await waitForTransactionReceipt(publicClient, { hash: grantRoleHash });
+await confirmTransaction({ client: publicClient, hash: grantRoleHash });
 
 console.log(`Admin: ${admin}`);
 console.log(`Gateway: ${gateway}`);
@@ -127,7 +128,7 @@ const hash = await writeContract(testClient, {
 
 console.log(`Transaction hash: ${hash}`);
 
-const receipt = await waitForTransactionReceipt(publicClient, { hash });
+const receipt = await confirmTransaction({ client: publicClient, hash });
 
 console.log(`Transaction confirmed in block ${receipt.blockNumber}`);
 console.log(`Mint fee updated: ${currentFee} -> ${fee} BPS`);

--- a/web/scripts/updateRedeemFee.ts
+++ b/web/scripts/updateRedeemFee.ts
@@ -13,13 +13,14 @@ import {
   impersonateAccount,
   readContract,
   setBalance,
-  waitForTransactionReceipt,
   writeContract,
 } from "viem/actions";
 import { mainnet } from "viem/chains";
 
 import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
 import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts";
+
+import { confirmTransaction } from "./utils.ts";
 
 const grantRoleAbi = [
   {
@@ -101,7 +102,7 @@ const grantRoleHash = await writeContract(testClient, {
   functionName: "grantRole",
 });
 
-await waitForTransactionReceipt(publicClient, { hash: grantRoleHash });
+await confirmTransaction({ client: publicClient, hash: grantRoleHash });
 
 console.log(`Admin: ${admin}`);
 console.log(`Gateway: ${gateway}`);
@@ -127,7 +128,7 @@ const hash = await writeContract(testClient, {
 
 console.log(`Transaction hash: ${hash}`);
 
-const receipt = await waitForTransactionReceipt(publicClient, { hash });
+const receipt = await confirmTransaction({ client: publicClient, hash });
 
 console.log(`Transaction confirmed in block ${receipt.blockNumber}`);
 console.log(`Redeem fee updated: ${currentFee} -> ${fee} BPS`);

--- a/web/scripts/utils.ts
+++ b/web/scripts/utils.ts
@@ -1,0 +1,18 @@
+import type { Client, Hash } from "viem";
+import { waitForTransactionReceipt } from "viem/actions";
+
+export async function confirmTransaction({
+  client,
+  hash,
+}: {
+  client: Client;
+  hash: Hash;
+}) {
+  const receipt = await waitForTransactionReceipt(client, { hash });
+
+  if (receipt.status !== "success") {
+    throw new Error(`Transaction ${hash} reverted`);
+  }
+
+  return receipt;
+}

--- a/web/scripts/whitelistInstantRedeem.ts
+++ b/web/scripts/whitelistInstantRedeem.ts
@@ -15,13 +15,14 @@ import {
   readContract,
   setBalance,
   stopImpersonatingAccount,
-  waitForTransactionReceipt,
   writeContract,
 } from "viem/actions";
 import { mainnet } from "viem/chains";
 
 import { gatewayAbi } from "../../packages/gateway/src/abi/gatewayAbi.ts";
 import { gatewayAddresses } from "../../packages/gateway/src/gatewayAddresses.ts";
+
+import { confirmTransaction } from "./utils.ts";
 
 // Whitelisting for instant redeem is `onlyRole(MAINTAINER_ROLE)`, and the
 // gateway delegates role checks to its Treasury (`Treasury.hasRole`). The
@@ -114,7 +115,7 @@ export async function whitelistInstantRedeem({
         args: [MAINTAINER_ROLE, owner],
         functionName: "grantRole",
       });
-      await waitForTransactionReceipt(publicClient, { hash: grantHash });
+      await confirmTransaction({ client: publicClient, hash: grantHash });
     }
 
     const whitelistHash = await writeContract(testClient, {
@@ -124,7 +125,7 @@ export async function whitelistInstantRedeem({
       args: [address],
       functionName: "addToInstantRedeemWhitelist",
     });
-    await waitForTransactionReceipt(publicClient, { hash: whitelistHash });
+    await confirmTransaction({ client: publicClient, hash: whitelistHash });
   } finally {
     await stopImpersonatingAccount(testClient, { address: owner });
   }

--- a/web/scripts/whitelistInstantWithdraw.ts
+++ b/web/scripts/whitelistInstantWithdraw.ts
@@ -13,13 +13,14 @@ import {
   readContract,
   setBalance,
   stopImpersonatingAccount,
-  waitForTransactionReceipt,
   writeContract,
 } from "viem/actions";
 import { mainnet } from "viem/chains";
 
 import { stakingVaultAbi } from "../../packages/earn/src/abi/stakingVaultAbi.ts";
 import { sVusdAddress } from "../../packages/earn/src/stakingVaultAddresses.ts";
+
+import { confirmTransaction } from "./utils.ts";
 
 // The StakingVault is Ownable2Step, so its owner-only setters can be called
 // directly after impersonating owner() — no role grant needed (unlike the
@@ -71,7 +72,7 @@ export async function whitelistInstantWithdraw({
       args: [true],
       functionName: "updateCooldownEnabled",
     });
-    await waitForTransactionReceipt(publicClient, { hash: enableHash });
+    await confirmTransaction({ client: publicClient, hash: enableHash });
 
     if (isWhitelisted) {
       console.log(`${address} is already whitelisted for instant withdraw.`);
@@ -83,7 +84,7 @@ export async function whitelistInstantWithdraw({
         args: [address, true],
         functionName: "updateInstantWithdrawWhitelist",
       });
-      await waitForTransactionReceipt(publicClient, { hash: whitelistHash });
+      await confirmTransaction({ client: publicClient, hash: whitelistHash });
     }
   } finally {
     await stopImpersonatingAccount(testClient, { address: owner });


### PR DESCRIPTION
### Description

Small improvement to the `web/scripts/` folder, following up #672.

The scripts that drive the local Anvil fork waited for transaction receipts but never checked `receipt.status`, so a reverted transaction was indistinguishable from a successful one — a couple of them even print a success line right afterwards.

In practice most reverts already surface at send time through anvil's gas estimation, but that's a property of the node rather than of these scripts. It matters because `web/e2e/*.spec.ts` imports several of them as fixtures: a silently reverted setup transaction shows up later as a confusing UI assertion instead of a failed setup step.

This adds a `confirmTransaction` helper in `web/scripts/utils.ts` that throws on a non-success receipt, and routes all 18 call sites across 9 scripts through it. No behavior change while everything succeeds.

### Screenshots

N/A — no UI changes.

### Related issue(s)

No related issue — small follow-up to #672.

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
