### PR TITLE
Reorder analytics pallete color list

### DIFF
--- a/web/src/pages/analytics/utils.ts
+++ b/web/src/pages/analytics/utils.ts
@@ -8,8 +8,8 @@ import type { AllocationItem, TreasuryToken } from "./types";
 type Prices = Record<string, string>;
 
 const colorPalette = [
-  "bg-blue-400",
   "bg-emerald-400",
+  "bg-blue-400",
   "bg-amber-400",
   "bg-rose-400",
   "bg-purple-400",

--- a/web/test/pages/analytics/utils.test.ts
+++ b/web/test/pages/analytics/utils.test.ts
@@ -50,12 +50,12 @@ const usdcToken = {
 describe("pages/analytics/utils", function () {
   describe("assignColor", function () {
     it("returns the color at the given index", function () {
-      expect(assignColor(0)).toBe("bg-blue-400");
-      expect(assignColor(1)).toBe("bg-emerald-400");
+      expect(assignColor(0)).toBe("bg-emerald-400");
+      expect(assignColor(1)).toBe("bg-blue-400");
     });
 
     it("wraps around when index exceeds palette length", function () {
-      expect(assignColor(8)).toBe("bg-blue-400");
+      expect(assignColor(8)).toBe("bg-emerald-400");
     });
   });
 


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

The color palette was a list of colors defined by us. IT happened to match (loosely) the USDT and USDC brand kits, but reverted. As the gateway contract always returns USDT first, by reverting this order we can ensure the colors match the token guidelines 😆 

### Screenshots

Before:

https://github.com/user-attachments/assets/0de49085-16dd-4c80-9536-99f960fa062c

Now:

https://github.com/user-attachments/assets/d2ab2394-74a1-49d3-a9b0-d958f3ba865b

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [ ] Automated tests added, or N/A.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.
