### PR TITLE
Bump @tsconfig/vite-react to 8.1.1

### DIFF
--- a/internal-dashboard/package.json
+++ b/internal-dashboard/package.json
@@ -29,7 +29,7 @@
     "@cloudflare/workers-types": "4.20260504.1",
     "@tailwindcss/vite": "4.3.0",
     "@total-typescript/ts-reset": "0.6.1",
-    "@tsconfig/vite-react": "7.0.2",
+    "@tsconfig/vite-react": "8.1.1",
     "@types/node": "24.1.0",
     "@types/react": "19.2.9",
     "@types/react-dom": "19.2.3",

--- a/internal-dashboard/tsconfig.json
+++ b/internal-dashboard/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./src",
     "resolveJsonModule": true,
+    "strict": true,
     "types": ["node"]
   },
   "include": ["reset.d.ts", "src", "test"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: 0.6.1
         version: 0.6.1
       '@tsconfig/vite-react':
-        specifier: 7.0.2
-        version: 7.0.2
+        specifier: 8.1.1
+        version: 8.1.1
       '@types/node':
         specifier: 24.1.0
         version: 24.1.0
@@ -537,8 +537,8 @@ importers:
         specifier: 0.6.1
         version: 0.6.1
       '@tsconfig/vite-react':
-        specifier: 7.0.2
-        version: 7.0.2
+        specifier: 8.1.1
+        version: 8.1.1
       '@types/node':
         specifier: 24.1.0
         version: 24.1.0
@@ -3458,8 +3458,8 @@ packages:
   '@tsconfig/node24@24.0.4':
     resolution: {integrity: sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==, tarball: https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.4.tgz}
 
-  '@tsconfig/vite-react@7.0.2':
-    resolution: {integrity: sha512-lEj4y5SPRcH+bjw0tyuxrEnPqQUwfQzBKgd1YamD9xyet9zLwh2gwy5F8w/Nxg5DjdgYVjjKo5aLJUf0BTDz4w==, tarball: https://registry.npmjs.org/@tsconfig/vite-react/-/vite-react-7.0.2.tgz}
+  '@tsconfig/vite-react@8.1.1':
+    resolution: {integrity: sha512-TdLtRE9INt7aupEC2yhem6y4RN8T+B4oa2OUYsay0ioxSDl8Q4yaq0k2yc86Gb2BEHjKp4RUxgIzqOTk4IQ8dQ==, tarball: https://registry.npmjs.org/@tsconfig/vite-react/-/vite-react-8.1.1.tgz}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==, tarball: https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz}
@@ -11951,7 +11951,7 @@ snapshots:
 
   '@tsconfig/node24@24.0.4': {}
 
-  '@tsconfig/vite-react@7.0.2': {}
+  '@tsconfig/vite-react@8.1.1': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -12314,7 +12314,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
 
   '@vitest/eslint-plugin@1.6.6(eslint@8.57.0)(typescript@6.0.2)(vitest@4.1.9)':
     dependencies:
@@ -14390,13 +14390,14 @@ snapshots:
       esquery: 1.7.0
       jsonc-eslint-parser: 2.4.2
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.1(eslint@8.57.0)(typescript@6.0.2)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@6.0.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14417,7 +14418,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/web/package.json
+++ b/web/package.json
@@ -57,7 +57,7 @@
     "@storybook/react-vite": "10.4.6",
     "@tailwindcss/vite": "4.3.0",
     "@total-typescript/ts-reset": "0.6.1",
-    "@tsconfig/vite-react": "7.0.2",
+    "@tsconfig/vite-react": "8.1.1",
     "@types/node": "24.1.0",
     "@types/react": "19.2.9",
     "@types/react-dom": "19.2.3",

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./src",
     "resolveJsonModule": true,
+    "strict": true,
     "types": ["node"]
   },
   "include": [


### PR DESCRIPTION
### Description

Bumps `@tsconfig/vite-react` from 7.0.2 to 8.1.1 in `web` and `internal-dashboard`, the two workspaces that extend it.

The v8 base dropped `strict: true`. Neither app set it locally, so both silently lost strict mode — and without `strictNullChecks` viem's types collapse (`The intersection 'Client' was reduced to 'never'`), breaking `tsc` in both apps. Restoring `"strict": true` explicitly in each `tsconfig.json` is the whole fix.

Other changes in the base that turned out not to affect us:

- **`DOM.Iterable` dropped from `lib`** — would break `for...of` over `NodeList`/`FormData`/`Headers`. Nothing uses it; both apps typecheck clean without it.
- **`types: ["vite/client"]` added** — no effect, since both configs already override `types` with `["node"]` and reference `vite/client` from their own `src/vite-env.d.ts`.
- **`useDefineForClassFields: true` dropped** — TypeScript defaults it to `true` at target ES2022+; the resolved config still reports `true`.
- **`target`/`lib` → ES2023** — purely additive, and `noEmit: true` means Vite drives the real build target.

One deliberate omission: the base also dropped `noUncheckedSideEffectImports: true` and nothing restores it. It isn't build-breaking, so it fell outside the minimal upgrade, but `tsc --noUncheckedSideEffectImports` passes clean today if we want the check back in a follow-up.

`pnpm-lock.yaml` also carries a little incidental churn — `pnpm install` re-resolved two unrelated peer keys (a vitest `@types/node` peer, and `eslint-module-utils`' parser peer). That's pre-existing drift being normalized, not an effect of this bump.

Supply-chain note: the package ships four files (LICENSE, README, `package.json`, `tsconfig.json`) with no dependencies, no `bin`, and no install scripts. The full published diff is the version bump plus the compiler-option changes listed above.

### Screenshots

N/A — no UI changes.

### Related issue(s)

N/A — dependency maintenance.

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
