### PR TITLE
Add maxRequestDeposit read to target-yield-earn

### DIFF
--- a/packages/target-yield-earn/README.md
+++ b/packages/target-yield-earn/README.md
@@ -21,6 +21,7 @@ npm add @vetro-protocol/target-yield-earn viem
 import {
   getCurrentRate,
   getEpochId,
+  getMaxRequestDeposit,
   pendingDepositRequest,
 } from "@vetro-protocol/target-yield-earn/actions";
 import { createPublicClient, http } from "viem";
@@ -36,6 +37,12 @@ const epochId = await getEpochId(publicClient, { address: vaultAddress });
 // Rate accruing now, WAD-scaled per annum. 0n outside an accrual interval.
 const rate = await getCurrentRate(publicClient, { address: vaultAddress });
 
+// Max amount of assets this controller can still request for deposit.
+const maxAssets = await getMaxRequestDeposit(publicClient, {
+  address: vaultAddress,
+  controller: "0x...",
+});
+
 // Assets requested for deposit that the keeper hasn't fulfilled yet.
 const pendingAssets = await pendingDepositRequest(publicClient, {
   address: vaultAddress,
@@ -49,6 +56,7 @@ const pendingAssets = await pendingDepositRequest(publicClient, {
 - Public actions (reads):
   - `getCurrentRate(client, params)` — the rate currently accruing, WAD-scaled per annum, `0n` outside an accrual interval.
   - `getEpochId(client, params)` — the current epoch id, `0n` when no epoch has started.
+  - `getMaxRequestDeposit(client, params)` — the assets the controller can still request for deposit, capped by the epoch's remaining deposit capacity. `0n` whenever a deposit request would revert — outside the entry window, while paused, shutdown or terminated, or when the controller has a pending request from an earlier epoch.
   - `pendingDepositRequest(client, params)` — assets in an unfulfilled deposit request, re-exported from `viem-erc7540`.
 - `targetYieldEarnPublicActions()` — viem extension factory that wires the same actions onto a client via `.extend()`.
 - `targetYieldEarnVaultAbi` — the minimal ABI subset used by the package.

--- a/packages/target-yield-earn/src/abi/targetYieldEarnVaultAbi.ts
+++ b/packages/target-yield-earn/src/abi/targetYieldEarnVaultAbi.ts
@@ -13,4 +13,11 @@ export const targetYieldEarnVaultAbi = [
     stateMutability: "view",
     type: "function",
   },
+  {
+    inputs: [{ name: "controller_", type: "address" }],
+    name: "maxRequestDeposit",
+    outputs: [{ type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
 ] as const;

--- a/packages/target-yield-earn/src/actions/public/getMaxRequestDeposit.ts
+++ b/packages/target-yield-earn/src/actions/public/getMaxRequestDeposit.ts
@@ -1,0 +1,36 @@
+import { type Address, type Client } from "viem";
+import { readContract } from "viem/actions";
+
+import { targetYieldEarnVaultAbi } from "../../abi/targetYieldEarnVaultAbi.js";
+import { isAddressValid } from "../../utils/isAddressValid.js";
+
+export async function getMaxRequestDeposit(
+  client: Client,
+  parameters: {
+    address: Address;
+    controller: Address;
+  },
+) {
+  if (!client) {
+    throw new Error("Client is not defined");
+  }
+
+  if (!parameters) {
+    throw new Error("Parameters are required");
+  }
+
+  if (!isAddressValid(parameters.address)) {
+    throw new Error("Vault address is invalid");
+  }
+
+  if (!isAddressValid(parameters.controller)) {
+    throw new Error("Controller address is invalid");
+  }
+
+  return readContract(client, {
+    abi: targetYieldEarnVaultAbi,
+    address: parameters.address,
+    args: [parameters.controller],
+    functionName: "maxRequestDeposit",
+  });
+}

--- a/packages/target-yield-earn/src/actions/public/index.ts
+++ b/packages/target-yield-earn/src/actions/public/index.ts
@@ -3,3 +3,4 @@ export { pendingDepositRequest } from "viem-erc7540/actions";
 
 export * from "./getCurrentRate.js";
 export * from "./getEpochId.js";
+export * from "./getMaxRequestDeposit.js";

--- a/packages/target-yield-earn/src/index.ts
+++ b/packages/target-yield-earn/src/index.ts
@@ -3,6 +3,7 @@ import type { Client } from "viem";
 import {
   getCurrentRate,
   getEpochId,
+  getMaxRequestDeposit,
   pendingDepositRequest,
 } from "./actions/public/index.js";
 
@@ -20,6 +21,8 @@ export const targetYieldEarnPublicActions = () => (client: Client) => ({
     getCurrentRate(client, params),
   getEpochId: (params: Parameters<typeof getEpochId>[1]) =>
     getEpochId(client, params),
+  getMaxRequestDeposit: (params: Parameters<typeof getMaxRequestDeposit>[1]) =>
+    getMaxRequestDeposit(client, params),
   pendingDepositRequest: (
     params: Parameters<typeof pendingDepositRequest>[1],
   ) => pendingDepositRequest(client, params),

--- a/packages/target-yield-earn/test/public/getMaxRequestDeposit.test.ts
+++ b/packages/target-yield-earn/test/public/getMaxRequestDeposit.test.ts
@@ -1,0 +1,108 @@
+import { type Address, type Client, zeroAddress } from "viem";
+import { readContract } from "viem/actions";
+import { describe, expect, it, vi } from "vitest";
+
+import { getMaxRequestDeposit } from "../../src/actions/public/getMaxRequestDeposit";
+
+vi.mock("viem/actions", () => ({
+  readContract: vi.fn(),
+}));
+
+const validParameters = {
+  address: "0x1234567890123456789012345678901234567890" as Address,
+  controller: "0x0987654321098765432109876543210987654321" as Address,
+};
+
+// @ts-expect-error - We only create an empty client for testing purposes
+const client: Client = {};
+
+describe("getMaxRequestDeposit", function () {
+  it("should throw an error if client is not defined", async function () {
+    await expect(
+      // @ts-expect-error - Testing invalid input
+      getMaxRequestDeposit(undefined, validParameters),
+    ).rejects.toThrow("Client is not defined");
+  });
+
+  it("should throw an error if parameters are not provided", async function () {
+    // @ts-expect-error - Testing invalid input
+    await expect(getMaxRequestDeposit(client, undefined)).rejects.toThrow(
+      "Parameters are required",
+    );
+  });
+
+  it("should throw an error if the address is not valid", async function () {
+    const parameters = {
+      ...validParameters,
+      address: "invalid_address",
+    };
+    // @ts-expect-error - Testing invalid input
+    await expect(getMaxRequestDeposit(client, parameters)).rejects.toThrow(
+      "Vault address is invalid",
+    );
+  });
+
+  it("should throw an error if the address is not provided", async function () {
+    const parameters = {
+      controller: validParameters.controller,
+    };
+    // @ts-expect-error - Testing invalid input
+    await expect(getMaxRequestDeposit(client, parameters)).rejects.toThrow(
+      "Vault address is invalid",
+    );
+  });
+
+  it("should throw an error if the address is zero address", async function () {
+    const parameters = {
+      ...validParameters,
+      address: zeroAddress,
+    };
+
+    await expect(getMaxRequestDeposit(client, parameters)).rejects.toThrow(
+      "Vault address is invalid",
+    );
+  });
+
+  it("should throw an error if the controller is not valid", async function () {
+    const parameters = {
+      ...validParameters,
+      controller: "invalid_address",
+    };
+    // @ts-expect-error - Testing invalid input
+    await expect(getMaxRequestDeposit(client, parameters)).rejects.toThrow(
+      "Controller address is invalid",
+    );
+  });
+
+  it("should throw an error if the controller is not provided", async function () {
+    const parameters = {
+      address: validParameters.address,
+    };
+    // @ts-expect-error - Testing invalid input
+    await expect(getMaxRequestDeposit(client, parameters)).rejects.toThrow(
+      "Controller address is invalid",
+    );
+  });
+
+  it("should throw an error if the controller is zero address", async function () {
+    const parameters = {
+      ...validParameters,
+      controller: zeroAddress,
+    };
+
+    await expect(getMaxRequestDeposit(client, parameters)).rejects.toThrow(
+      "Controller address is invalid",
+    );
+  });
+
+  it("should call readContract if all parameters are valid", async function () {
+    await getMaxRequestDeposit(client, validParameters);
+
+    expect(readContract).toHaveBeenCalledWith(client, {
+      abi: expect.anything(),
+      address: validParameters.address,
+      args: [validParameters.controller],
+      functionName: "maxRequestDeposit",
+    });
+  });
+});


### PR DESCRIPTION
### Description

Adds `getMaxRequestDeposit` to `@vetro-protocol/target-yield-earn`, wrapping the epoch vault's `maxRequestDeposit(controller)` view.

It returns the assets a controller can still request for deposit, capped by the epoch's remaining capacity (`maxDeposits - deposits`), and `0` whenever a `requestDeposit` call would revert — outside the entry window, while paused/shutdown/terminated, or when the controller has a pending request from an earlier epoch.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #646

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
