### PR TITLE
Track Uniswap V3 pools in the DEX tab

### DIFF
--- a/internal-dashboard/package.json
+++ b/internal-dashboard/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-query": "5.90.19",
     "@vetro-protocol/earn": "workspace:*",
     "@vetro-protocol/gateway": "workspace:*",
+    "@vetro-protocol/treasury": "workspace:*",
     "crypto-shortener": "1.2.0",
     "fetch-plus-plus": "1.0.0",
     "react": "19.2.3",

--- a/internal-dashboard/src/components/dex/tokenDistribution.tsx
+++ b/internal-dashboard/src/components/dex/tokenDistribution.tsx
@@ -1,6 +1,7 @@
 import { VictoryPie, VictoryTooltip } from "victory";
 import { formatUnits } from "viem";
 
+import { type Dex, dexLabels } from "../../config/dexes";
 import { useTokenPrices } from "../../hooks/useTokenPrices";
 import { useTrackedTokens } from "../../hooks/useTrackedTokens";
 import {
@@ -11,6 +12,7 @@ import { formatPercent, formatTokenAmount, formatUsd } from "../../lib/format";
 import { type TrackedPool } from "../../lib/types";
 
 import { TokenIcon } from "./tokenIcon";
+import { VenueBadge } from "./venueBadge";
 
 type Props = {
   pools: TrackedPool[];
@@ -62,6 +64,7 @@ const DistributionCard = function ({
               );
               return {
                 balance,
+                dex: slice.pool.dex,
                 usd: price !== undefined ? balance * price : undefined,
                 x: slice.pool.name,
                 y: slice.share * 100,
@@ -79,6 +82,7 @@ const DistributionCard = function ({
             labels={({ datum }) =>
               [
                 datum.x,
+                dexLabels[datum.dex as Dex],
                 `${formatTokenAmount(datum.balance)} ${token.symbol}`,
                 datum.usd !== undefined ? formatUsd(datum.usd) : undefined,
               ]
@@ -107,6 +111,7 @@ const DistributionCard = function ({
               <span className="truncate text-neutral-700">
                 {slice.pool.name}
               </span>
+              <VenueBadge dex={slice.pool.dex} />
             </span>
             <span className="shrink-0 font-medium text-neutral-950">
               {formatPercent(slice.share * 100)}

--- a/internal-dashboard/src/components/dex/venueBadge.tsx
+++ b/internal-dashboard/src/components/dex/venueBadge.tsx
@@ -1,15 +1,16 @@
-import { type Dex } from "../../config/dexes";
+import { type Dex, dexLabels } from "../../config/dexes";
 
 // Per-venue pill so pools are scannable by DEX in the list and on the details page.
 const styles: Record<Dex, string> = {
   curve: "bg-blue-50 text-blue-700 ring-blue-600/20",
   sushi: "bg-pink-50 text-pink-700 ring-pink-600/20",
+  uniswap: "bg-fuchsia-50 text-fuchsia-700 ring-fuchsia-600/20",
 };
 
 export const VenueBadge = ({ dex }: { dex: Dex }) => (
   <span
-    className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ring-1 ring-inset ${styles[dex]}`}
+    className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${styles[dex]}`}
   >
-    {dex}
+    {dexLabels[dex]}
   </span>
 );

--- a/internal-dashboard/src/config/chain.ts
+++ b/internal-dashboard/src/config/chain.ts
@@ -15,13 +15,21 @@ const sushiTokenIconUrl = function (address: Address) {
   }
 };
 
+const uniswapTokenIconUrl = (address: Address) =>
+  `https://cdn.jsdelivr.net/gh/Uniswap/assets@master/blockchains/ethereum/assets/${getAddress(address)}/logo.png`;
+
 // The venue's own asset CDN, used as a fallback when a token isn't in the Hemilabs
 // token list. Returns a 404 (handled by the icon component) for unknown tokens.
+const iconUrlByDex: Record<Dex, (address: Address) => string | undefined> = {
+  curve: curveTokenIconUrl,
+  sushi: sushiTokenIconUrl,
+  uniswap: uniswapTokenIconUrl,
+};
+
 export const dexTokenIconUrl = ({
   address,
   dex,
 }: {
   address: Address;
   dex: Dex;
-}) =>
-  dex === "sushi" ? sushiTokenIconUrl(address) : curveTokenIconUrl(address);
+}) => iconUrlByDex[dex](address);

--- a/internal-dashboard/src/config/dexes.ts
+++ b/internal-dashboard/src/config/dexes.ts
@@ -1,5 +1,11 @@
-// Supported DEX venues. To start tracking another, add its id to `Dex` and a
-// pool source under fetchers/ that the aggregator merges in. Pools carry their
-// `dex` so the UI can label and group by venue without hard-coding Curve; the
-// id doubles as the display label (capitalized via CSS).
-export type Dex = "curve" | "sushi";
+// Supported DEX venues. To start tracking another, add its id to `Dex`, its
+// display label to `dexLabels`, and a pool source under fetchers/ that the
+// aggregator merges in. Pools carry their `dex` so the UI can label and group by
+// venue without hard-coding Curve.
+export type Dex = "curve" | "sushi" | "uniswap";
+
+export const dexLabels: Record<Dex, string> = {
+  curve: "Curve",
+  sushi: "Sushi",
+  uniswap: "Uniswap",
+};

--- a/internal-dashboard/src/config/uniswap.ts
+++ b/internal-dashboard/src/config/uniswap.ts
@@ -1,0 +1,9 @@
+import { type Address } from "viem";
+
+// Uniswap's V3 factory on Ethereum mainnet.
+export const uniswapV3FactoryAddress: Address =
+  "0x1F98431c8aD98523631AE4a59f267346ea31F984";
+
+// The fee tiers enabled on mainnet, in hundredths of a bip: 0.01%, 0.05%, 0.3%
+// and 1%. A pool exists per pair *and* tier, so discovery asks for all four.
+export const uniswapV3FeeTiers = [100, 500, 3000, 10000];

--- a/internal-dashboard/src/fetchers/fetchTrackedPools.ts
+++ b/internal-dashboard/src/fetchers/fetchTrackedPools.ts
@@ -5,6 +5,7 @@ import { type TrackedPool } from "../lib/types";
 
 import { fetchCurvePools } from "./fetchCurvePools";
 import { fetchSushiPools } from "./fetchSushiPools";
+import { fetchUniswapPools } from "./fetchUniswapPools";
 
 export const fetchTrackedPools = async function (
   queryClient: QueryClient,
@@ -20,6 +21,7 @@ export const fetchTrackedPools = async function (
   const results = await Promise.allSettled([
     fetchCurvePools(trackedAddresses),
     fetchSushiPools(trackedAddresses),
+    fetchUniswapPools(queryClient),
   ]);
 
   const fulfilled = results.filter(

--- a/internal-dashboard/src/fetchers/fetchUniswapPools.ts
+++ b/internal-dashboard/src/fetchers/fetchUniswapPools.ts
@@ -1,0 +1,83 @@
+import { type QueryClient } from "@tanstack/react-query";
+import { type Address, formatUnits, parseUnits } from "viem";
+
+import { trackedTokensOptions } from "../hooks/useTrackedTokens";
+import { whitelistedTokensOptions } from "../hooks/useWhitelistedTokens";
+import { type PoolCoin, type TrackedPool } from "../lib/types";
+import { fetchUniswapPoolData } from "../lib/uniswapApi";
+import { buildPoolQueries, findPools, type PoolQuery } from "../lib/uniswapV3";
+
+const fetchUniswapPool = async function (
+  pool: PoolQuery & { address: Address },
+): Promise<TrackedPool> {
+  const data = await fetchUniswapPoolData(pool.address);
+
+  const coins = [pool.token0, pool.token1].map(
+    (token, index): PoolCoin => ({
+      address: token.address,
+      balance: parseUnits(
+        data.supplies[index].toFixed(token.decimals),
+        token.decimals,
+      ),
+      decimals: token.decimals,
+      symbol: token.symbol,
+      usdPrice: data.usdPrices[index],
+    }),
+  );
+
+  // Uniswap's own TVL counts only the legs it can price, so it's the one figure
+  // that can't be taken as published; both legs are valued here instead.
+  const tvlUsd = coins.reduce(
+    (sum, coin) =>
+      sum + Number(formatUnits(coin.balance, coin.decimals)) * coin.usdPrice,
+    0,
+  );
+  // Uniswap publishes no fee figure, so it follows from the volume it does
+  // publish: the tier is charged on every swap's input.
+  const feesUsd24h = (data.volumeUsd24h * data.feeTier) / 1_000_000;
+
+  return {
+    address: pool.address,
+    baseApy: tvlUsd > 0 ? ((feesUsd24h * 365) / tvlUsd) * 100 : 0,
+    coins,
+    dex: "uniswap",
+    feesUsd24h,
+    gaugeAddress: undefined,
+    id: pool.address,
+    lpTokenAddress: undefined,
+    name: coins.map((coin) => coin.symbol).join("/"),
+    poolType: `Uniswap V3 · ${data.feeTier / 10_000}%`,
+    rewardApy: 0,
+    rewardApyMax: 0,
+    tvlUsd,
+    url: `https://app.uniswap.org/explore/pools/ethereum/${pool.address}`,
+    virtualPrice: 0,
+    volumeUsd24h: data.volumeUsd24h,
+  };
+};
+
+export const fetchUniswapPools = async function (queryClient: QueryClient) {
+  const [trackedTokens, whitelistedTokens] = await Promise.all([
+    queryClient.ensureQueryData(trackedTokensOptions()),
+    queryClient.ensureQueryData(whitelistedTokensOptions()),
+  ]);
+
+  const pools = await findPools(
+    buildPoolQueries({
+      candidates: [...trackedTokens, ...whitelistedTokens],
+      trackedAddresses: new Set(
+        trackedTokens.map((token) => token.address.toLowerCase()),
+      ),
+    }),
+  );
+
+  // Isolate per-pool failures so one pool Uniswap can't answer for doesn't drop
+  // the whole Uniswap source.
+  const results = await Promise.allSettled(pools.map(fetchUniswapPool));
+  return results
+    .filter(
+      (result): result is PromiseFulfilledResult<TrackedPool> =>
+        result.status === "fulfilled",
+    )
+    .map((result) => result.value);
+};

--- a/internal-dashboard/src/fetchers/fetchWhitelistedTokens.ts
+++ b/internal-dashboard/src/fetchers/fetchWhitelistedTokens.ts
@@ -1,0 +1,43 @@
+import { gateways } from "@vetro-protocol/gateway";
+import { getTreasury } from "@vetro-protocol/gateway/actions";
+import { getWhitelistedTokens } from "@vetro-protocol/treasury/actions";
+import { getAddress } from "viem";
+import { decimals, symbol } from "viem-erc20/actions";
+
+import { client } from "../lib/client";
+import { type WhitelistedToken } from "../lib/types";
+
+// Discovers the collateral each gateway accepts on-chain: gateway → treasury →
+// whitelisted tokens. Together with the tracked tokens these form the token
+// universe the Uniswap pool discovery pairs up (see fetchers/fetchUniswapPools);
+// they're the pools' counterparty legs, like the WBTC in vetBTC/WBTC.
+export const fetchWhitelistedTokens = async function (): Promise<
+  WhitelistedToken[]
+> {
+  const perGateway = await Promise.all(
+    gateways.map(async function (gateway) {
+      const treasuryAddress = getAddress(
+        await getTreasury(client, { address: gateway.address }),
+      );
+      const tokens = await getWhitelistedTokens(client, {
+        address: treasuryAddress,
+      });
+      return Promise.all(
+        tokens.map(async function (token) {
+          const address = getAddress(token);
+          const [tokenDecimals, tokenSymbol] = await Promise.all([
+            decimals(client, { address }),
+            symbol(client, { address }),
+          ]);
+          return {
+            address,
+            decimals: tokenDecimals,
+            symbol: tokenSymbol,
+          } satisfies WhitelistedToken;
+        }),
+      );
+    }),
+  );
+
+  return perGateway.flat();
+};

--- a/internal-dashboard/src/hooks/useWhitelistedTokens.ts
+++ b/internal-dashboard/src/hooks/useWhitelistedTokens.ts
@@ -1,0 +1,10 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { fetchWhitelistedTokens } from "../fetchers/fetchWhitelistedTokens";
+
+export const whitelistedTokensOptions = () =>
+  queryOptions({
+    queryFn: fetchWhitelistedTokens,
+    queryKey: ["whitelisted-tokens"],
+    staleTime: 10 * 60 * 1000,
+  });

--- a/internal-dashboard/src/index.ts
+++ b/internal-dashboard/src/index.ts
@@ -76,18 +76,18 @@ const scriptSrc = [
 const csp = [
   "base-uri 'none'",
   // The DEX tab reads Curve liquidity straight from the Curve API (pool list /
-  // volumes / gauges) and per-pool 24h fees from Curve's analytics API. Sushi
-  // pools come from Sushi's data API via the worker's own /api/sushi proxy, so
-  // they need no extra origin here ('self' covers it). Tracked-token discovery
-  // and share values are read on-chain from the mainnet RPC, and token USD
-  // prices come from the Portal API.
+  // volumes / gauges) and per-pool 24h fees from Curve's analytics API. Sushi and
+  // Uniswap pool data comes from their own APIs via the worker's /api/sushi and
+  // /api/uniswap proxies, so they need no extra origin here ('self' covers it).
+  // Token / pool discovery, pool balances and share values are read on-chain from
+  // the mainnet RPC, and token USD prices come from the Portal API.
   `connect-src 'self' https://api.curve.finance https://prices.curve.finance ${rpcConnectSrc} ${portalApiUrl}`,
   "default-src 'none'",
   "font-src 'self'",
   "form-action 'none'",
   "frame-ancestors 'none'",
   // Token logos come from the Hemilabs token list (GitHub Pages), falling back
-  // to the Curve/Sushi asset CDNs (jsDelivr).
+  // to the venues' asset CDNs — Curve, Sushi and Uniswap (all jsDelivr).
   "img-src 'self' data: https://hemilabs.github.io https://cdn.jsdelivr.net",
   `script-src ${scriptSrc}`,
   // Tailwind v4 injects styles via a <style> tag, so 'unsafe-inline' is needed.
@@ -116,30 +116,42 @@ const htmlHeaders = {
   "X-Frame-Options": "DENY",
 };
 
-// Sushi's data API rejects the deployed browser's cross-origin requests (they
-// work from localhost), so the worker forwards them server-side, where CORS
-// doesn't apply. Keep in sync with lib/sushiApi.ts, which posts to /api/sushi.
-const SUSHI_UPSTREAM = "https://production.data-gcp.sushi.com/graphql";
+const graphqlProxies: Record<
+  string,
+  { headers?: Record<string, string>; upstream: string }
+> = {
+  "/api/sushi": { upstream: "https://production.data-gcp.sushi.com/graphql" },
+  "/api/uniswap": {
+    headers: { origin: "https://app.uniswap.org" },
+    upstream: "https://interface.gateway.uniswap.org/v1/graphql",
+  },
+};
 
-const proxySushi = async function (request: Request) {
-  const upstream = await fetch(SUSHI_UPSTREAM, {
+const proxyGraphql = async function ({
+  headers,
+  request,
+  upstream,
+}: {
+  headers?: Record<string, string>;
+  request: Request;
+  upstream: string;
+}) {
+  const response = await fetch(upstream, {
     body: await request.text(),
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...headers },
     method: "POST",
   });
-  return new Response(upstream.body, {
+  return new Response(response.body, {
     headers: { "content-type": "application/json" },
-    status: upstream.status,
+    status: response.status,
   });
 };
 
 export default {
   async fetch(request: Request, env: Env) {
-    if (
-      request.method === "POST" &&
-      new URL(request.url).pathname === "/api/sushi"
-    ) {
-      return proxySushi(request);
+    const proxy = graphqlProxies[new URL(request.url).pathname];
+    if (request.method === "POST" && proxy) {
+      return proxyGraphql({ ...proxy, request });
     }
 
     const response = await env.ASSETS.fetch(request);

--- a/internal-dashboard/src/lib/types.ts
+++ b/internal-dashboard/src/lib/types.ts
@@ -67,6 +67,12 @@ export type TrackedToken = {
   symbol: string;
 };
 
+export type WhitelistedToken = {
+  address: Address;
+  decimals: number;
+  symbol: string;
+};
+
 export type GaugeEmission = {
   estCrvPerDay: number; // estimated CRV directed to this gauge per day
   inflationRate: number; // network-wide CRV emitted per second

--- a/internal-dashboard/src/lib/uniswapApi.ts
+++ b/internal-dashboard/src/lib/uniswapApi.ts
@@ -94,11 +94,16 @@ export const fetchUniswapPoolData = async function (
     headers: { "content-type": "application/json" },
     method: "POST",
   });
+  // GraphQL reports failures as a 200 with an `errors` array, which can arrive
+  // alongside a partially populated `data`; surface the real message rather than
+  // silently pricing the pool off whatever fields did come back.
+  if (body.errors?.length) {
+    const reason = body.errors.map((error) => error.message).join("; ");
+    throw new Error(`Uniswap API error for pool ${address}: ${reason}`);
+  }
   const pool = body.data?.v3Pool;
   if (!pool) {
-    const reason =
-      body.errors?.map((error) => error.message).join("; ") ?? "not found";
-    throw new Error(`Uniswap pool ${address}: ${reason}`);
+    throw new Error(`Uniswap pool ${address} not found`);
   }
   return {
     feeTier: pool.feeTier,

--- a/internal-dashboard/src/lib/uniswapApi.ts
+++ b/internal-dashboard/src/lib/uniswapApi.ts
@@ -1,0 +1,112 @@
+import fetch from "fetch-plus-plus";
+import { type Address } from "viem";
+
+const UNISWAP_API_URL = "/api/uniswap";
+
+const CHAIN = "ETHEREUM";
+
+const query = `
+  query V3Pool($address: String!, $chain: Chain!) {
+    v3Pool(address: $address, chain: $chain) {
+      feeTier
+      priceHistory(duration: WEEK) {
+        token1Price
+      }
+      token0 {
+        market(currency: USD) {
+          price {
+            value
+          }
+        }
+      }
+      token0Supply
+      token1 {
+        market(currency: USD) {
+          price {
+            value
+          }
+        }
+      }
+      token1Supply
+      volume24h: cumulativeVolume(duration: DAY) {
+        value
+      }
+    }
+  }
+`;
+
+type RawToken = { market: { price: { value: number } | null } | null };
+
+type RawV3Pool = {
+  feeTier: number;
+  priceHistory: { token1Price: number | null }[] | null;
+  token0: RawToken;
+  token0Supply: number | null;
+  token1: RawToken;
+  token1Supply: number | null;
+  volume24h: { value: number } | null;
+};
+
+type UniswapPoolData = {
+  feeTier: number; // hundredths of a bip (3000 = 0.3%)
+  supplies: [number, number]; // whole tokens held
+  usdPrices: [number, number];
+  volumeUsd24h: number;
+};
+
+const poolRate = function (history: RawV3Pool["priceHistory"]) {
+  const rates = (history ?? [])
+    .map((point) => point.token1Price ?? 0)
+    .filter((rate) => rate > 0);
+  return rates[rates.length - 1] ?? 0;
+};
+
+const resolvePrices = function ({
+  prices,
+  rate,
+}: {
+  prices: [number, number];
+  rate: number;
+}): [number, number] {
+  const [price0, price1] = prices;
+  if (rate <= 0) {
+    return prices;
+  }
+  if (price0 > 0 && price1 <= 0) {
+    return [price0, price0 / rate];
+  }
+  if (price1 > 0 && price0 <= 0) {
+    return [price1 * rate, price1];
+  }
+  return prices;
+};
+
+const tokenPrice = (token: RawToken) => token.market?.price?.value ?? 0;
+
+export const fetchUniswapPoolData = async function (
+  address: Address,
+): Promise<UniswapPoolData> {
+  const body: {
+    data?: { v3Pool: RawV3Pool | null };
+    errors?: { message: string }[];
+  } = await fetch(UNISWAP_API_URL, {
+    body: JSON.stringify({ query, variables: { address, chain: CHAIN } }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+  const pool = body.data?.v3Pool;
+  if (!pool) {
+    const reason =
+      body.errors?.map((error) => error.message).join("; ") ?? "not found";
+    throw new Error(`Uniswap pool ${address}: ${reason}`);
+  }
+  return {
+    feeTier: pool.feeTier,
+    supplies: [pool.token0Supply ?? 0, pool.token1Supply ?? 0],
+    usdPrices: resolvePrices({
+      prices: [tokenPrice(pool.token0), tokenPrice(pool.token1)],
+      rate: poolRate(pool.priceHistory),
+    }),
+    volumeUsd24h: pool.volume24h?.value ?? 0,
+  };
+};

--- a/internal-dashboard/src/lib/uniswapV3.ts
+++ b/internal-dashboard/src/lib/uniswapV3.ts
@@ -63,6 +63,10 @@ export const buildPoolQueries = function ({
 export const findPools = async function (queries: PoolQuery[]) {
   const addresses = await multicall(client, {
     allowFailure: false,
+    // One aggregate3 for every getPool. viem's 1024-byte default would split
+    // these into a dozen concurrent eth_calls, which the keyless public RPC
+    // rate-limits — and allowFailure: false turns a single rejected chunk into
+    // a total discovery failure.
     batchSize: 0,
     contracts: queries.map((query) => ({
       abi: factoryAbi,

--- a/internal-dashboard/src/lib/uniswapV3.ts
+++ b/internal-dashboard/src/lib/uniswapV3.ts
@@ -1,0 +1,78 @@
+import { type Address, isAddressEqual, zeroAddress } from "viem";
+import { multicall } from "viem/actions";
+
+import { uniswapV3FactoryAddress, uniswapV3FeeTiers } from "../config/uniswap";
+
+import { client } from "./client";
+
+const factoryAbi = [
+  {
+    inputs: [
+      { name: "tokenA", type: "address" },
+      { name: "tokenB", type: "address" },
+      { name: "fee", type: "uint24" },
+    ],
+    name: "getPool",
+    outputs: [{ name: "pool", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+// A pool's tokens travel with the query, so a discovered pool already knows what
+// it holds — no second lookup by address once the factory answers.
+type PoolToken = { address: Address; decimals: number; symbol: string };
+
+export type PoolQuery = { fee: number; token0: PoolToken; token1: PoolToken };
+
+export const buildPoolQueries = function ({
+  candidates,
+  trackedAddresses,
+}: {
+  candidates: PoolToken[];
+  trackedAddresses: Set<string>;
+}): PoolQuery[] {
+  const pairs = new Map(
+    candidates
+      .filter((candidate) =>
+        trackedAddresses.has(candidate.address.toLowerCase()),
+      )
+      .flatMap((tracked) =>
+        candidates
+          .filter(
+            (candidate) => !isAddressEqual(candidate.address, tracked.address),
+          )
+          .map(function (other) {
+            const [token0, token1] =
+              tracked.address.toLowerCase() < other.address.toLowerCase()
+                ? [tracked, other]
+                : [other, tracked];
+            return [
+              `${token0.address}-${token1.address}`.toLowerCase(),
+              { token0, token1 },
+            ];
+          }),
+      ),
+  );
+
+  return [...pairs.values()].flatMap((pair) =>
+    uniswapV3FeeTiers.map((fee) => ({ ...pair, fee })),
+  );
+};
+
+export const findPools = async function (queries: PoolQuery[]) {
+  const addresses = await multicall(client, {
+    allowFailure: false,
+    batchSize: 0,
+    contracts: queries.map((query) => ({
+      abi: factoryAbi,
+      address: uniswapV3FactoryAddress,
+      args: [query.token0.address, query.token1.address, query.fee],
+      functionName: "getPool",
+    })),
+  });
+
+  return queries
+    .map((query, index) => ({ ...query, address: addresses[index] }))
+    .filter((pool) => !isAddressEqual(pool.address, zeroAddress));
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       '@vetro-protocol/gateway':
         specifier: workspace:*
         version: link:../packages/gateway
+      '@vetro-protocol/treasury':
+        specifier: workspace:*
+        version: link:../packages/treasury
       crypto-shortener:
         specifier: 1.2.0
         version: 1.2.0
@@ -12198,7 +12201,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
 
   '@vitest/eslint-plugin@1.6.6(eslint@8.57.0)(typescript@6.0.2)(vitest@4.1.9)':
     dependencies:
@@ -14272,14 +14275,13 @@ snapshots:
       esquery: 1.7.0
       jsonc-eslint-parser: 2.4.2
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.53.1(eslint@8.57.0)(typescript@6.0.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14300,7 +14302,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
### Description

Adds Uniswap as a third DEX source in the internal dashboard, alongside Curve and Sushi, so the pools listed in #665 (WBTC/VUSD, vetBTC/WBTC, vetBTC/cbBTC, hemiBTC/vetBTC) show up in the DEX tab.

Pools are discovered on-chain rather than hardcoded: tracked tokens are paired against the collateral each gateway whitelists (gateway → treasury → `getWhitelistedTokens`) and looked up in the V3 factory across the four mainnet fee tiers. Per-pool supplies, token prices and 24h volume come from Uniswap's GraphQL API, reached through a new `/api/uniswap` worker proxy — the existing Sushi proxy generalized, since both upstreams reject the deployed browser's cross-origin requests.

Two figures are derived rather than taken as published: TVL, because Uniswap counts only the legs it can price, and 24h fees, which it doesn't expose at all and follow from volume × fee tier.

The Stats distribution cards now also carry a venue badge per pool, in the legend and in the pie tooltip, so it's clear which protocol each slice of a token's liquidity sits on.

### Screenshots

https://github.com/user-attachments/assets/760904e7-2737-471b-a51d-5b5c5f4711da

### Related issue(s)

Closes #665

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
