### PR TITLE
Add currentRate read to target-yield-earn

### DIFF
--- a/packages/target-yield-earn/README.md
+++ b/packages/target-yield-earn/README.md
@@ -19,6 +19,7 @@ npm add @vetro-protocol/target-yield-earn viem
 
 ```ts
 import {
+  getCurrentRate,
   getEpochId,
   pendingDepositRequest,
 } from "@vetro-protocol/target-yield-earn/actions";
@@ -32,6 +33,9 @@ const vaultAddress = "0x...";
 // Current epoch, or 0n if the vault hasn't started one yet.
 const epochId = await getEpochId(publicClient, { address: vaultAddress });
 
+// Rate accruing now, WAD-scaled per annum. 0n outside an accrual interval.
+const rate = await getCurrentRate(publicClient, { address: vaultAddress });
+
 // Assets requested for deposit that the keeper hasn't fulfilled yet.
 const pendingAssets = await pendingDepositRequest(publicClient, {
   address: vaultAddress,
@@ -43,6 +47,7 @@ const pendingAssets = await pendingDepositRequest(publicClient, {
 ## API
 
 - Public actions (reads):
+  - `getCurrentRate(client, params)` — the rate currently accruing, WAD-scaled per annum, `0n` outside an accrual interval.
   - `getEpochId(client, params)` — the current epoch id, `0n` when no epoch has started.
   - `pendingDepositRequest(client, params)` — assets in an unfulfilled deposit request, re-exported from `viem-erc7540`.
 - `targetYieldEarnPublicActions()` — viem extension factory that wires the same actions onto a client via `.extend()`.

--- a/packages/target-yield-earn/src/abi/targetYieldEarnVaultAbi.ts
+++ b/packages/target-yield-earn/src/abi/targetYieldEarnVaultAbi.ts
@@ -1,6 +1,13 @@
 export const targetYieldEarnVaultAbi = [
   {
     inputs: [],
+    name: "currentRate",
+    outputs: [{ type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
     name: "epochId",
     outputs: [{ type: "uint256" }],
     stateMutability: "view",

--- a/packages/target-yield-earn/src/actions/public/getCurrentRate.ts
+++ b/packages/target-yield-earn/src/actions/public/getCurrentRate.ts
@@ -1,0 +1,33 @@
+import { type Address, type Client } from "viem";
+import { readContract } from "viem/actions";
+
+import { targetYieldEarnVaultAbi } from "../../abi/targetYieldEarnVaultAbi.js";
+import { isAddressValid } from "../../utils/isAddressValid.js";
+
+export async function getCurrentRate(
+  client: Client,
+  parameters: {
+    address: Address;
+  },
+) {
+  // Validate client
+  if (!client) {
+    throw new Error("Client is not defined");
+  }
+
+  // Validate parameters exist
+  if (!parameters) {
+    throw new Error("Parameters are required");
+  }
+
+  // Validate vault address
+  if (!isAddressValid(parameters.address)) {
+    throw new Error("Vault address is invalid");
+  }
+
+  return readContract(client, {
+    abi: targetYieldEarnVaultAbi,
+    address: parameters.address,
+    functionName: "currentRate",
+  });
+}

--- a/packages/target-yield-earn/src/actions/public/index.ts
+++ b/packages/target-yield-earn/src/actions/public/index.ts
@@ -1,4 +1,5 @@
 // The vault is an ERC-7540 async vault, so we re-export the ERC-7540 reads it supports
 export { pendingDepositRequest } from "viem-erc7540/actions";
 
+export * from "./getCurrentRate.js";
 export * from "./getEpochId.js";

--- a/packages/target-yield-earn/src/index.ts
+++ b/packages/target-yield-earn/src/index.ts
@@ -1,6 +1,10 @@
 import type { Client } from "viem";
 
-import { getEpochId, pendingDepositRequest } from "./actions/public/index.js";
+import {
+  getCurrentRate,
+  getEpochId,
+  pendingDepositRequest,
+} from "./actions/public/index.js";
 
 export { targetYieldEarnVaultAbi } from "./abi/targetYieldEarnVaultAbi.js";
 
@@ -12,6 +16,8 @@ export {
 
 // Export factory functions for .extend() pattern
 export const targetYieldEarnPublicActions = () => (client: Client) => ({
+  getCurrentRate: (params: Parameters<typeof getCurrentRate>[1]) =>
+    getCurrentRate(client, params),
   getEpochId: (params: Parameters<typeof getEpochId>[1]) =>
     getEpochId(client, params),
   pendingDepositRequest: (

--- a/packages/target-yield-earn/test/public/getCurrentRate.test.ts
+++ b/packages/target-yield-earn/test/public/getCurrentRate.test.ts
@@ -1,0 +1,71 @@
+import { type Address, type Client, zeroAddress } from "viem";
+import { readContract } from "viem/actions";
+import { describe, expect, it, vi } from "vitest";
+
+import { getCurrentRate } from "../../src/actions/public/getCurrentRate";
+
+vi.mock("viem/actions", () => ({
+  readContract: vi.fn(),
+}));
+
+const validParameters = {
+  address: "0x1234567890123456789012345678901234567890" as Address,
+};
+
+// @ts-expect-error - We only create an empty client for testing purposes
+const client: Client = {};
+
+describe("getCurrentRate", function () {
+  it("should throw an error if client is not defined", async function () {
+    await expect(
+      // @ts-expect-error - Testing invalid input
+      getCurrentRate(undefined, validParameters),
+    ).rejects.toThrow("Client is not defined");
+  });
+
+  it("should throw an error if parameters are not provided", async function () {
+    // @ts-expect-error - Testing invalid input
+    await expect(getCurrentRate(client, undefined)).rejects.toThrow(
+      "Parameters are required",
+    );
+  });
+
+  it("should throw an error if the address is not valid", async function () {
+    const parameters = {
+      ...validParameters,
+      address: "invalid_address",
+    };
+    // @ts-expect-error - Testing invalid input
+    await expect(getCurrentRate(client, parameters)).rejects.toThrow(
+      "Vault address is invalid",
+    );
+  });
+
+  it("should throw an error if the address is not provided", async function () {
+    const parameters = {};
+    // @ts-expect-error - Testing invalid input
+    await expect(getCurrentRate(client, parameters)).rejects.toThrow(
+      "Vault address is invalid",
+    );
+  });
+
+  it("should throw an error if the address is zero address", async function () {
+    const parameters = {
+      address: zeroAddress,
+    };
+
+    await expect(getCurrentRate(client, parameters)).rejects.toThrow(
+      "Vault address is invalid",
+    );
+  });
+
+  it("should call readContract if all parameters are valid", async function () {
+    await getCurrentRate(client, validParameters);
+
+    expect(readContract).toHaveBeenCalledWith(client, {
+      abi: expect.anything(),
+      address: validParameters.address,
+      functionName: "currentRate",
+    });
+  });
+});


### PR DESCRIPTION
### Description

Adds `getCurrentRate` to `@vetro-protocol/target-yield-earn`, wrapping the vault's `currentRate()` read. It returns the WAD-scaled per-annum rate accruing right now (`1e18` = 100%), and `0n` whenever the vault is outside an accrual interval — before the first epoch starts, or between epochs.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #646

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
