### PR TITLE
Add target-yield-earn package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
     permissions:
       contents: read
       id-token: write # for npm provenance
+    # Once target-yield-earn package is ready to be published,
+    # add || startsWith(github.event.release.tag_name, 'target-yield-earn@')  below
     if: |
       startsWith(github.event.release.tag_name, 'bridge@')
       || startsWith(github.event.release.tag_name, 'earn@')

--- a/packages/target-yield-earn/README.md
+++ b/packages/target-yield-earn/README.md
@@ -1,0 +1,50 @@
+# @vetro-protocol/target-yield-earn
+
+Vetro Protocol target-yield earning vault actions for viem clients. The vault is an epoch-based ERC-7540 async vault over a pegged token (`VUSDx` over `VUSD` being the first instance): each epoch is a fixed term carrying a target yield, not a guaranteed return.
+
+## Installation
+
+```sh
+npm add @vetro-protocol/target-yield-earn viem
+```
+
+## Overview
+
+- Deposits and redemptions are asynchronous following ERC-7540.
+- The vault runs in epochs. Each epoch is a term with its own target APR, a max deposit cap, and an exit window at its end during which redeem requests are accepted. `getEpochId` returns the current epoch (`0n` when none has started yet).
+- The APR is a target, not a promise. It's set per epoch before that epoch starts and applies only to that term — nothing commits the vault to it beyond the current epoch — and the owner can terminate the vault once an epoch ends, after which yield stops accruing for good.
+- `minEpochDurationSeconds`, `minExitWindowSeconds` and `maxExitWindowSeconds` mirror the vault's hardcoded values. They're exported as seconds.
+
+## Usage
+
+```ts
+import {
+  getEpochId,
+  pendingDepositRequest,
+} from "@vetro-protocol/target-yield-earn/actions";
+import { createPublicClient, http } from "viem";
+import { hemi } from "viem/chains";
+
+const publicClient = createPublicClient({ chain: hemi, transport: http() });
+
+const vaultAddress = "0x...";
+
+// Current epoch, or 0n if the vault hasn't started one yet.
+const epochId = await getEpochId(publicClient, { address: vaultAddress });
+
+// Assets requested for deposit that the keeper hasn't fulfilled yet.
+const pendingAssets = await pendingDepositRequest(publicClient, {
+  address: vaultAddress,
+  controller: "0x...",
+  requestId: 0n,
+});
+```
+
+## API
+
+- Public actions (reads):
+  - `getEpochId(client, params)` — the current epoch id, `0n` when no epoch has started.
+  - `pendingDepositRequest(client, params)` — assets in an unfulfilled deposit request, re-exported from `viem-erc7540`.
+- `targetYieldEarnPublicActions()` — viem extension factory that wires the same actions onto a client via `.extend()`.
+- `targetYieldEarnVaultAbi` — the minimal ABI subset used by the package.
+- Constants: `maxExitWindowSeconds`, `minEpochDurationSeconds`, `minExitWindowSeconds`.

--- a/packages/target-yield-earn/package.json
+++ b/packages/target-yield-earn/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@vetro-protocol/target-yield-earn",
+  "version": "1.0.0",
+  "description": "Vetro Protocol target-yield earning vault actions for viem.",
+  "license": "MIT",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "_esm",
+    "_types",
+    "src"
+  ],
+  "repository": {
+    "directory": "packages/target-yield-earn",
+    "type": "git",
+    "url": "git+https://github.com/vetro-protocol/vetro-monorepo.git"
+  },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",
+    "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
+    "clean": "rm -rf ./_esm ./_types",
+    "prepack": "cp ../../LICENSE LICENSE",
+    "prepublishOnly": "pnpm clean && pnpm build:esm && pnpm build:types",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "viem-erc20": "2.2.0",
+    "viem-erc4626": "1.0.0",
+    "viem-erc7540": "1.0.0"
+  },
+  "devDependencies": {
+    "@tsconfig/node24": "24.0.4",
+    "@types/node": "24.1.0",
+    "@vitest/coverage-v8": "4.1.9",
+    "typescript": "5.9.3",
+    "viem": "2.44.4",
+    "vitest": "4.1.9"
+  },
+  "peerDependencies": {
+    "viem": "^2.x"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "default": "./_esm/index.js",
+        "types": "./_types/index.d.ts"
+      },
+      "./actions": {
+        "default": "./_esm/actions/index.js",
+        "types": "./_types/actions/index.d.ts"
+      },
+      "./package.json": "./package.json"
+    },
+    "main": "./_esm/index.js",
+    "provenance": true,
+    "types": "./_types/index.d.ts"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./actions": {
+      "types": "./src/actions/index.ts",
+      "default": "./src/actions/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false
+}

--- a/packages/target-yield-earn/src/abi/targetYieldEarnVaultAbi.ts
+++ b/packages/target-yield-earn/src/abi/targetYieldEarnVaultAbi.ts
@@ -1,0 +1,9 @@
+export const targetYieldEarnVaultAbi = [
+  {
+    inputs: [],
+    name: "epochId",
+    outputs: [{ type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;

--- a/packages/target-yield-earn/src/actions/index.ts
+++ b/packages/target-yield-earn/src/actions/index.ts
@@ -1,0 +1,1 @@
+export * from "./public/index.js";

--- a/packages/target-yield-earn/src/actions/public/getEpochId.ts
+++ b/packages/target-yield-earn/src/actions/public/getEpochId.ts
@@ -1,0 +1,33 @@
+import { type Address, type Client } from "viem";
+import { readContract } from "viem/actions";
+
+import { targetYieldEarnVaultAbi } from "../../abi/targetYieldEarnVaultAbi.js";
+import { isAddressValid } from "../../utils/isAddressValid.js";
+
+export async function getEpochId(
+  client: Client,
+  parameters: {
+    address: Address;
+  },
+) {
+  // Validate client
+  if (!client) {
+    throw new Error("Client is not defined");
+  }
+
+  // Validate parameters exist
+  if (!parameters) {
+    throw new Error("Parameters are required");
+  }
+
+  // Validate vault address
+  if (!isAddressValid(parameters.address)) {
+    throw new Error("Vault address is invalid");
+  }
+
+  return readContract(client, {
+    abi: targetYieldEarnVaultAbi,
+    address: parameters.address,
+    functionName: "epochId",
+  });
+}

--- a/packages/target-yield-earn/src/actions/public/index.ts
+++ b/packages/target-yield-earn/src/actions/public/index.ts
@@ -1,0 +1,4 @@
+// The vault is an ERC-7540 async vault, so we re-export the ERC-7540 reads it supports
+export { pendingDepositRequest } from "viem-erc7540/actions";
+
+export * from "./getEpochId.js";

--- a/packages/target-yield-earn/src/constants.ts
+++ b/packages/target-yield-earn/src/constants.ts
@@ -1,0 +1,7 @@
+// These are hardcoded in the VUSDx contract
+// 7 days
+export const maxExitWindowSeconds = 604_800n;
+// 15 days
+export const minEpochDurationSeconds = 1_296_000n;
+// 1 day
+export const minExitWindowSeconds = 86_400n;

--- a/packages/target-yield-earn/src/index.ts
+++ b/packages/target-yield-earn/src/index.ts
@@ -1,0 +1,20 @@
+import type { Client } from "viem";
+
+import { getEpochId, pendingDepositRequest } from "./actions/public/index.js";
+
+export { targetYieldEarnVaultAbi } from "./abi/targetYieldEarnVaultAbi.js";
+
+export {
+  maxExitWindowSeconds,
+  minEpochDurationSeconds,
+  minExitWindowSeconds,
+} from "./constants.js";
+
+// Export factory functions for .extend() pattern
+export const targetYieldEarnPublicActions = () => (client: Client) => ({
+  getEpochId: (params: Parameters<typeof getEpochId>[1]) =>
+    getEpochId(client, params),
+  pendingDepositRequest: (
+    params: Parameters<typeof pendingDepositRequest>[1],
+  ) => pendingDepositRequest(client, params),
+});

--- a/packages/target-yield-earn/src/utils/isAddressValid.ts
+++ b/packages/target-yield-earn/src/utils/isAddressValid.ts
@@ -1,0 +1,6 @@
+import { type Address, isAddress, isAddressEqual, zeroAddress } from "viem";
+
+export const isAddressValid = (
+  address: Address | undefined,
+): address is Address =>
+  !!address && isAddress(address) && !isAddressEqual(address, zeroAddress);

--- a/packages/target-yield-earn/test/public/getEpochId.test.ts
+++ b/packages/target-yield-earn/test/public/getEpochId.test.ts
@@ -1,0 +1,71 @@
+import { type Address, type Client, zeroAddress } from "viem";
+import { readContract } from "viem/actions";
+import { describe, expect, it, vi } from "vitest";
+
+import { getEpochId } from "../../src/actions/public/getEpochId";
+
+vi.mock("viem/actions", () => ({
+  readContract: vi.fn(),
+}));
+
+const validParameters = {
+  address: "0x1234567890123456789012345678901234567890" as Address,
+};
+
+// @ts-expect-error - We only create an empty client for testing purposes
+const client: Client = {};
+
+describe("getEpochId", function () {
+  it("should throw an error if client is not defined", async function () {
+    await expect(
+      // @ts-expect-error - Testing invalid input
+      getEpochId(undefined, validParameters),
+    ).rejects.toThrow("Client is not defined");
+  });
+
+  it("should throw an error if parameters are not provided", async function () {
+    // @ts-expect-error - Testing invalid input
+    await expect(getEpochId(client, undefined)).rejects.toThrow(
+      "Parameters are required",
+    );
+  });
+
+  it("should throw an error if the address is not valid", async function () {
+    const parameters = {
+      ...validParameters,
+      address: "invalid_address",
+    };
+    // @ts-expect-error - Testing invalid input
+    await expect(getEpochId(client, parameters)).rejects.toThrow(
+      "Vault address is invalid",
+    );
+  });
+
+  it("should throw an error if the address is not provided", async function () {
+    const parameters = {};
+    // @ts-expect-error - Testing invalid input
+    await expect(getEpochId(client, parameters)).rejects.toThrow(
+      "Vault address is invalid",
+    );
+  });
+
+  it("should throw an error if the address is zero address", async function () {
+    const parameters = {
+      address: zeroAddress,
+    };
+
+    await expect(getEpochId(client, parameters)).rejects.toThrow(
+      "Vault address is invalid",
+    );
+  });
+
+  it("should call readContract if all parameters are valid", async function () {
+    await getEpochId(client, validParameters);
+
+    expect(readContract).toHaveBeenCalledWith(client, {
+      abi: expect.anything(),
+      address: validParameters.address,
+      functionName: "epochId",
+    });
+  });
+});

--- a/packages/target-yield-earn/tsconfig.build.json
+++ b/packages/target-yield-earn/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/target-yield-earn/tsconfig.json
+++ b/packages/target-yield-earn/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "erasableSyntaxOnly": true,
+    "noEmit": true
+  },
+  "exclude": ["node_modules", "test/*"],
+  "extends": "@tsconfig/node24/tsconfig.json",
+  "include": ["**/*.ts"]
+}

--- a/packages/target-yield-earn/vitest.config.ts
+++ b/packages/target-yield-earn/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    clearMocks: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,37 @@ importers:
         specifier: 4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.0.9)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@25.0.9)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
 
+  packages/target-yield-earn:
+    dependencies:
+      viem-erc20:
+        specifier: 2.2.0
+        version: 2.2.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
+      viem-erc4626:
+        specifier: 1.0.0
+        version: 1.0.0(viem-erc20@2.2.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
+      viem-erc7540:
+        specifier: 1.0.0
+        version: 1.0.0(viem-erc20@2.2.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem-erc4626@1.0.0(viem-erc20@2.2.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
+    devDependencies:
+      '@tsconfig/node24':
+        specifier: 24.0.4
+        version: 24.0.4
+      '@types/node':
+        specifier: 24.1.0
+        version: 24.1.0
+      '@vitest/coverage-v8':
+        specifier: 4.1.9
+        version: 4.1.9(vitest@4.1.9)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      viem:
+        specifier: 2.44.4
+        version: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      vitest:
+        specifier: 4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+
   packages/treasury:
     devDependencies:
       '@tsconfig/node24':
@@ -591,10 +622,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==, tarball: https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==, tarball: https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz}
     engines: {node: '>=6.9.0'}
@@ -614,11 +641,6 @@ packages:
   '@babel/helpers@7.28.6':
     resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==, tarball: https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.28.6':
-    resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==, tarball: https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==, tarball: https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz}
@@ -643,10 +665,6 @@ packages:
 
   '@babel/traverse@7.28.6':
     resolution: {integrity: sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==, tarball: https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.6':
-    resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==, tarball: https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -8330,6 +8348,14 @@ packages:
       viem: ^2.x
       viem-erc20: ^2.x
 
+  viem-erc7540@1.0.0:
+    resolution: {integrity: sha512-cB4qiRzBZQIbm7RD1PrgZB8Kn2kWBRc4Mm8W+Q2cuwv65m/ZJ5a9Js87l5iLACIbSNxXFhZ/5hBl54oCv2Bp6g==, tarball: https://registry.npmjs.org/viem-erc7540/-/viem-erc7540-1.0.0.tgz}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      viem: ^2.x
+      viem-erc20: ^2.x
+      viem-erc4626: ^1.x
+
   viem@2.23.2:
     resolution: {integrity: sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA==, tarball: https://registry.npmjs.org/viem/-/viem-2.23.2.tgz}
     peerDependencies:
@@ -8836,10 +8862,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6)
       '@babel/helpers': 7.28.6
-      '@babel/parser': 7.28.6
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -8883,8 +8909,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -8896,10 +8920,6 @@ snapshots:
   '@babel/helpers@7.28.6':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.7
-
-  '@babel/parser@7.28.6':
-    dependencies:
       '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
@@ -8923,17 +8943,12 @@ snapshots:
       '@babel/code-frame': 7.28.6
       '@babel/generator': 7.28.6
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.6
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.7
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.28.6':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -17828,6 +17843,12 @@ snapshots:
     dependencies:
       viem: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       viem-erc20: 2.2.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
+
+  viem-erc7540@1.0.0(viem-erc20@2.2.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem-erc4626@1.0.0(viem-erc20@2.2.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)):
+    dependencies:
+      viem: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      viem-erc20: 2.2.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
+      viem-erc4626: 1.0.0(viem-erc20@2.2.0(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
 
   viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ minimumReleaseAgeExclude:
   - "eslint-config-bloq"
   - "viem-erc20"
   - "viem-erc4626"
+  - "viem-erc7540"
 
 onlyBuiltDependencies: []
 


### PR DESCRIPTION
### Description

Adds `@vetro-protocol/target-yield-earn`, the viem action package for the VUSDx epoch-based ERC-7540 async vault (`VUSDx` over `VUSD` being the first instance). It builds on [`viem-erc7540`](https://github.com/hemilabs/viem-erc7540), which landed earlier as the first checked item of #646.

What ships:

- `getEpochId(client, params)` — reads `epochId()`, the first entry of the read list in #646.
- `pendingDepositRequest` — re-exported from `viem-erc7540`, so the async-vault reads are reachable from one entry point.
- `targetYieldEarnVaultAbi` — the minimal ABI subset the package needs.
- `minEpochDurationSeconds`, `minExitWindowSeconds`, `maxExitWindowSeconds` — the contract's hardcoded bounds (`15 days` / `1 days` / `7 days`), exported as seconds.
- `targetYieldEarnPublicActions()` — the `.extend()` factory, matching the other `@vetro-protocol/*` packages.

The package is deliberately `"private": true` for now. `publishConfig` is in place, but the `publish.yml` allowlist entry is left commented out and `RELEASING.md` is untouched, so nothing reaches npm until we flip it on purpose.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #646

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
