### PR TITLE
Replace isValidUrl with native URL.canParse

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     env: {
       // Swap/redeem is fully on-chain; the portal API only supplies USD display
       // values. Disable it so e2e stays hermetic (prices render as $0, which
-      // these tests don't assert on). isValidUrl("") is false → query disabled.
+      // these tests don't assert on). URL.canParse("") is false → query disabled.
       VITE_PORTAL_API_URL: "",
       VITE_RPC_URL_MAINNET: ANVIL_URL,
       // The Vetro API is enabled with a fake localhost URL

--- a/web/src/hooks/borrow/useAprHistory.ts
+++ b/web/src/hooks/borrow/useAprHistory.ts
@@ -1,7 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
 import type { ChartPeriod } from "utils/chartPeriods";
-import { isValidUrl } from "utils/url";
 import type { Hash } from "viem";
 
 export type AprHistoryEntry = {
@@ -13,7 +12,7 @@ const apiUrl = import.meta.env.VITE_VETRO_API_URL;
 
 export const useAprHistory = (marketId: Hash, period: ChartPeriod) =>
   useQuery({
-    enabled: apiUrl !== undefined && isValidUrl(apiUrl),
+    enabled: apiUrl !== undefined && URL.canParse(apiUrl),
     queryFn: () =>
       fetch(`${apiUrl}/borrow/${marketId}/apr-history/${period}`).then(
         (data: AprHistoryEntry[]) =>

--- a/web/src/hooks/borrow/useMarketCollateral.ts
+++ b/web/src/hooks/borrow/useMarketCollateral.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
-import { isValidUrl } from "utils/url";
 import type { Hash } from "viem";
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
@@ -12,7 +11,7 @@ export const marketCollateralQueryKey = (marketId: Hash) => [
 
 export const useMarketCollateral = (marketId: Hash) =>
   useQuery({
-    enabled: apiUrl !== undefined && isValidUrl(apiUrl),
+    enabled: apiUrl !== undefined && URL.canParse(apiUrl),
     queryFn: () =>
       fetch(`${apiUrl}/borrow/${marketId}/collateral-assets`).then(
         ({ collateralAssets }: { collateralAssets: number }) =>

--- a/web/src/hooks/useAnalyticsStaked.ts
+++ b/web/src/hooks/useAnalyticsStaked.ts
@@ -1,6 +1,5 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
-import { isValidUrl } from "utils/url";
 import type { Address } from "viem";
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
@@ -18,7 +17,7 @@ const analyticsStakedOptions = (gatewayAddress: Address | undefined) =>
   queryOptions({
     enabled:
       apiUrl !== undefined &&
-      isValidUrl(apiUrl) &&
+      URL.canParse(apiUrl) &&
       gatewayAddress !== undefined,
     queryFn: () =>
       (

--- a/web/src/hooks/useAnalyticsTreasury.ts
+++ b/web/src/hooks/useAnalyticsTreasury.ts
@@ -1,7 +1,6 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
 import type { TreasuryToken } from "pages/analytics/types";
-import { isValidUrl } from "utils/url";
 import type { Address } from "viem";
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
@@ -18,7 +17,7 @@ const analyticsTreasuryOptions = ({
   queryOptions({
     enabled:
       apiUrl !== undefined &&
-      isValidUrl(apiUrl) &&
+      URL.canParse(apiUrl) &&
       gatewayAddress !== undefined,
     queryFn: () =>
       fetch(`${apiUrl}/analytics/treasury/${gatewayAddress}`) as Promise<

--- a/web/src/hooks/useAnalyticsTvl.ts
+++ b/web/src/hooks/useAnalyticsTvl.ts
@@ -1,6 +1,5 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
-import { isValidUrl } from "utils/url";
 import type { Address } from "viem";
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
@@ -18,7 +17,7 @@ const analyticsTvlOptions = (gatewayAddress: Address | undefined) =>
   queryOptions({
     enabled:
       apiUrl !== undefined &&
-      isValidUrl(apiUrl) &&
+      URL.canParse(apiUrl) &&
       gatewayAddress !== undefined,
     queryFn: () =>
       (

--- a/web/src/hooks/useApy.ts
+++ b/web/src/hooks/useApy.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
-import { isValidUrl } from "utils/url";
 import type { Address } from "viem";
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
@@ -9,7 +8,7 @@ type ApyResponse = Partial<Record<Address, { apy: number }>>;
 
 export const useApy = (stakingVaultAddress: Address) =>
   useQuery({
-    enabled: apiUrl !== undefined && isValidUrl(apiUrl),
+    enabled: apiUrl !== undefined && URL.canParse(apiUrl),
     queryFn: () =>
       fetch(`${apiUrl}/variable-stake/apy`) as Promise<ApyResponse>,
     queryKey: ["variable-stake-apy"],

--- a/web/src/hooks/useApyHistory.ts
+++ b/web/src/hooks/useApyHistory.ts
@@ -4,7 +4,6 @@ import { useEthereumClient } from "hooks/useEthereumClient";
 import { stakingVaultForPeggedTokenOptions } from "hooks/useStakingVaultForPeggedToken";
 import type { TokenWithGateway } from "types";
 import type { ChartPeriod } from "utils/chartPeriods";
-import { isValidUrl } from "utils/url";
 import type { Client } from "viem";
 
 type ApiEntry = { apy: number; timestamp: number };
@@ -22,7 +21,7 @@ const apyHistoryOptions = ({
 }) =>
   queryOptions({
     enabled:
-      !!client && !!peggedToken && apiUrl !== undefined && isValidUrl(apiUrl),
+      !!client && !!peggedToken && apiUrl !== undefined && URL.canParse(apiUrl),
     async queryFn({ client: queryClient }) {
       const stakingVaultAddress = await queryClient.ensureQueryData(
         stakingVaultForPeggedTokenOptions({

--- a/web/src/hooks/useCollateralizationRatio.ts
+++ b/web/src/hooks/useCollateralizationRatio.ts
@@ -1,6 +1,5 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
-import { isValidUrl } from "utils/url";
 import type { Address } from "viem";
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
@@ -18,7 +17,7 @@ const collateralizationRatioOptions = (gatewayAddress: Address | undefined) =>
   queryOptions({
     enabled:
       apiUrl !== undefined &&
-      isValidUrl(apiUrl) &&
+      URL.canParse(apiUrl) &&
       gatewayAddress !== undefined,
     queryFn: () =>
       fetch(

--- a/web/src/hooks/useCostBasis.ts
+++ b/web/src/hooks/useCostBasis.ts
@@ -1,6 +1,5 @@
 import { queryOptions } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
-import { isValidUrl } from "utils/url";
 import type { Address } from "viem";
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
@@ -17,7 +16,7 @@ export const costBasisQueryOptions = ({
 }) =>
   queryOptions({
     enabled:
-      apiUrl !== undefined && isValidUrl(apiUrl) && address !== undefined,
+      apiUrl !== undefined && URL.canParse(apiUrl) && address !== undefined,
     async queryFn() {
       const data = (await fetch(
         `${apiUrl}/variable-stake/cost-basis/${address}`,

--- a/web/src/hooks/useEarnedAmountUsd.ts
+++ b/web/src/hooks/useEarnedAmountUsd.ts
@@ -2,7 +2,6 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { fetchEarnedAmountUsd } from "fetchers/fetchEarnedAmountUsd";
 import { useEthereumClient } from "hooks/useEthereumClient";
-import { isValidUrl } from "utils/url";
 import type { Address } from "viem";
 import { useAccount } from "wagmi";
 
@@ -23,7 +22,7 @@ export function useEarnedAmountUsd() {
 
   return useQuery({
     enabled:
-      apiUrl !== undefined && isValidUrl(apiUrl) && !!client && !!account,
+      apiUrl !== undefined && URL.canParse(apiUrl) && !!client && !!account,
     queryFn: () =>
       fetchEarnedAmountUsd({
         account: account!,

--- a/web/src/hooks/useShareValueHistory.ts
+++ b/web/src/hooks/useShareValueHistory.ts
@@ -4,7 +4,6 @@ import { useEthereumClient } from "hooks/useEthereumClient";
 import { stakingVaultForPeggedTokenOptions } from "hooks/useStakingVaultForPeggedToken";
 import type { TokenWithGateway } from "types";
 import type { ChartPeriod } from "utils/chartPeriods";
-import { isValidUrl } from "utils/url";
 
 type ApiEntry = { shareValue: number; timestamp: number };
 
@@ -21,7 +20,7 @@ export const useShareValueHistory = function ({
   const queryClient = useQueryClient();
   return useQuery({
     enabled:
-      !!client && !!peggedToken && apiUrl !== undefined && isValidUrl(apiUrl),
+      !!client && !!peggedToken && apiUrl !== undefined && URL.canParse(apiUrl),
     async queryFn() {
       const stakingVaultAddress = await queryClient.ensureQueryData(
         stakingVaultForPeggedTokenOptions({

--- a/web/src/hooks/useSubmitContactForm.ts
+++ b/web/src/hooks/useSubmitContactForm.ts
@@ -1,6 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
-import { isValidUrl } from "utils/url";
 
 type ContactFormValues = {
   // Optional screenshots; sent as multipart file parts.
@@ -20,7 +19,7 @@ export const useSubmitContactForm = () =>
     // `undefined`) on success, and throws on any non-2xx so the form surfaces
     // its error toast.
     mutationFn({ attachments = [], category, email, message, token }) {
-      if (apiUrl === undefined || !isValidUrl(apiUrl)) {
+      if (apiUrl === undefined || !URL.canParse(apiUrl)) {
         throw new Error("VITE_VETRO_API_URL is not configured");
       }
       const body = new FormData();

--- a/web/src/hooks/useTokenPrices.ts
+++ b/web/src/hooks/useTokenPrices.ts
@@ -4,7 +4,6 @@ import {
   useQuery,
 } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
-import { isValidUrl } from "utils/url";
 
 const apiUrl = import.meta.env.VITE_PORTAL_API_URL;
 
@@ -21,7 +20,7 @@ export const tokenPricesOptions = <TSelect = Prices>(
   options: QueryOptions<TSelect> = {} as QueryOptions<TSelect>,
 ) =>
   queryOptions({
-    enabled: apiUrl !== undefined && isValidUrl(apiUrl),
+    enabled: apiUrl !== undefined && URL.canParse(apiUrl),
     queryFn: () =>
       fetch(`${apiUrl}/prices`).then(({ prices }) => prices as Prices),
     queryKey: tokenPricesQueryKey(),

--- a/web/src/hooks/useVariableStakeExitQueue.ts
+++ b/web/src/hooks/useVariableStakeExitQueue.ts
@@ -1,7 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
 import { useMainnet } from "hooks/useMainnet";
-import { isValidUrl } from "utils/url";
 import type { Address } from "viem";
 
 const apiUrl = import.meta.env.VITE_VETRO_API_URL;
@@ -17,7 +16,7 @@ export function useVariableStakeExitQueue(gatewayAddress: Address | undefined) {
   return useQuery({
     enabled:
       apiUrl !== undefined &&
-      isValidUrl(apiUrl) &&
+      URL.canParse(apiUrl) &&
       gatewayAddress !== undefined,
     async queryFn() {
       const { assets, openTickets } = await (fetch(

--- a/web/src/networks/updateRpcUrls.ts
+++ b/web/src/networks/updateRpcUrls.ts
@@ -1,11 +1,10 @@
-import { isValidUrl } from "utils/url";
 import { type Chain, defineChain } from "viem";
 
 export const updateRpcUrls = function (chain: Chain, rpcUrlEnv?: string) {
   if (typeof rpcUrlEnv !== "string") {
     return chain;
   }
-  const urls = rpcUrlEnv.split("+").filter(isValidUrl);
+  const urls = rpcUrlEnv.split("+").filter((url) => URL.canParse(url));
   if (urls.length > 0) {
     return defineChain({
       ...chain,

--- a/web/src/pages/earn/hooks/useExitTickets.ts
+++ b/web/src/pages/earn/hooks/useExitTickets.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import fetch from "fetch-plus-plus";
-import { isValidUrl } from "utils/url";
 import { useAccount } from "wagmi";
 
 import type { ExitTicket } from "../types";
@@ -15,7 +14,7 @@ export function useExitTickets() {
 
   return useQuery({
     enabled:
-      apiUrl !== undefined && isValidUrl(apiUrl) && address !== undefined,
+      apiUrl !== undefined && URL.canParse(apiUrl) && address !== undefined,
     queryFn: () =>
       fetch(`${apiUrl}/variable-stake/exit-tickets/${address}`) as Promise<
         ExitTicket[]

--- a/web/src/utils/url.ts
+++ b/web/src/utils/url.ts
@@ -7,12 +7,3 @@ export function getUrlOrigin(url: string | undefined): string | null {
     return null;
   }
 }
-
-export function isValidUrl(url: string) {
-  try {
-    new URL(url);
-    return true;
-  } catch {
-    return false;
-  }
-}

--- a/web/test/utils/url.test.ts
+++ b/web/test/utils/url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isRelativeUrl, isValidUrl } from "../../src/utils/url";
+import { isRelativeUrl } from "../../src/utils/url";
 
 describe("isRelativeUrl", function () {
   it("should return true for relative URLs starting with /", function () {
@@ -9,31 +9,5 @@ describe("isRelativeUrl", function () {
 
   it("should return false for absolute URLs", function () {
     expect(isRelativeUrl("https://example.com/path")).toBe(false);
-  });
-});
-
-describe("isValidUrl", function () {
-  it("should return true for valid https URL", function () {
-    expect(isValidUrl("https://example.com")).toBe(true);
-  });
-
-  it("should return true for valid http URL", function () {
-    expect(isValidUrl("http://localhost:3000")).toBe(true);
-  });
-
-  it("should return true for URL with path", function () {
-    expect(isValidUrl("https://api.example.com/v1/endpoint")).toBe(true);
-  });
-
-  it("should return false for invalid URL", function () {
-    expect(isValidUrl("not-a-url")).toBe(false);
-  });
-
-  it("should return false for empty string", function () {
-    expect(isValidUrl("")).toBe(false);
-  });
-
-  it("should return false for relative path", function () {
-    expect(isValidUrl("/api/endpoint")).toBe(false);
   });
 });


### PR DESCRIPTION
### Description

Came across `URL.canParse()` and realized it does exactly what our custom `isValidUrl` helper in `web/src/utils/url.ts` did — a `try { new URL(x) } catch` wrapper — so there's no reason to keep our own version. This drops the helper and calls the native static method at the 16 call sites instead.

The `isValidUrl` unit tests were removed along with it; they asserted platform behavior rather than our own code.

One note: `URL.canParse` does raise the minimum browser we support to Chrome 120 / Firefox 115 / Safari 17, a bit above Vite's current default baseline. That said, all three shipped in 2023 and are ~2.5–3 years old by now, and the method is available in Node 18.17+ / 20+ as well, so we're fine relying on it.

### Screenshots

N/A — no UI changes.

### Related issue(s)

N/A

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
