### PR TITLE
Add --rpc-url and stamp calldata with the endpoint's chain

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,9 +16,31 @@ node packages/cli/_esm/cli.js swap pegged-token --gateway 0x...
 
 ## Configuration
 
-The following env variables can be set.
+`--rpc-url <url>` is a global option, accepted anywhere on the command line — before or after the subcommand:
 
-- `RPC_URL` — RPC endpoint used for reads. Falls back to a public Ethereum mainnet RPC when unset.
+```sh
+vetro-cli --rpc-url https://my-node.example swap treasury --gateway 0x...
+vetro-cli swap treasury --gateway 0x... --rpc-url https://my-node.example
+```
+
+It sets the endpoint every read goes to, and therefore the chain the emitted calldata is stamped with. It also accepts the endpoint via env var, so the resolution order is:
+
+1. `--rpc-url`
+2. `RPC_URL`
+3. a public Ethereum mainnet RPC (viem's default for mainnet)
+
+Only `http`/`https` endpoints are accepted; anything else is rejected as a usage error before any request is made.
+
+### Supported chains
+
+Vetro is deployed on Ethereum mainnet only, so every command starts by reading the endpoint's `eth_chainId` and fails if it is anything other than:
+
+| Chain ID | Endpoint                           |
+| -------- | ---------------------------------- |
+| `1`      | Ethereum mainnet                   |
+| `31337`  | local fork (anvil/Hardhat default) |
+
+The check runs before any contract read, so pointing at another network fails fast rather than returning state read off the wrong chain. This restriction is temporary and lifts once Vetro is deployed on more chains.
 
 ## Output
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,7 +18,7 @@ node packages/cli/_esm/cli.js swap pegged-token --gateway 0x...
 
 The following env variables can be set.
 
-- `RPC_URL` — Ethereum mainnet RPC endpoint used for reads. Falls back to a public RPC when unset.
+- `RPC_URL` — RPC endpoint used for reads. Falls back to a public Ethereum mainnet RPC when unset.
 
 ## Output
 
@@ -40,7 +40,7 @@ Write commands touch no keys — they emit a JSON-RPC transaction request and th
 { "chainId": "0x1", "data": "0x8b6099db…", "to": "0x…gateway", "value": "0x0" }
 ```
 
-Every numeric field is a hex `QUANTITY`, so the object can be lifted straight into `eth_sendTransaction` or an [ERC-5792](https://eips.ethereum.org/EIPS/eip-5792) `wallet_sendCalls` batch. The chain is always Ethereum mainnet, so `chainId` is always `"0x1"` and `value` is always `"0x0"`.
+Every numeric field is a hex `QUANTITY`, so the object can be lifted straight into `eth_sendTransaction` or an [ERC-5792](https://eips.ethereum.org/EIPS/eip-5792) `wallet_sendCalls` batch. `value` is always `"0x0"`.
 
 ## Token arguments
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
+import { type GlobalOptions } from "./lib/client.js";
 import { printError } from "./lib/output.js";
 import { createProgram } from "./program.js";
 
-createProgram().parseAsync(process.argv).catch(printError);
+const program = createProgram();
+
+program
+  .parseAsync(process.argv)
+  .catch((error: unknown) =>
+    printError({ error, rpcUrl: program.opts<GlobalOptions>().rpcUrl }),
+  );

--- a/packages/cli/src/features/swap/commands/allowance.ts
+++ b/packages/cli/src/features/swap/commands/allowance.ts
@@ -3,7 +3,7 @@ import { type Address, formatUnits } from "viem";
 import { allowance } from "viem-erc20/actions";
 
 import { parseAddress } from "../../../lib/args.js";
-import { createVetroClient } from "../../../lib/client.js";
+import { type GlobalOptions, createVetroClient } from "../../../lib/client.js";
 import { printResult } from "../../../lib/output.js";
 import { resolveSwapToken } from "../../../lib/tokens.js";
 
@@ -16,8 +16,13 @@ export function register(swap: Command) {
       "Whitelisted or pegged token to check, by symbol or address",
     )
     .requiredOption("--account <addr>", "Token owner", parseAddress)
-    .action(async function (options: { account: Address; token: string }) {
-      const client = createVetroClient();
+    .action(async function (
+      options: { account: Address; token: string },
+      command: Command,
+    ) {
+      const { client } = await createVetroClient(
+        command.optsWithGlobals<GlobalOptions>(),
+      );
       const token = await resolveSwapToken({
         client,
         value: options.token,

--- a/packages/cli/src/features/swap/commands/approve.ts
+++ b/packages/cli/src/features/swap/commands/approve.ts
@@ -22,7 +22,8 @@ export function register(swap: Command) {
         client,
         value: options.token,
       });
-      printTransactionRequest({
+      await printTransactionRequest({
+        client,
         data: encodeApproveData({
           amount: parseUnits(options.amount, token.decimals),
           spender: token.gatewayAddress,

--- a/packages/cli/src/features/swap/commands/approve.ts
+++ b/packages/cli/src/features/swap/commands/approve.ts
@@ -3,7 +3,7 @@ import { parseUnits } from "viem";
 import { encodeApproveData } from "viem-erc20/actions";
 
 import { parseAmount } from "../../../lib/args.js";
-import { createVetroClient } from "../../../lib/client.js";
+import { type GlobalOptions, createVetroClient } from "../../../lib/client.js";
 import { printTransactionRequest } from "../../../lib/output.js";
 import { resolveSwapToken } from "../../../lib/tokens.js";
 
@@ -16,14 +16,19 @@ export function register(swap: Command) {
       "Whitelisted or pegged token to approve, by symbol or address",
     )
     .requiredOption("--amount <n>", "Amount in human units", parseAmount)
-    .action(async function (options: { amount: string; token: string }) {
-      const client = createVetroClient();
+    .action(async function (
+      options: { amount: string; token: string },
+      command: Command,
+    ) {
+      const { chainId, client } = await createVetroClient(
+        command.optsWithGlobals<GlobalOptions>(),
+      );
       const token = await resolveSwapToken({
         client,
         value: options.token,
       });
-      await printTransactionRequest({
-        client,
+      printTransactionRequest({
+        chainId,
         data: encodeApproveData({
           amount: parseUnits(options.amount, token.decimals),
           spender: token.gatewayAddress,

--- a/packages/cli/src/features/swap/commands/mint.ts
+++ b/packages/cli/src/features/swap/commands/mint.ts
@@ -9,7 +9,7 @@ import { type Command } from "commander";
 import { type Address, formatUnits, parseUnits } from "viem";
 
 import { parseAddress, parseAmount, parseSlippage } from "../../../lib/args.js";
-import { createVetroClient } from "../../../lib/client.js";
+import { type GlobalOptions, createVetroClient } from "../../../lib/client.js";
 import { printTransactionRequest } from "../../../lib/output.js";
 import { DEFAULT_SLIPPAGE, applySlippage } from "../../../lib/slippage.js";
 import {
@@ -42,14 +42,19 @@ export function register(swap: Command) {
       parseSlippage,
       DEFAULT_SLIPPAGE,
     )
-    .action(async function (options: {
-      amount: string;
-      from: string;
-      receiver: Address;
-      slippage: number;
-      to?: string;
-    }) {
-      const client = createVetroClient();
+    .action(async function (
+      options: {
+        amount: string;
+        from: string;
+        receiver: Address;
+        slippage: number;
+        to?: string;
+      },
+      command: Command,
+    ) {
+      const { chainId, client } = await createVetroClient(
+        command.optsWithGlobals<GlobalOptions>(),
+      );
       const tokenIn = await resolveWhitelistedToken({
         client,
         value: options.from,
@@ -111,8 +116,8 @@ export function register(swap: Command) {
         slippage: options.slippage,
       });
 
-      await printTransactionRequest({
-        client,
+      printTransactionRequest({
+        chainId,
         data: encodeDeposit({
           amountIn,
           minPeggedTokenOut,

--- a/packages/cli/src/features/swap/commands/mint.ts
+++ b/packages/cli/src/features/swap/commands/mint.ts
@@ -111,7 +111,8 @@ export function register(swap: Command) {
         slippage: options.slippage,
       });
 
-      printTransactionRequest({
+      await printTransactionRequest({
+        client,
         data: encodeDeposit({
           amountIn,
           minPeggedTokenOut,

--- a/packages/cli/src/features/swap/commands/peggedToken.ts
+++ b/packages/cli/src/features/swap/commands/peggedToken.ts
@@ -3,7 +3,7 @@ import { type Command } from "commander";
 import { type Address } from "viem";
 
 import { parseGateway } from "../../../lib/args.js";
-import { createVetroClient } from "../../../lib/client.js";
+import { type GlobalOptions, createVetroClient } from "../../../lib/client.js";
 import { printResult } from "../../../lib/output.js";
 
 export function register(swap: Command) {
@@ -11,8 +11,10 @@ export function register(swap: Command) {
     .command("pegged-token")
     .description("Print the gateway's pegged-token address")
     .requiredOption("--gateway <addr>", "Gateway address", parseGateway)
-    .action(async function (options: { gateway: Address }) {
-      const client = createVetroClient();
+    .action(async function (options: { gateway: Address }, command: Command) {
+      const { client } = await createVetroClient(
+        command.optsWithGlobals<GlobalOptions>(),
+      );
       const peggedToken = await getPeggedToken(client, {
         address: options.gateway,
       });

--- a/packages/cli/src/features/swap/commands/treasury.ts
+++ b/packages/cli/src/features/swap/commands/treasury.ts
@@ -3,7 +3,7 @@ import { type Command } from "commander";
 import { type Address } from "viem";
 
 import { parseGateway } from "../../../lib/args.js";
-import { createVetroClient } from "../../../lib/client.js";
+import { type GlobalOptions, createVetroClient } from "../../../lib/client.js";
 import { printResult } from "../../../lib/output.js";
 
 export function register(swap: Command) {
@@ -11,8 +11,10 @@ export function register(swap: Command) {
     .command("treasury")
     .description("Print the gateway's treasury address")
     .requiredOption("--gateway <addr>", "Gateway address", parseGateway)
-    .action(async function (options: { gateway: Address }) {
-      const client = createVetroClient();
+    .action(async function (options: { gateway: Address }, command: Command) {
+      const { client } = await createVetroClient(
+        command.optsWithGlobals<GlobalOptions>(),
+      );
       const treasury = await getTreasury(client, {
         address: options.gateway,
       });

--- a/packages/cli/src/lib/args.ts
+++ b/packages/cli/src/lib/args.ts
@@ -30,6 +30,19 @@ export function parseGateway(value: string) {
   return address;
 }
 
+export function parseRpcUrl(value: string) {
+  if (!URL.canParse(value)) {
+    throw new InvalidArgumentError(`Invalid RPC URL: "${value}"`);
+  }
+  const { protocol } = new URL(value);
+  if (protocol !== "http:" && protocol !== "https:") {
+    throw new InvalidArgumentError(
+      `RPC URL must use http or https: "${value}"`,
+    );
+  }
+  return value;
+}
+
 export function parseSlippage(value: string) {
   const normalized = value.replace(",", ".");
   if (normalized !== "" && !/^\d+(\.\d?)?$/.test(normalized)) {

--- a/packages/cli/src/lib/args.ts
+++ b/packages/cli/src/lib/args.ts
@@ -31,11 +31,13 @@ export function parseGateway(value: string) {
 }
 
 export function parseRpcUrl(value: string) {
-  if (!URL.canParse(value)) {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
     throw new InvalidArgumentError(`Invalid RPC URL: "${value}"`);
   }
-  const { protocol } = new URL(value);
-  if (protocol !== "http:" && protocol !== "https:") {
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
     throw new InvalidArgumentError(
       `RPC URL must use http or https: "${value}"`,
     );

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -1,11 +1,26 @@
 import { createPublicClient, http } from "viem";
+import { getChainId } from "viem/actions";
 import { mainnet } from "viem/chains";
 
-// TODO extend custom RPC https://github.com/vetro-protocol/vetro-monorepo/issues/445#issuecomment-5062771972
-// For the time being, for development, let's allow overriding with env vars
-export const createVetroClient = () =>
-  createPublicClient({
+export type GlobalOptions = { rpcUrl?: string };
+
+// Hardhat chain id when using local fork.
+const localChainId = 31337;
+const supportedChainIds = [mainnet.id, localChainId];
+
+export async function createVetroClient({ rpcUrl }: GlobalOptions) {
+  const client = createPublicClient({
     batch: { multicall: true },
     chain: mainnet,
-    transport: http(process.env.RPC_URL),
+    transport: http(rpcUrl),
   });
+
+  const chainId = await getChainId(client);
+  if (!supportedChainIds.includes(chainId)) {
+    throw new Error(
+      `The RPC endpoint is on chain ${chainId}, but Vetro is only deployed on Ethereum mainnet (${mainnet.id}); a local fork of it (${localChainId}) is also accepted`,
+    );
+  }
+
+  return { chainId, client };
+}

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -1,5 +1,5 @@
-import { type Address, type Hex, numberToHex } from "viem";
-import { mainnet } from "viem/chains";
+import { type Address, type Client, type Hex, numberToHex } from "viem";
+import { getChainId } from "viem/actions";
 
 export function printResult(value: unknown) {
   const json = JSON.stringify(value ?? null, (_key, val) =>
@@ -8,15 +8,17 @@ export function printResult(value: unknown) {
   process.stdout.write(`${json}\n`);
 }
 
-export function printTransactionRequest({
+export async function printTransactionRequest({
+  client,
   data,
   to,
 }: {
+  client: Client;
   data: Hex;
   to: Address;
 }) {
   printResult({
-    chainId: numberToHex(mainnet.id),
+    chainId: numberToHex(await getChainId(client)),
     data,
     to,
     value: "0x0",

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -1,5 +1,4 @@
-import { type Address, type Client, type Hex, numberToHex } from "viem";
-import { getChainId } from "viem/actions";
+import { type Address, type Hex, numberToHex } from "viem";
 
 export function printResult(value: unknown) {
   const json = JSON.stringify(value ?? null, (_key, val) =>
@@ -8,35 +7,54 @@ export function printResult(value: unknown) {
   process.stdout.write(`${json}\n`);
 }
 
-export async function printTransactionRequest({
-  client,
+export function printTransactionRequest({
+  chainId,
   data,
   to,
 }: {
-  client: Client;
+  chainId: number;
   data: Hex;
   to: Address;
 }) {
   printResult({
-    chainId: numberToHex(await getChainId(client)),
+    chainId: numberToHex(chainId),
     data,
     to,
     value: "0x0",
   });
 }
 
-function sanitize(message: string) {
-  let sanitized = message;
-  // TODO extend custom RPC https://github.com/vetro-protocol/vetro-monorepo/issues/445#issuecomment-5062771972
-  const rpcUrl = process.env.RPC_URL;
-  if (rpcUrl) {
-    sanitized = sanitized.replaceAll(rpcUrl, "[redacted]");
-  }
-  return sanitized;
-}
+/**
+ * Redacts option values from a usage error, which commander reports before the
+ * endpoint is ever resolved. Only the quoted forms are replaced: the value is
+ * whatever was typed, so a bare replace would rewrite the message around it.
+ */
+export const redactOptionValues = ({
+  message,
+  values,
+}: {
+  message: string;
+  values: (string | undefined)[];
+}) =>
+  values.reduce<string>(
+    (redacted, value) =>
+      value
+        ? redacted
+            .replaceAll(`'${value}'`, "'[redacted]'")
+            .replaceAll(`"${value}"`, '"[redacted]"')
+        : redacted,
+    message,
+  );
 
-export function printError(error: unknown) {
+export function printError({
+  error,
+  rpcUrl,
+}: {
+  error: unknown;
+  rpcUrl?: string;
+}) {
   const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`${JSON.stringify({ error: sanitize(message) })}\n`);
+  const redacted = rpcUrl ? message.replaceAll(rpcUrl, "[redacted]") : message;
+  process.stderr.write(`${JSON.stringify({ error: redacted })}\n`);
   process.exitCode = 1;
 }

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,11 +1,36 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { register as swap } from "./features/swap/index.js";
+import { parseRpcUrl } from "./lib/args.js";
+import { redactOptionValues } from "./lib/output.js";
 
 const features = [swap];
+
+/**
+ * The option, paired with the redactor for the usage errors it can raise.
+ * Commander reports those before the endpoint is resolved and echoes the
+ * offending value, so the parser keeps hold of whatever it was handed --
+ * for the flag and the env var alike, including a value it rejected.
+ */
+const createRpcUrlOption = function () {
+  let attempted: string | undefined;
+  return {
+    option: new Option(
+      "--rpc-url <url>",
+      "RPC endpoint to read from, which also determines the chain the calldata is stamped with; defaults to a public Ethereum mainnet RPC",
+    )
+      .argParser(function (value: string) {
+        attempted = value;
+        return parseRpcUrl(value);
+      })
+      .env("RPC_URL"),
+    redactUsageError: (message: string) =>
+      redactOptionValues({ message, values: [attempted, process.env.RPC_URL] }),
+  };
+};
 
 export function createProgram() {
   const packageJsonPath = join(
@@ -20,12 +45,17 @@ export function createProgram() {
   };
 
   const program = new Command();
+  const { option: rpcUrlOption, redactUsageError } = createRpcUrlOption();
 
   program
+    .configureOutput({
+      outputError: (message, write) => write(redactUsageError(message)),
+    })
     // The CLI name is the bin key (vetro-cli), not the scoped package name.
     .name(Object.keys(pkg.bin)[0])
     .description(pkg.description)
-    .version(pkg.version);
+    .version(pkg.version)
+    .addOption(rpcUrlOption);
 
   features.forEach((register) => register(program));
 

--- a/packages/cli/test/args.test.ts
+++ b/packages/cli/test/args.test.ts
@@ -4,6 +4,7 @@ import {
   parseAddress,
   parseAmount,
   parseGateway,
+  parseRpcUrl,
   parseSlippage,
 } from "../src/lib/args.js";
 
@@ -72,6 +73,31 @@ describe("parseGateway", function () {
 
   it("throws for a malformed address", function () {
     expect(() => parseGateway("nope")).toThrow('Invalid address: "nope"');
+  });
+});
+
+describe("parseRpcUrl", function () {
+  it("returns the URL unchanged so it still matches for redaction", function () {
+    expect(parseRpcUrl("https://eth-mainnet.example/v2/KEY")).toBe(
+      "https://eth-mainnet.example/v2/KEY",
+    );
+    expect(parseRpcUrl("http://127.0.0.1:8545")).toBe("http://127.0.0.1:8545");
+  });
+
+  it("throws for a malformed URL", function () {
+    expect(() => parseRpcUrl("not-a-url")).toThrow(
+      'Invalid RPC URL: "not-a-url"',
+    );
+  });
+
+  it("throws for an empty value rather than treating it as unset", function () {
+    expect(() => parseRpcUrl("")).toThrow('Invalid RPC URL: ""');
+  });
+
+  it("throws for a transport the client cannot use", function () {
+    expect(() => parseRpcUrl("ws://127.0.0.1:8545")).toThrow(
+      'RPC URL must use http or https: "ws://127.0.0.1:8545"',
+    );
   });
 });
 

--- a/packages/cli/test/client.test.ts
+++ b/packages/cli/test/client.test.ts
@@ -1,0 +1,47 @@
+import { numberToHex } from "viem";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createVetroClient } from "../src/lib/client.js";
+
+const rpcUrl = "https://rpc.example";
+
+const stubEndpointOnChain = (chainId: number) =>
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            id: 1,
+            jsonrpc: "2.0",
+            result: numberToHex(chainId),
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        ),
+    ),
+  );
+
+describe("createVetroClient", function () {
+  afterEach(function () {
+    vi.unstubAllGlobals();
+  });
+
+  it("accepts Ethereum mainnet", async function () {
+    stubEndpointOnChain(1);
+    const { chainId } = await createVetroClient({ rpcUrl });
+    expect(chainId).toBe(1);
+  });
+
+  it("accepts a local fork on the anvil/Hardhat default", async function () {
+    stubEndpointOnChain(31337);
+    const { chainId } = await createVetroClient({ rpcUrl });
+    expect(chainId).toBe(31337);
+  });
+
+  it("rejects a chain Vetro is not deployed on", async function () {
+    stubEndpointOnChain(8453);
+    await expect(createVetroClient({ rpcUrl })).rejects.toThrow(
+      "The RPC endpoint is on chain 8453, but Vetro is only deployed on Ethereum mainnet (1)",
+    );
+  });
+});

--- a/packages/cli/test/e2e/allowance.test.ts
+++ b/packages/cli/test/e2e/allowance.test.ts
@@ -7,64 +7,49 @@ const untouchedAccount = "0x000000000000000000000000000000000000dead";
 describe("swap allowance", function () {
   const rpcUrl = inject("anvilUrl");
 
+  const allowanceOnFork = ({
+    account,
+    token,
+  }: {
+    account: string;
+    token: string;
+  }) => [
+    "swap",
+    "allowance",
+    "--token",
+    token,
+    "--account",
+    account,
+    "--rpc-url",
+    rpcUrl,
+  ];
+
   it("reads the allowance by symbol", async function () {
-    const approved = await runCli({
-      args: [
-        "swap",
-        "allowance",
-        "--token",
-        usdc.symbol,
-        "--account",
-        untouchedAccount,
-      ],
-      rpcUrl,
-    });
+    const approved = await runCli(
+      allowanceOnFork({ account: untouchedAccount, token: usdc.symbol }),
+    );
     expect(approved).toBe("0");
   });
 
   it("reads the allowance by address", async function () {
-    const approved = await runCli({
-      args: [
-        "swap",
-        "allowance",
-        "--token",
-        usdc.address,
-        "--account",
-        untouchedAccount,
-      ],
-      rpcUrl,
-    });
+    const approved = await runCli(
+      allowanceOnFork({ account: untouchedAccount, token: usdc.address }),
+    );
     expect(approved).toBe("0");
   });
 
   it("rejects an invalid --account", async function () {
-    const { exitCode, stderr } = await runCliRaw({
-      args: [
-        "swap",
-        "allowance",
-        "--token",
-        usdc.symbol,
-        "--account",
-        "notanaddress",
-      ],
-      rpcUrl,
-    });
+    const { exitCode, stderr } = await runCliRaw(
+      allowanceOnFork({ account: "notanaddress", token: usdc.symbol }),
+    );
     expect(exitCode).toBe(1);
     expect(stderr).toContain('Invalid address: "notanaddress"');
   });
 
   it("rejects a token the protocol does not know", async function () {
-    const { exitCode, stderr } = await runCliRaw({
-      args: [
-        "swap",
-        "allowance",
-        "--token",
-        "USDX",
-        "--account",
-        untouchedAccount,
-      ],
-      rpcUrl,
-    });
+    const { exitCode, stderr } = await runCliRaw(
+      allowanceOnFork({ account: untouchedAccount, token: "USDX" }),
+    );
     expect(exitCode).toBe(1);
     expect(JSON.parse(stderr).error).toBe(
       'Not a whitelisted or pegged token: "USDX"',

--- a/packages/cli/test/e2e/approve.test.ts
+++ b/packages/cli/test/e2e/approve.test.ts
@@ -14,60 +14,62 @@ import {
   vusd,
 } from "./helpers.js";
 
-const readAllowance = ({ rpcUrl, token }: { rpcUrl: string; token: string }) =>
-  runCli({
-    args: ["swap", "allowance", "--token", token, "--account", TEST_ADDRESS],
-    rpcUrl,
-  });
-
 describe("swap approve", function () {
   const rpcUrl = inject("anvilUrl");
 
+  const approveOnFork = (token: string) => [
+    ...approveArgs(token),
+    "--rpc-url",
+    rpcUrl,
+  ];
+
+  const readAllowance = (token: string) =>
+    runCli([
+      "swap",
+      "allowance",
+      "--token",
+      token,
+      "--account",
+      TEST_ADDRESS,
+      "--rpc-url",
+      rpcUrl,
+    ]);
+
   it("grants the gateway a USDC allowance once the approve calldata is broadcast", async function () {
     await fundTestAccount({ amount: "1000", rpcUrl });
-    const request = await runCli<TransactionRequest>({
-      args: approveArgs(usdc.symbol),
-      rpcUrl,
-    });
+    const request = await runCli<TransactionRequest>(
+      approveOnFork(usdc.symbol),
+    );
     expect(isAddressEqual(request.to, usdc.address)).toBe(true);
 
     const receipt = await sendTransactionRequest({ request, rpcUrl });
     expect(receipt.status).toBe("success");
 
-    expect(await readAllowance({ rpcUrl, token: usdc.symbol })).toBe(
-      swapAmount,
-    );
+    expect(await readAllowance(usdc.symbol)).toBe(swapAmount);
   });
 
   it("grants the gateway an allowance on the pegged token", async function () {
     await fundTestAccount({ amount: "1000", rpcUrl });
-    const request = await runCli<TransactionRequest>({
-      args: approveArgs(vusd.symbol),
-      rpcUrl,
-    });
+    const request = await runCli<TransactionRequest>(
+      approveOnFork(vusd.symbol),
+    );
     expect(isAddressEqual(request.to, vusd.address)).toBe(true);
 
     const receipt = await sendTransactionRequest({ request, rpcUrl });
     expect(receipt.status).toBe("success");
 
-    expect(await readAllowance({ rpcUrl, token: vusd.symbol })).toBe(
-      swapAmount,
-    );
+    expect(await readAllowance(vusd.symbol)).toBe(swapAmount);
   });
 
   it("resolves a token given a non-checksummed address", async function () {
-    const request = await runCli<TransactionRequest>({
-      args: approveArgs(usdc.address.toLowerCase()),
-      rpcUrl,
-    });
+    const request = await runCli<TransactionRequest>(
+      approveOnFork(usdc.address.toLowerCase()),
+    );
     expect(isAddressEqual(request.to, usdc.address)).toBe(true);
   });
 
   it("rejects a token the protocol does not know", async function () {
-    const { exitCode, stderr } = await runCliRaw({
-      args: approveArgs("USDX"),
-      rpcUrl,
-    });
+    const { exitCode, stderr } = await runCliRaw(approveOnFork("USDX"));
     expect(exitCode).toBe(1);
     expect(JSON.parse(stderr).error).toBe(
       'Not a whitelisted or pegged token: "USDX"',

--- a/packages/cli/test/e2e/helpers.ts
+++ b/packages/cli/test/e2e/helpers.ts
@@ -33,6 +33,7 @@ import {
 } from "viem/actions";
 import { mainnet } from "viem/chains";
 
+import { type GlobalOptions } from "../../src/lib/client.js";
 import { printError } from "../../src/lib/output.js";
 import { createProgram } from "../../src/program.js";
 
@@ -114,37 +115,26 @@ const withExitOverride = function (command: Command) {
  * `printError`. Driving `createProgram` in this process, rather than spawning
  * the bundled bin, is what lets coverage see these runs.
  */
-export const runCliRaw = async function ({
-  args,
-  rpcUrl,
-}: {
-  args: string[];
-  rpcUrl: string;
-}) {
+export const runCliRaw = async function (args: string[]) {
   const stdout = captureStream(process.stdout);
   const stderr = captureStream(process.stderr);
-  const previousRpcUrl = process.env.RPC_URL;
   const previousExitCode = process.exitCode;
 
-  process.env.RPC_URL = rpcUrl;
   process.exitCode = 0;
 
+  const program = withExitOverride(createProgram());
+
   try {
-    await withExitOverride(createProgram()).parseAsync(args, { from: "user" });
+    await program.parseAsync(args, { from: "user" });
   } catch (error) {
     if (error instanceof CommanderError) {
       process.exitCode = error.exitCode;
     } else {
-      printError(error);
+      printError({ error, rpcUrl: program.opts<GlobalOptions>().rpcUrl });
     }
   } finally {
     stdout.restore();
     stderr.restore();
-    if (previousRpcUrl === undefined) {
-      delete process.env.RPC_URL;
-    } else {
-      process.env.RPC_URL = previousRpcUrl;
-    }
   }
 
   const exitCode = process.exitCode ?? 0;
@@ -154,14 +144,8 @@ export const runCliRaw = async function ({
   return { exitCode, stderr: stderr.read(), stdout: stdout.read() };
 };
 
-export const runCli = async function <T = string>({
-  args,
-  rpcUrl,
-}: {
-  args: string[];
-  rpcUrl: string;
-}) {
-  const { exitCode, stderr, stdout } = await runCliRaw({ args, rpcUrl });
+export const runCli = async function <T = string>(args: string[]) {
+  const { exitCode, stderr, stdout } = await runCliRaw(args);
   if (exitCode !== 0) {
     throw new Error(
       `vetro-cli ${args.join(" ")} exited ${exitCode}: ${stderr}`,

--- a/packages/cli/test/e2e/mint.test.ts
+++ b/packages/cli/test/e2e/mint.test.ts
@@ -31,11 +31,14 @@ describe("swap mint", function () {
   const rpcUrl = inject("anvilUrl");
   const { publicClient } = createClients(rpcUrl);
 
+  const mintOnFork = (extra: string[] = []) => [
+    ...mintArgs(extra),
+    "--rpc-url",
+    rpcUrl,
+  ];
+
   it("targets the chain the RPC is on, with no native value", async function () {
-    const request = await runCli<TransactionRequest>({
-      args: mintArgs(),
-      rpcUrl,
-    });
+    const request = await runCli<TransactionRequest>(mintOnFork());
     expect(request.chainId).toBe(numberToHex(await getChainId(publicClient)));
     expect(isHex(request.data)).toBe(true);
     expect(isAddress(request.to)).toBe(true);
@@ -43,22 +46,22 @@ describe("swap mint", function () {
   });
 
   it("deposits into the gateway that mints VUSD", async function () {
-    const request = await runCli<TransactionRequest>({
-      args: mintArgs(),
+    const request = await runCli<TransactionRequest>(mintOnFork());
+    const peggedToken = await runCli<Address>([
+      "swap",
+      "pegged-token",
+      "--gateway",
+      request.to,
+      "--rpc-url",
       rpcUrl,
-    });
-    const peggedToken = await runCli<Address>({
-      args: ["swap", "pegged-token", "--gateway", request.to],
-      rpcUrl,
-    });
+    ]);
     expect(isAddressEqual(peggedToken, vusd.address)).toBe(true);
   });
 
   it("encodes the deposit arguments as given", async function () {
-    const request = await runCli<TransactionRequest>({
-      args: mintArgs(["--slippage", slippage]),
-      rpcUrl,
-    });
+    const request = await runCli<TransactionRequest>(
+      mintOnFork(["--slippage", slippage]),
+    );
     const { args } = decodeFunctionData({
       abi: gatewayAbi,
       data: request.data,
@@ -73,10 +76,7 @@ describe("swap mint", function () {
   });
 
   it("requires the full preview when --slippage is omitted", async function () {
-    const request = await runCli<TransactionRequest>({
-      args: mintArgs(),
-      rpcUrl,
-    });
+    const request = await runCli<TransactionRequest>(mintOnFork());
     const { args } = decodeFunctionData({
       abi: gatewayAbi,
       data: request.data,
@@ -91,10 +91,9 @@ describe("swap mint", function () {
   });
 
   it("encodes the deposit when --to is the gateway's pegged token", async function () {
-    const request = await runCli<TransactionRequest>({
-      args: mintArgs(["--to", vusd.symbol]),
-      rpcUrl,
-    });
+    const request = await runCli<TransactionRequest>(
+      mintOnFork(["--to", vusd.symbol]),
+    );
     const { args } = decodeFunctionData({
       abi: gatewayAbi,
       data: request.data,
@@ -107,28 +106,26 @@ describe("swap mint", function () {
   });
 
   it("rejects a --to that is not the gateway's pegged token", async function () {
-    const { exitCode, stderr } = await runCliRaw({
-      args: mintArgs(["--to", "vetBTC"]),
-      rpcUrl,
-    });
+    const { exitCode, stderr } = await runCliRaw(
+      mintOnFork(["--to", "vetBTC"]),
+    );
     expect(exitCode).toBe(1);
     expect(JSON.parse(stderr).error).toContain("is not the pegged token");
   });
 
   it("rejects minting from a pegged token", async function () {
-    const { exitCode, stderr } = await runCliRaw({
-      args: [
-        "swap",
-        "mint",
-        "--from",
-        vusd.symbol,
-        "--amount",
-        swapAmount,
-        "--receiver",
-        TEST_ADDRESS,
-      ],
+    const { exitCode, stderr } = await runCliRaw([
+      "swap",
+      "mint",
+      "--from",
+      vusd.symbol,
+      "--amount",
+      swapAmount,
+      "--receiver",
+      TEST_ADDRESS,
+      "--rpc-url",
       rpcUrl,
-    });
+    ]);
     expect(exitCode).toBe(1);
     expect(JSON.parse(stderr).error).toBe(
       `Not a whitelisted token: "${vusd.symbol}"`,
@@ -136,10 +133,7 @@ describe("swap mint", function () {
   });
 
   it("rejects an amount that would mint past the gateway's remaining capacity", async function () {
-    const { to: gateway } = await runCli<TransactionRequest>({
-      args: mintArgs(),
-      rpcUrl,
-    });
+    const { to: gateway } = await runCli<TransactionRequest>(mintOnFork());
     const remainingCapacity = parseUnits("0.5", vusd.decimals);
     const { maxMintAfter, maxMintBefore } = await setMaxMint({
       gateway,
@@ -150,16 +144,12 @@ describe("swap mint", function () {
 
     try {
       // Below the max mint
-      const request = await runCli<TransactionRequest>({
-        args: mintArgs(["--amount", "0.1"]),
-        rpcUrl,
-      });
+      const request = await runCli<TransactionRequest>(
+        mintOnFork(["--amount", "0.1"]),
+      );
 
       // above the max mint
-      const { exitCode, stderr } = await runCliRaw({
-        args: mintArgs(),
-        rpcUrl,
-      });
+      const { exitCode, stderr } = await runCliRaw(mintOnFork());
       expect(exitCode).toBe(1);
       expect(JSON.parse(stderr).error).toContain(
         "Amount exceeds the mint limit",
@@ -172,10 +162,7 @@ describe("swap mint", function () {
   });
 
   it("rejects minting a token whose deposits are paused", async function () {
-    const { to: gateway } = await runCli<TransactionRequest>({
-      args: mintArgs(),
-      rpcUrl,
-    });
+    const { to: gateway } = await runCli<TransactionRequest>(mintOnFork());
     await setDepositActive({
       active: false,
       gateway,
@@ -184,10 +171,7 @@ describe("swap mint", function () {
     });
 
     try {
-      const { exitCode, stderr } = await runCliRaw({
-        args: mintArgs(),
-        rpcUrl,
-      });
+      const { exitCode, stderr } = await runCliRaw(mintOnFork());
       expect(exitCode).toBe(1);
       expect(JSON.parse(stderr).error).toBe(
         `Minting from "${usdc.symbol}" is paused`,
@@ -211,10 +195,7 @@ describe("swap mint", function () {
     ["--receiver", "notanaddress"],
   ])("rejects %s %s as a usage error", async function ([flag, value]) {
     // Later occurrences win in commander, so appending overrides the default.
-    const { exitCode, stderr } = await runCliRaw({
-      args: mintArgs([flag, value]),
-      rpcUrl,
-    });
+    const { exitCode, stderr } = await runCliRaw(mintOnFork([flag, value]));
     expect(exitCode).toBe(1);
     expect(stderr).toContain(`option '${flag}`);
   });

--- a/packages/cli/test/e2e/mint.test.ts
+++ b/packages/cli/test/e2e/mint.test.ts
@@ -6,8 +6,10 @@ import {
   isAddress,
   isAddressEqual,
   isHex,
+  numberToHex,
   parseUnits,
 } from "viem";
+import { getChainId } from "viem/actions";
 import { describe, expect, inject, it } from "vitest";
 
 import {
@@ -29,12 +31,12 @@ describe("swap mint", function () {
   const rpcUrl = inject("anvilUrl");
   const { publicClient } = createClients(rpcUrl);
 
-  it("targets mainnet with no native value", async function () {
+  it("targets the chain the RPC is on, with no native value", async function () {
     const request = await runCli<TransactionRequest>({
       args: mintArgs(),
       rpcUrl,
     });
-    expect(request.chainId).toBe("0x1");
+    expect(request.chainId).toBe(numberToHex(await getChainId(publicClient)));
     expect(isHex(request.data)).toBe(true);
     expect(isAddress(request.to)).toBe(true);
     expect(request.value).toBe("0x0");

--- a/packages/cli/test/e2e/peggedToken.test.ts
+++ b/packages/cli/test/e2e/peggedToken.test.ts
@@ -9,13 +9,20 @@ describe("swap pegged-token", function () {
   const rpcUrl = inject("anvilUrl");
   const { publicClient } = createClients(rpcUrl);
 
+  const peggedTokenOnFork = (extra: string[] = []) => [
+    "swap",
+    "pegged-token",
+    ...extra,
+    "--rpc-url",
+    rpcUrl,
+  ];
+
   it.for(gatewayAddresses)(
     "prints the pegged token of gateway %s",
     async function (gateway) {
-      const peggedToken = await runCli<Address>({
-        args: ["swap", "pegged-token", "--gateway", gateway],
-        rpcUrl,
-      });
+      const peggedToken = await runCli<Address>(
+        peggedTokenOnFork(["--gateway", gateway]),
+      );
 
       expect(getAddress(peggedToken)).toBe(peggedToken);
       expect(
@@ -26,36 +33,30 @@ describe("swap pegged-token", function () {
 
   it("accepts a non-checksummed gateway address", async function () {
     const [gateway] = gatewayAddresses;
-    const peggedToken = await runCli<Address>({
-      args: ["swap", "pegged-token", "--gateway", gateway.toLowerCase()],
-      rpcUrl,
-    });
+    const peggedToken = await runCli<Address>(
+      peggedTokenOnFork(["--gateway", gateway.toLowerCase()]),
+    );
     expect(getAddress(peggedToken)).toBe(peggedToken);
   });
 
   it("rejects an address that is not an enabled gateway", async function () {
-    const { exitCode, stderr } = await runCliRaw({
-      args: ["swap", "pegged-token", "--gateway", usdc.address],
-      rpcUrl,
-    });
+    const { exitCode, stderr } = await runCliRaw(
+      peggedTokenOnFork(["--gateway", usdc.address]),
+    );
     expect(exitCode).toBe(1);
     expect(stderr).toContain(`Not an enabled gateway: "${usdc.address}"`);
   });
 
   it("rejects an invalid gateway address", async function () {
-    const { exitCode, stderr } = await runCliRaw({
-      args: ["swap", "pegged-token", "--gateway", "notanaddress"],
-      rpcUrl,
-    });
+    const { exitCode, stderr } = await runCliRaw(
+      peggedTokenOnFork(["--gateway", "notanaddress"]),
+    );
     expect(exitCode).toBe(1);
     expect(stderr).toContain('Invalid address: "notanaddress"');
   });
 
   it("rejects a missing --gateway", async function () {
-    const { exitCode, stderr } = await runCliRaw({
-      args: ["swap", "pegged-token"],
-      rpcUrl,
-    });
+    const { exitCode, stderr } = await runCliRaw(peggedTokenOnFork());
     expect(exitCode).toBe(1);
     expect(stderr).toContain("required option '--gateway <addr>'");
   });

--- a/packages/cli/test/e2e/rpcUrl.test.ts
+++ b/packages/cli/test/e2e/rpcUrl.test.ts
@@ -1,0 +1,129 @@
+import { gatewayAddresses } from "@vetro-protocol/gateway";
+import { type Address, isAddress } from "viem";
+import { afterEach, describe, expect, inject, it } from "vitest";
+
+import { runCli, runCliRaw } from "./helpers.js";
+
+const [gateway] = gatewayAddresses;
+
+describe("--rpc-url", function () {
+  const rpcUrl = inject("anvilUrl");
+  const originalRpcUrl = process.env.RPC_URL;
+
+  const readTreasury = (extra: string[]) =>
+    runCli<Address>(["swap", "treasury", "--gateway", gateway, ...extra]);
+
+  afterEach(function () {
+    if (originalRpcUrl === undefined) {
+      delete process.env.RPC_URL;
+    } else {
+      process.env.RPC_URL = originalRpcUrl;
+    }
+  });
+
+  it("reads from the endpoint given before the subcommand", async function () {
+    const treasury = await runCli<Address>([
+      "--rpc-url",
+      rpcUrl,
+      "swap",
+      "treasury",
+      "--gateway",
+      gateway,
+    ]);
+    expect(isAddress(treasury)).toBe(true);
+  });
+
+  it("falls back to RPC_URL when the flag is absent", async function () {
+    process.env.RPC_URL = rpcUrl;
+    expect(isAddress(await readTreasury([]))).toBe(true);
+  });
+
+  it("prefers the flag over RPC_URL", async function () {
+    process.env.RPC_URL = "http://127.0.0.1:1";
+    expect(isAddress(await readTreasury(["--rpc-url", rpcUrl]))).toBe(true);
+  });
+
+  it("rejects an empty RPC_URL rather than treating it as unset", async function () {
+    process.env.RPC_URL = "";
+    const { exitCode, stderr } = await runCliRaw([
+      "swap",
+      "treasury",
+      "--gateway",
+      gateway,
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Invalid RPC URL");
+  });
+
+  it("rejects a malformed URL as a usage error", async function () {
+    const { exitCode, stderr } = await runCliRaw([
+      "swap",
+      "treasury",
+      "--gateway",
+      gateway,
+      "--rpc-url",
+      "nope",
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Invalid RPC URL");
+  });
+
+  // A usage error is raised before any endpoint is resolved, so it can't go
+  // through printError -- commander echoes the value and needs its own redaction.
+  it("keeps a rejected endpoint out of the usage error", async function () {
+    const secret = "wss://eth-mainnet.example/v2/SUPER_SECRET_KEY";
+    const { exitCode, stderr } = await runCliRaw([
+      "swap",
+      "treasury",
+      "--gateway",
+      gateway,
+      "--rpc-url",
+      secret,
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).not.toContain("SUPER_SECRET_KEY");
+    expect(stderr).toContain("[redacted]");
+  });
+
+  it("keeps a rejected RPC_URL out of the usage error", async function () {
+    process.env.RPC_URL = "wss://eth-mainnet.example/v2/SUPER_SECRET_KEY";
+    const { exitCode, stderr } = await runCliRaw([
+      "swap",
+      "treasury",
+      "--gateway",
+      gateway,
+    ]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).not.toContain("SUPER_SECRET_KEY");
+    expect(stderr).toContain("[redacted]");
+  });
+
+  // The value is whatever was typed, so redaction must not rewrite the message
+  // around it -- only the quoted occurrences are replaced.
+  it("does not mangle the message when the value is short", async function () {
+    const { stderr } = await runCliRaw([
+      "swap",
+      "treasury",
+      "--gateway",
+      gateway,
+      "--rpc-url",
+      "a",
+    ]);
+    expect(stderr).toContain("is invalid");
+    expect(stderr).toContain("Invalid RPC URL");
+  });
+
+  it("reports an unreachable endpoint without leaking it", async function () {
+    const { exitCode, stderr } = await runCliRaw([
+      "swap",
+      "treasury",
+      "--gateway",
+      gateway,
+      "--rpc-url",
+      "http://127.0.0.1:1",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).not.toContain("127.0.0.1:1");
+    expect(stderr).toContain("[redacted]");
+  });
+});

--- a/packages/cli/test/e2e/swap.test.ts
+++ b/packages/cli/test/e2e/swap.test.ts
@@ -22,18 +22,18 @@ describe("swap in (USDC → VUSD)", function () {
   const rpcUrl = inject("anvilUrl");
   const { publicClient } = createClients(rpcUrl);
 
+  const onFork = (args: string[]) => [...args, "--rpc-url", rpcUrl];
+
   it("mints at least minPeggedTokenOut once the mint calldata is broadcast", async function () {
-    const mintRequest = await runCli<TransactionRequest>({
-      args: mintArgs(["--slippage", slippage]),
-      rpcUrl,
-    });
+    const mintRequest = await runCli<TransactionRequest>(
+      onFork(mintArgs(["--slippage", slippage])),
+    );
     await fundTestAccount({ amount: "1000", rpcUrl });
     // Approving sets the allowance, so this is safe however often it runs.
     await sendTransactionRequest({
-      request: await runCli<TransactionRequest>({
-        args: approveArgs(usdc.symbol),
-        rpcUrl,
-      }),
+      request: await runCli<TransactionRequest>(
+        onFork(approveArgs(usdc.symbol)),
+      ),
       rpcUrl,
     });
 

--- a/packages/cli/test/e2e/treasury.test.ts
+++ b/packages/cli/test/e2e/treasury.test.ts
@@ -7,49 +7,50 @@ import { runCli, runCliRaw, usdc } from "./helpers.js";
 describe("swap treasury", function () {
   const rpcUrl = inject("anvilUrl");
 
+  const treasuryOnFork = (extra: string[] = []) => [
+    "swap",
+    "treasury",
+    ...extra,
+    "--rpc-url",
+    rpcUrl,
+  ];
+
   it.for(gatewayAddresses)(
     "prints the treasury of gateway %s",
     async function (gateway) {
-      const treasury = await runCli<Address>({
-        args: ["swap", "treasury", "--gateway", gateway],
-        rpcUrl,
-      });
+      const treasury = await runCli<Address>(
+        treasuryOnFork(["--gateway", gateway]),
+      );
       expect(getAddress(treasury)).toBe(treasury);
     },
   );
 
   it("accepts a non-checksummed gateway address", async function () {
     const [gateway] = gatewayAddresses;
-    const treasury = await runCli<Address>({
-      args: ["swap", "treasury", "--gateway", gateway.toLowerCase()],
-      rpcUrl,
-    });
+    const treasury = await runCli<Address>(
+      treasuryOnFork(["--gateway", gateway.toLowerCase()]),
+    );
     expect(getAddress(treasury)).toBe(treasury);
   });
 
   it("rejects an address that is not an enabled gateway", async function () {
-    const { exitCode, stderr } = await runCliRaw({
-      args: ["swap", "treasury", "--gateway", usdc.address],
-      rpcUrl,
-    });
+    const { exitCode, stderr } = await runCliRaw(
+      treasuryOnFork(["--gateway", usdc.address]),
+    );
     expect(exitCode).toBe(1);
     expect(stderr).toContain(`Not an enabled gateway: "${usdc.address}"`);
   });
 
   it("rejects an invalid gateway address", async function () {
-    const { exitCode, stderr } = await runCliRaw({
-      args: ["swap", "treasury", "--gateway", "notanaddress"],
-      rpcUrl,
-    });
+    const { exitCode, stderr } = await runCliRaw(
+      treasuryOnFork(["--gateway", "notanaddress"]),
+    );
     expect(exitCode).toBe(1);
     expect(stderr).toContain('Invalid address: "notanaddress"');
   });
 
   it("rejects a missing --gateway", async function () {
-    const { exitCode, stderr } = await runCliRaw({
-      args: ["swap", "treasury"],
-      rpcUrl,
-    });
+    const { exitCode, stderr } = await runCliRaw(treasuryOnFork());
     expect(exitCode).toBe(1);
     expect(stderr).toContain("required option '--gateway <addr>'");
   });

--- a/packages/cli/test/output.test.ts
+++ b/packages/cli/test/output.test.ts
@@ -1,6 +1,11 @@
+import { createClient, custom, numberToHex } from "viem";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { printError, printResult } from "../src/lib/output.js";
+import {
+  printError,
+  printResult,
+  printTransactionRequest,
+} from "../src/lib/output.js";
 
 const captureStdout = () =>
   vi.spyOn(process.stdout, "write").mockImplementation(() => true);
@@ -41,6 +46,37 @@ describe("printResult", function () {
     const spy = captureStdout();
     printResult(undefined);
     expect(spy).toHaveBeenCalledWith("null\n");
+  });
+});
+
+describe("printTransactionRequest", function () {
+  const clientOnChain = (chainId: number) =>
+    createClient({
+      transport: custom({
+        request: () => Promise.resolve(numberToHex(chainId)),
+      }),
+    });
+
+  it("stamps the chain the client is connected to", async function () {
+    const spy = captureStdout();
+    await printTransactionRequest({
+      client: clientOnChain(999),
+      data: "0xdeadbeef",
+      to: "0xDaD503f8B9d42bb7af3AfC588358D30163e4416F",
+    });
+    expect(spy).toHaveBeenCalledWith(
+      '{"chainId":"0x3e7","data":"0xdeadbeef","to":"0xDaD503f8B9d42bb7af3AfC588358D30163e4416F","value":"0x0"}\n',
+    );
+  });
+
+  it("stamps mainnet when the client is connected to mainnet", async function () {
+    const spy = captureStdout();
+    await printTransactionRequest({
+      client: clientOnChain(1),
+      data: "0xdeadbeef",
+      to: "0xDaD503f8B9d42bb7af3AfC588358D30163e4416F",
+    });
+    expect(JSON.parse(spy.mock.calls[0][0] as string).chainId).toBe("0x1");
   });
 });
 

--- a/packages/cli/test/output.test.ts
+++ b/packages/cli/test/output.test.ts
@@ -1,4 +1,3 @@
-import { createClient, custom, numberToHex } from "viem";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -50,66 +49,60 @@ describe("printResult", function () {
 });
 
 describe("printTransactionRequest", function () {
-  const clientOnChain = (chainId: number) =>
-    createClient({
-      transport: custom({
-        request: () => Promise.resolve(numberToHex(chainId)),
-      }),
-    });
-
-  it("stamps the chain the client is connected to", async function () {
+  it("emits the chain it was given as a hex QUANTITY", function () {
     const spy = captureStdout();
-    await printTransactionRequest({
-      client: clientOnChain(999),
+    printTransactionRequest({
+      chainId: 1,
       data: "0xdeadbeef",
       to: "0xDaD503f8B9d42bb7af3AfC588358D30163e4416F",
     });
     expect(spy).toHaveBeenCalledWith(
-      '{"chainId":"0x3e7","data":"0xdeadbeef","to":"0xDaD503f8B9d42bb7af3AfC588358D30163e4416F","value":"0x0"}\n',
+      '{"chainId":"0x1","data":"0xdeadbeef","to":"0xDaD503f8B9d42bb7af3AfC588358D30163e4416F","value":"0x0"}\n',
     );
-  });
-
-  it("stamps mainnet when the client is connected to mainnet", async function () {
-    const spy = captureStdout();
-    await printTransactionRequest({
-      client: clientOnChain(1),
-      data: "0xdeadbeef",
-      to: "0xDaD503f8B9d42bb7af3AfC588358D30163e4416F",
-    });
-    expect(JSON.parse(spy.mock.calls[0][0] as string).chainId).toBe("0x1");
   });
 });
 
 describe("printError", function () {
-  const originalRpcUrl = process.env.RPC_URL;
-
   afterEach(function () {
-    if (originalRpcUrl === undefined) {
-      delete process.env.RPC_URL;
-    } else {
-      process.env.RPC_URL = originalRpcUrl;
-    }
     process.exitCode = 0;
   });
 
-  it("redacts the configured RPC_URL so a key doesn't leak", function () {
-    process.env.RPC_URL = "https://eth-mainnet.example/v2/SECRET_KEY";
+  it("redacts the resolved RPC URL so a key doesn't leak", function () {
     const spy = captureStderr();
-    printError(
-      new Error(
+    printError({
+      error: new Error(
         "HTTP request failed. URL: https://eth-mainnet.example/v2/SECRET_KEY",
       ),
-    );
+      rpcUrl: "https://eth-mainnet.example/v2/SECRET_KEY",
+    });
     expect(spy).toHaveBeenCalledWith(
       '{"error":"HTTP request failed. URL: [redacted]"}\n',
     );
     expect(process.exitCode).toBe(1);
   });
 
-  it("passes the message through when RPC_URL is unset", function () {
-    delete process.env.RPC_URL;
+  it("redacts every occurrence of the URL", function () {
     const spy = captureStderr();
-    printError(new Error("boom"));
+    printError({
+      error: new Error(
+        "https://secret.example/KEY failed; retry https://secret.example/KEY",
+      ),
+      rpcUrl: "https://secret.example/KEY",
+    });
+    expect(spy).toHaveBeenCalledWith(
+      '{"error":"[redacted] failed; retry [redacted]"}\n',
+    );
+  });
+
+  it("passes the message through when no RPC URL was configured", function () {
+    const spy = captureStderr();
+    printError({ error: new Error("boom") });
     expect(spy).toHaveBeenCalledWith('{"error":"boom"}\n');
+  });
+
+  it("stringifies a non-Error rejection", function () {
+    const spy = captureStderr();
+    printError({ error: "plain failure" });
+    expect(spy).toHaveBeenCalledWith('{"error":"plain failure"}\n');
   });
 });


### PR DESCRIPTION
### Description

Adds a global `--rpc-url <url>` option, so a custom RPC endpoint can be set per invocation instead of only through the `RPC_URL` env var. It is accepted anywhere on the command line and resolves `--rpc-url` → `RPC_URL` → viem's public mainnet RPC.

Adding it surfaced a bug: the emitted `chainId` was hardcoded to mainnet while reads came from whatever `RPC_URL` pointed at, so calldata built against a fork was still labelled `"0x1"`. It is now read from the endpoint with `eth_chainId`.

Vetro is mainnet-only for now, so that chain id is also validated before any contract read — anything other than mainnet (`1`) or a local fork (`31337`) fails fast instead of returning state from the wrong chain.

Also fixes a leak the flag exposed: commander echoes a rejected option value, so an API key in `RPC_URL` reached stderr. Usage errors are now redacted too.

**Commits:**

5a66f91 Read chainId from the RPC, don't assume mainnet
4ad83b5 Add a global --rpc-url and guard the chain

### Screenshots

N/A — CLI only, no UI changes.

### Related issue(s)

Related to #445

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
