### PR TITLE
Add maxRequestRedeem read to target-yield-earn

### DIFF
--- a/packages/target-yield-earn/README.md
+++ b/packages/target-yield-earn/README.md
@@ -22,6 +22,7 @@ import {
   getCurrentRate,
   getEpochId,
   getMaxRequestDeposit,
+  getMaxRequestRedeem,
   pendingDepositRequest,
 } from "@vetro-protocol/target-yield-earn/actions";
 import { createPublicClient, http } from "viem";
@@ -43,6 +44,12 @@ const maxAssets = await getMaxRequestDeposit(publicClient, {
   controller: "0x...",
 });
 
+// Max amount of shares this owner can still request for redemption.
+const maxShares = await getMaxRequestRedeem(publicClient, {
+  address: vaultAddress,
+  owner: "0x...",
+});
+
 // Assets requested for deposit that the keeper hasn't fulfilled yet.
 const pendingAssets = await pendingDepositRequest(publicClient, {
   address: vaultAddress,
@@ -57,6 +64,7 @@ const pendingAssets = await pendingDepositRequest(publicClient, {
   - `getCurrentRate(client, params)` — the rate currently accruing, WAD-scaled per annum, `0n` outside an accrual interval.
   - `getEpochId(client, params)` — the current epoch id, `0n` when no epoch has started.
   - `getMaxRequestDeposit(client, params)` — the assets the controller can still request for deposit, capped by the epoch's remaining deposit capacity. `0n` whenever a deposit request would revert — outside the entry window, while paused, shutdown or terminated, or when the controller has a pending request from an earlier epoch.
+  - `getMaxRequestRedeem(client, params)` — the shares the owner can still request for redemption. `0n` whenever a redeem request would revert — outside the exit window, while shutdown, or when a redeem batch from an earlier epoch is still pending and the vault hasn't terminated.
   - `pendingDepositRequest(client, params)` — assets in an unfulfilled deposit request, re-exported from `viem-erc7540`.
 - `targetYieldEarnPublicActions()` — viem extension factory that wires the same actions onto a client via `.extend()`.
 - `targetYieldEarnVaultAbi` — the minimal ABI subset used by the package.

--- a/packages/target-yield-earn/src/abi/targetYieldEarnVaultAbi.ts
+++ b/packages/target-yield-earn/src/abi/targetYieldEarnVaultAbi.ts
@@ -20,4 +20,11 @@ export const targetYieldEarnVaultAbi = [
     stateMutability: "view",
     type: "function",
   },
+  {
+    inputs: [{ name: "owner_", type: "address" }],
+    name: "maxRequestRedeem",
+    outputs: [{ type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
 ] as const;

--- a/packages/target-yield-earn/src/actions/public/getMaxRequestRedeem.ts
+++ b/packages/target-yield-earn/src/actions/public/getMaxRequestRedeem.ts
@@ -1,0 +1,36 @@
+import { type Address, type Client } from "viem";
+import { readContract } from "viem/actions";
+
+import { targetYieldEarnVaultAbi } from "../../abi/targetYieldEarnVaultAbi.js";
+import { isAddressValid } from "../../utils/isAddressValid.js";
+
+export async function getMaxRequestRedeem(
+  client: Client,
+  parameters: {
+    address: Address;
+    owner: Address;
+  },
+) {
+  if (!client) {
+    throw new Error("Client is not defined");
+  }
+
+  if (!parameters) {
+    throw new Error("Parameters are required");
+  }
+
+  if (!isAddressValid(parameters.address)) {
+    throw new Error("Vault address is invalid");
+  }
+
+  if (!isAddressValid(parameters.owner)) {
+    throw new Error("Owner address is invalid");
+  }
+
+  return readContract(client, {
+    abi: targetYieldEarnVaultAbi,
+    address: parameters.address,
+    args: [parameters.owner],
+    functionName: "maxRequestRedeem",
+  });
+}

--- a/packages/target-yield-earn/src/actions/public/index.ts
+++ b/packages/target-yield-earn/src/actions/public/index.ts
@@ -4,3 +4,4 @@ export { pendingDepositRequest } from "viem-erc7540/actions";
 export * from "./getCurrentRate.js";
 export * from "./getEpochId.js";
 export * from "./getMaxRequestDeposit.js";
+export * from "./getMaxRequestRedeem.js";

--- a/packages/target-yield-earn/src/index.ts
+++ b/packages/target-yield-earn/src/index.ts
@@ -4,6 +4,7 @@ import {
   getCurrentRate,
   getEpochId,
   getMaxRequestDeposit,
+  getMaxRequestRedeem,
   pendingDepositRequest,
 } from "./actions/public/index.js";
 
@@ -23,6 +24,8 @@ export const targetYieldEarnPublicActions = () => (client: Client) => ({
     getEpochId(client, params),
   getMaxRequestDeposit: (params: Parameters<typeof getMaxRequestDeposit>[1]) =>
     getMaxRequestDeposit(client, params),
+  getMaxRequestRedeem: (params: Parameters<typeof getMaxRequestRedeem>[1]) =>
+    getMaxRequestRedeem(client, params),
   pendingDepositRequest: (
     params: Parameters<typeof pendingDepositRequest>[1],
   ) => pendingDepositRequest(client, params),

--- a/packages/target-yield-earn/test/public/getMaxRequestRedeem.test.ts
+++ b/packages/target-yield-earn/test/public/getMaxRequestRedeem.test.ts
@@ -1,0 +1,108 @@
+import { type Address, type Client, zeroAddress } from "viem";
+import { readContract } from "viem/actions";
+import { describe, expect, it, vi } from "vitest";
+
+import { getMaxRequestRedeem } from "../../src/actions/public/getMaxRequestRedeem";
+
+vi.mock("viem/actions", () => ({
+  readContract: vi.fn(),
+}));
+
+const validParameters = {
+  address: "0x1234567890123456789012345678901234567890" as Address,
+  owner: "0x0987654321098765432109876543210987654321" as Address,
+};
+
+// @ts-expect-error - We only create an empty client for testing purposes
+const client: Client = {};
+
+describe("getMaxRequestRedeem", function () {
+  it("should throw an error if client is not defined", async function () {
+    await expect(
+      // @ts-expect-error - Testing invalid input
+      getMaxRequestRedeem(undefined, validParameters),
+    ).rejects.toThrow("Client is not defined");
+  });
+
+  it("should throw an error if parameters are not provided", async function () {
+    // @ts-expect-error - Testing invalid input
+    await expect(getMaxRequestRedeem(client, undefined)).rejects.toThrow(
+      "Parameters are required",
+    );
+  });
+
+  it("should throw an error if the address is not valid", async function () {
+    const parameters = {
+      ...validParameters,
+      address: "invalid_address",
+    };
+    // @ts-expect-error - Testing invalid input
+    await expect(getMaxRequestRedeem(client, parameters)).rejects.toThrow(
+      "Vault address is invalid",
+    );
+  });
+
+  it("should throw an error if the address is not provided", async function () {
+    const parameters = {
+      owner: validParameters.owner,
+    };
+    // @ts-expect-error - Testing invalid input
+    await expect(getMaxRequestRedeem(client, parameters)).rejects.toThrow(
+      "Vault address is invalid",
+    );
+  });
+
+  it("should throw an error if the address is zero address", async function () {
+    const parameters = {
+      ...validParameters,
+      address: zeroAddress,
+    };
+
+    await expect(getMaxRequestRedeem(client, parameters)).rejects.toThrow(
+      "Vault address is invalid",
+    );
+  });
+
+  it("should throw an error if the owner is not valid", async function () {
+    const parameters = {
+      ...validParameters,
+      owner: "invalid_address",
+    };
+    // @ts-expect-error - Testing invalid input
+    await expect(getMaxRequestRedeem(client, parameters)).rejects.toThrow(
+      "Owner address is invalid",
+    );
+  });
+
+  it("should throw an error if the owner is not provided", async function () {
+    const parameters = {
+      address: validParameters.address,
+    };
+    // @ts-expect-error - Testing invalid input
+    await expect(getMaxRequestRedeem(client, parameters)).rejects.toThrow(
+      "Owner address is invalid",
+    );
+  });
+
+  it("should throw an error if the owner is zero address", async function () {
+    const parameters = {
+      ...validParameters,
+      owner: zeroAddress,
+    };
+
+    await expect(getMaxRequestRedeem(client, parameters)).rejects.toThrow(
+      "Owner address is invalid",
+    );
+  });
+
+  it("should call readContract if all parameters are valid", async function () {
+    await getMaxRequestRedeem(client, validParameters);
+
+    expect(readContract).toHaveBeenCalledWith(client, {
+      abi: expect.anything(),
+      address: validParameters.address,
+      args: [validParameters.owner],
+      functionName: "maxRequestRedeem",
+    });
+  });
+});


### PR DESCRIPTION
### Description

Adds `getMaxRequestRedeem` to `@vetro-protocol/target-yield-earn`, wrapping the epoch vault's `maxRequestRedeem(owner)` view.

It returns the shares an owner can still request for redemption — their share balance — and `0` whenever a `requestRedeem` call would revert: outside the exit window, while shutdown, or when a redeem batch from an earlier epoch is still pending and the vault hasn't terminated. Unlike the deposit read, it does not gate on `paused()`, and termination does not zero it.

The parameter is `owner` rather than the deposit read's `controller`, matching the contract, the spec, and `maxRedeem` in ERC-4626.

> [!NOTE]
> Stacked on #690 — based on `add-max-request-deposit`, so review that one first. The diff here is the second commit only.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #646

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
