### PR TITLE
Add a swap mint-fee read command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -90,6 +90,7 @@ This is the list of commands available
 | Command                                                   | Reads            | Returns                                                                                                                                                                 |
 | --------------------------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `vetro-cli swap allowance --token <tok> --account <addr>` | `allowance`      | Gateway's spending allowance, in human units. `<tok>` may be a whitelisted token (swap-in) or a pegged token (one-step swap-out; the two-step queue needs no allowance) |
+| `vetro-cli swap mint-fee --token <tok>`                   | `getMintFee`     | Mint fee charged on a deposit of the whitelisted `<tok>`, in bps                                                                                                        |
 | `vetro-cli swap pegged-token --gateway <addr>`            | `getPeggedToken` | Gateway's pegged-token address                                                                                                                                          |
 | `vetro-cli swap treasury --gateway <addr>`                | `getTreasury`    | Gateway's treasury address                                                                                                                                              |
 

--- a/packages/cli/src/features/swap/commands/mintFee.ts
+++ b/packages/cli/src/features/swap/commands/mintFee.ts
@@ -1,0 +1,30 @@
+import { getMintFee } from "@vetro-protocol/gateway/actions";
+import { type Command } from "commander";
+
+import { type GlobalOptions, createVetroClient } from "../../../lib/client.js";
+import { printResult } from "../../../lib/output.js";
+import { resolveWhitelistedToken } from "../../../lib/tokens.js";
+
+export function register(swap: Command) {
+  swap
+    .command("mint-fee")
+    .description("Print the mint fee for a whitelisted token, in bps")
+    .requiredOption(
+      "--token <token>",
+      "Whitelisted token to deposit, by symbol or address",
+    )
+    .action(async function (options: { token: string }, command: Command) {
+      const { client } = await createVetroClient(
+        command.optsWithGlobals<GlobalOptions>(),
+      );
+      const token = await resolveWhitelistedToken({
+        client,
+        value: options.token,
+      });
+      const fee = await getMintFee(client, {
+        address: token.gatewayAddress,
+        token: token.address,
+      });
+      printResult(fee);
+    });
+}

--- a/packages/cli/src/features/swap/index.ts
+++ b/packages/cli/src/features/swap/index.ts
@@ -3,10 +3,11 @@ import { type Command } from "commander";
 import { register as allowance } from "./commands/allowance.js";
 import { register as approve } from "./commands/approve.js";
 import { register as mint } from "./commands/mint.js";
+import { register as mintFee } from "./commands/mintFee.js";
 import { register as peggedToken } from "./commands/peggedToken.js";
 import { register as treasury } from "./commands/treasury.js";
 
-const swapCommands = [allowance, approve, mint, peggedToken, treasury];
+const swapCommands = [allowance, approve, mint, mintFee, peggedToken, treasury];
 
 export function register(program: Command) {
   const swap = program

--- a/packages/cli/test/e2e/mintFee.test.ts
+++ b/packages/cli/test/e2e/mintFee.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, inject, it } from "vitest";
+
+import { runCli, runCliRaw, usdc, vusd } from "./helpers.js";
+
+describe("swap mint-fee", function () {
+  const rpcUrl = inject("anvilUrl");
+
+  const mintFeeOnFork = (extra: string[] = []) => [
+    "swap",
+    "mint-fee",
+    ...extra,
+    "--rpc-url",
+    rpcUrl,
+  ];
+
+  it("reads the mint fee by symbol", async function () {
+    const fee = await runCli(mintFeeOnFork(["--token", usdc.symbol]));
+    expect(fee).toMatch(/^\d+$/);
+  });
+
+  it("reads the mint fee by address", async function () {
+    const fee = await runCli(mintFeeOnFork(["--token", usdc.address]));
+    expect(fee).toMatch(/^\d+$/);
+  });
+
+  it("rejects a pegged token", async function () {
+    const { exitCode, stderr } = await runCliRaw(
+      mintFeeOnFork(["--token", vusd.symbol]),
+    );
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(stderr).error).toBe(
+      `Not a whitelisted token: "${vusd.symbol}"`,
+    );
+  });
+
+  it("rejects a missing --token", async function () {
+    const { exitCode, stderr } = await runCliRaw(mintFeeOnFork());
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("required option '--token <token>'");
+  });
+});


### PR DESCRIPTION
### Description

Adds `vetro-cli swap mint-fee --token <tok>`, a read command that returns the mint fee charged on a deposit of the given whitelisted token, in bps.

The gateway is inferred from `--token` via `resolveWhitelistedToken`, consistent with the other token-based swap commands, and the value is read with `getMintFee` from `@vetro-protocol/gateway/actions`. Passing a pegged token is rejected, since the mint fee is only defined for whitelisted (deposit) tokens.

E2E tests cover reading the fee by symbol and by address, rejecting a pegged token, and rejecting a missing `--token`. The command table in `packages/cli/README.md` is updated.

### Screenshots

N/A

### Related issue(s)

Related to #445

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.