### PR TITLE
Fix TVL for Sushi price-band views

### DIFF
--- a/internal-dashboard/src/fetchers/fetchSushiPools.ts
+++ b/internal-dashboard/src/fetchers/fetchSushiPools.ts
@@ -3,7 +3,8 @@ import { formatUnits } from "viem";
 import { type SushiPoolConfig, sushiPools } from "../config/sushiPools";
 import { fetchSushiPoolData, type SushiToken } from "../lib/sushiApi";
 import { type PoolCoin, type TrackedPool } from "../lib/types";
-import { computeBandAmounts } from "../lib/v3PositionMath";
+import { fetchV3PoolState } from "../lib/v3PoolState";
+import { computeBandAmounts, priceToTick } from "../lib/v3PositionMath";
 
 const buildCoins = ({
   balances,
@@ -23,13 +24,14 @@ const buildCoins = ({
   }));
 
 // The Sushi implementation of a DEX pool source. One GraphQL call to Sushi's own
-// API (fetchSushiPoolData) supplies everything — token identity, balances, TVL,
-// prices, 24h volume / fees / APR, plus the pool's current liquidity / sqrt price
-// — so nothing is read on-chain. A configured price band's concentrated liquidity
-// is derived from that current liquidity with Uniswap's own Position math
-// (lib/v3PositionMath). USD prices anchor the reference leg (the non-tracked
-// stable) at $1 and take the tracked leg's price from the pool rate. Gauge
-// emissions aren't a Sushi concept, so that stays unset.
+// API (fetchSushiPoolData) supplies everything the whole-pool entry needs — token
+// identity, balances, TVL, prices, 24h volume / fees / APR. A configured price
+// band additionally needs the pool's liquidity spread across ticks, which no data
+// API publishes, so that much is read on-chain (lib/v3PoolState) and turned into
+// token amounts with Uniswap's own Position math (lib/v3PositionMath). USD prices
+// anchor the reference leg (the non-tracked stable) at $1 and take the tracked
+// leg's price from the pool rate. Gauge emissions aren't a Sushi concept, so that
+// stays unset.
 const fetchSushiPool = async function ({
   pool,
   trackedAddresses,
@@ -105,15 +107,34 @@ const fetchSushiPool = async function ({
     tvlUsd: data.liquidityUsd,
   });
 
-  // Each configured band: how much of the pool's current liquidity sits within
-  // it, from the pool's live liquidity / sqrt price (no chain reads needed).
-  const rangeEntries = (pool.ranges ?? []).map(function (range) {
+  const ranges = pool.ranges ?? [];
+  if (ranges.length === 0) {
+    return [fullEntry];
+  }
+
+  const decimals = {
+    decimals0: data.token0.decimals,
+    decimals1: data.token1.decimals,
+  };
+  // One read spanning every configured band, so they all value the same snapshot.
+  const poolState = await fetchV3PoolState({
+    lowerTick: priceToTick({
+      ...decimals,
+      price: Math.min(...ranges.map((range) => range.lowerPrice)),
+    }),
+    poolAddress: pool.address,
+    upperTick: priceToTick({
+      ...decimals,
+      price: Math.max(...ranges.map((range) => range.upperPrice)),
+    }),
+  });
+
+  // Each configured band: how much of the pool's liquidity sits within it.
+  const rangeEntries = ranges.map(function (range) {
     const { amount0, amount1 } = computeBandAmounts({
-      decimals0: data.token0.decimals,
-      decimals1: data.token1.decimals,
-      liquidity: data.liquidity,
+      ...decimals,
+      ...poolState,
       lowerPrice: range.lowerPrice,
-      sqrtPriceX96: data.sqrtPriceX96,
       upperPrice: range.upperPrice,
     });
     const coins = buildCoins({

--- a/internal-dashboard/src/lib/sushiApi.ts
+++ b/internal-dashboard/src/lib/sushiApi.ts
@@ -5,10 +5,9 @@ import { type Address } from "viem";
 // (https://www.sushi.com/ethereum/pool/v3/<address>). Direct browser calls fail
 // in the deployed environment (they work from localhost), so requests go through
 // the worker's /api/sushi proxy (src/index.ts), which forwards them server-side
-// and sidesteps the browser's cross-origin restrictions. Sushi is the single
-// source for everything the dashboard renders about a pool — including the
-// current liquidity / sqrt price the price-band views derive from — so nothing
-// is read on-chain.
+// and sidesteps the browser's cross-origin restrictions. Sushi is the source for
+// everything the dashboard renders about a whole pool; the per-tick liquidity a
+// price band needs isn't published here and is read on-chain (lib/v3PoolState).
 const SUSHI_API_URL = "/api/sushi";
 
 // Ethereum mainnet — everything the dashboard tracks lives here.
@@ -22,12 +21,10 @@ const query = `
       feeApr1d
       feeUSD1d
       incentiveApr
-      liquidity
       liquidityUSD
       name
       reserve0
       reserve1
-      sqrtPrice
       swapFee
       token0 {
         address
@@ -52,12 +49,10 @@ type RawV3Pool = {
   feeApr1d: number;
   feeUSD1d: number;
   incentiveApr: number;
-  liquidity: string;
   liquidityUSD: number;
   name: string;
   reserve0: string;
   reserve1: string;
-  sqrtPrice: string;
   swapFee: number;
   token0: SushiToken;
   token0Price: number;
@@ -69,13 +64,11 @@ type RawV3Pool = {
 type SushiPoolData = {
   baseApy: number; // % from trading fees
   feesUsd24h: number;
-  liquidity: bigint; // pool's current in-range liquidity (for band views)
   liquidityUsd: number; // whole-pool TVL, as Sushi values it
   name: string;
   reserve0: bigint; // raw balance of token0 held by the pool
   reserve1: bigint;
   rewardApy: number; // % from incentives
-  sqrtPriceX96: bigint; // current price as a Q64.96 sqrt ratio (for band views)
   swapFee: number; // fee tier as a fraction (0.0005 = 0.05%)
   token0: SushiToken;
   token0Price: number; // token0 per token1
@@ -113,13 +106,11 @@ export const fetchSushiPoolData = async function (
   return {
     baseApy: pool.feeApr1d * 100,
     feesUsd24h: pool.feeUSD1d,
-    liquidity: BigInt(pool.liquidity),
     liquidityUsd: pool.liquidityUSD,
     name: pool.name,
     reserve0: BigInt(pool.reserve0),
     reserve1: BigInt(pool.reserve1),
     rewardApy: pool.incentiveApr * 100,
-    sqrtPriceX96: BigInt(pool.sqrtPrice),
     swapFee: pool.swapFee,
     token0: pool.token0,
     token0Price: pool.token0Price,

--- a/internal-dashboard/src/lib/v3PoolState.ts
+++ b/internal-dashboard/src/lib/v3PoolState.ts
@@ -1,0 +1,164 @@
+import { type Address } from "viem";
+import { multicall } from "viem/actions";
+
+import { client } from "./client";
+import { type TickLiquidity } from "./v3PositionMath";
+
+// The Uniswap-v3 pool surface the band views need (SushiSwap V3 is a fork of it):
+// the current price and liquidity, plus the liquidity deltas of the initialized
+// ticks the band spans. No data API publishes the per-tick distribution, so this
+// is the one part of a Sushi pool read on-chain.
+const poolAbi = [
+  {
+    inputs: [],
+    name: "liquidity",
+    outputs: [{ name: "", type: "uint128" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "slot0",
+    outputs: [
+      { name: "sqrtPriceX96", type: "uint160" },
+      { name: "tick", type: "int24" },
+      { name: "observationIndex", type: "uint16" },
+      { name: "observationCardinality", type: "uint16" },
+      { name: "observationCardinalityNext", type: "uint16" },
+      { name: "feeProtocol", type: "uint8" },
+      { name: "unlocked", type: "bool" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ name: "wordPosition", type: "int16" }],
+    name: "tickBitmap",
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "tickSpacing",
+    outputs: [{ name: "", type: "int24" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ name: "tick", type: "int24" }],
+    name: "ticks",
+    outputs: [
+      { name: "liquidityGross", type: "uint128" },
+      { name: "liquidityNet", type: "int128" },
+      { name: "feeGrowthOutside0X128", type: "uint256" },
+      { name: "feeGrowthOutside1X128", type: "uint256" },
+      { name: "tickCumulativeOutside", type: "int56" },
+      { name: "secondsPerLiquidityOutsideX128", type: "uint160" },
+      { name: "secondsOutside", type: "uint32" },
+      { name: "initialized", type: "bool" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+const BITS_PER_WORD = 256;
+
+// A pool records which ticks are initialized in 256-bit words, indexed by the
+// tick divided by the pool's spacing.
+const wordPosition = ({ spacing, tick }: { spacing: number; tick: number }) =>
+  Math.floor(Math.floor(tick / spacing) / BITS_PER_WORD);
+
+const setBits = function (bitmap: bigint) {
+  const bits: number[] = [];
+  for (let bit = 0; bit < BITS_PER_WORD; bit++) {
+    if (((bitmap >> BigInt(bit)) & 1n) === 1n) {
+      bits.push(bit);
+    }
+  }
+  return bits;
+};
+
+// The pool state a price band is valued from. Only ticks within the range asked
+// for are read, so the result is valid for bands inside that range and no wider.
+// The range is widened to the current tick when the price sits outside it: the
+// walk that spreads liquidity across a band starts from the pool's reported
+// liquidity, which is the liquidity at the current tick.
+export const fetchV3PoolState = async function ({
+  lowerTick,
+  poolAddress,
+  upperTick,
+}: {
+  lowerTick: number;
+  poolAddress: Address;
+  upperTick: number;
+}) {
+  const [[sqrtPriceX96, currentTick], liquidity, spacing] = await multicall(
+    client,
+    {
+      allowFailure: false,
+      contracts: [
+        { abi: poolAbi, address: poolAddress, functionName: "slot0" },
+        { abi: poolAbi, address: poolAddress, functionName: "liquidity" },
+        { abi: poolAbi, address: poolAddress, functionName: "tickSpacing" },
+      ],
+    },
+  );
+
+  const firstWord = wordPosition({
+    spacing,
+    tick: Math.min(lowerTick, currentTick),
+  });
+  const lastWord = wordPosition({
+    spacing,
+    tick: Math.max(upperTick, currentTick),
+  });
+  const words = Array.from(
+    { length: lastWord - firstWord + 1 },
+    (_, index) => firstWord + index,
+  );
+
+  const bitmaps = await multicall(client, {
+    allowFailure: false,
+    // One aggregate3 for the whole set, matching findPools: viem's default
+    // byte-size batching would split these across concurrent eth_calls that the
+    // keyless public RPC rate-limits.
+    batchSize: 0,
+    contracts: words.map((word) => ({
+      abi: poolAbi,
+      address: poolAddress,
+      args: [word] as const,
+      functionName: "tickBitmap" as const,
+    })),
+  });
+
+  const ticks = words.flatMap((word, index) =>
+    setBits(bitmaps[index]).map(
+      (bit) => (word * BITS_PER_WORD + bit) * spacing,
+    ),
+  );
+
+  const tickData = await multicall(client, {
+    allowFailure: false,
+    batchSize: 0,
+    contracts: ticks.map((tick) => ({
+      abi: poolAbi,
+      address: poolAddress,
+      args: [tick] as const,
+      functionName: "ticks" as const,
+    })),
+  });
+
+  return {
+    currentTick,
+    initializedTicks: ticks.map(
+      (tick, index): TickLiquidity => ({
+        liquidityNet: tickData[index][1],
+        tick,
+      }),
+    ),
+    liquidity,
+    sqrtPriceX96,
+  };
+};

--- a/internal-dashboard/src/lib/v3PoolState.ts
+++ b/internal-dashboard/src/lib/v3PoolState.ts
@@ -1,5 +1,5 @@
 import { type Address } from "viem";
-import { multicall } from "viem/actions";
+import { getBlockNumber, multicall } from "viem/actions";
 
 import { client } from "./client";
 import { type TickLiquidity } from "./v3PositionMath";
@@ -94,10 +94,13 @@ export const fetchV3PoolState = async function ({
   poolAddress: Address;
   upperTick: number;
 }) {
+  const blockNumber = await getBlockNumber(client);
+
   const [[sqrtPriceX96, currentTick], liquidity, spacing] = await multicall(
     client,
     {
       allowFailure: false,
+      blockNumber,
       contracts: [
         { abi: poolAbi, address: poolAddress, functionName: "slot0" },
         { abi: poolAbi, address: poolAddress, functionName: "liquidity" },
@@ -121,6 +124,7 @@ export const fetchV3PoolState = async function ({
     // byte-size batching would split these across concurrent eth_calls that the
     // keyless public RPC rate-limits.
     batchSize: 0,
+    blockNumber,
     contracts: words.map((word) => ({
       abi: poolAbi,
       address: poolAddress,
@@ -142,6 +146,7 @@ export const fetchV3PoolState = async function ({
   const tickData = await multicall(client, {
     allowFailure: false,
     batchSize: 0,
+    blockNumber,
     contracts: ticks.map((tick) => ({
       abi: poolAbi,
       address: poolAddress,

--- a/internal-dashboard/src/lib/v3PoolState.ts
+++ b/internal-dashboard/src/lib/v3PoolState.ts
@@ -106,14 +106,10 @@ export const fetchV3PoolState = async function ({
     },
   );
 
-  const firstWord = wordPosition({
-    spacing,
-    tick: Math.min(lowerTick, currentTick),
-  });
-  const lastWord = wordPosition({
-    spacing,
-    tick: Math.max(upperTick, currentTick),
-  });
+  const firstTick = Math.min(lowerTick, currentTick);
+  const lastTick = Math.max(upperTick, currentTick);
+  const firstWord = wordPosition({ spacing, tick: firstTick });
+  const lastWord = wordPosition({ spacing, tick: lastTick });
   const words = Array.from(
     { length: lastWord - firstWord + 1 },
     (_, index) => firstWord + index,
@@ -133,11 +129,15 @@ export const fetchV3PoolState = async function ({
     })),
   });
 
-  const ticks = words.flatMap((word, index) =>
-    setBits(bitmaps[index]).map(
-      (bit) => (word * BITS_PER_WORD + bit) * spacing,
-    ),
-  );
+  // A word spans 256 ticks of spacing, so the outermost two reach past the range
+  // asked for; drop what they overshoot rather than read those ticks.
+  const ticks = words
+    .flatMap((word, index) =>
+      setBits(bitmaps[index]).map(
+        (bit) => (word * BITS_PER_WORD + bit) * spacing,
+      ),
+    )
+    .filter((tick) => tick >= firstTick && tick <= lastTick);
 
   const tickData = await multicall(client, {
     allowFailure: false,

--- a/internal-dashboard/src/lib/v3PositionMath.test.ts
+++ b/internal-dashboard/src/lib/v3PositionMath.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { computeBandAmounts } from "./v3PositionMath";
-
-// A real VUSD/USDT pool snapshot (18/6 decimals) with price ~ $1.
-const vusdUsdt = {
-  decimals0: 18,
-  decimals1: 6,
-  liquidity: 131831110600160155n,
-  sqrtPriceX96: 79293867267539787587777n,
-};
+import {
+  computeBandAmounts,
+  priceToTick,
+  type TickLiquidity,
+} from "./v3PositionMath";
 
 const TWO_POW_96 = 2 ** 96;
 const priceToSqrtX96 = ({
@@ -24,12 +20,75 @@ const priceToSqrtX96 = ({
     Math.floor(Math.sqrt(price * 10 ** (decimals1 - decimals0)) * TWO_POW_96),
   );
 
+// An 18/18 pool at exactly $1 whose whole liquidity is a single position ten
+// ticks wide (~$0.999 – $1.001).
+const positionLiquidity = 10n ** 24n;
+const narrowPool = {
+  currentTick: 0,
+  decimals0: 18,
+  decimals1: 18,
+  initializedTicks: [
+    { liquidityNet: positionLiquidity, tick: -10 },
+    { liquidityNet: -positionLiquidity, tick: 10 },
+  ],
+  liquidity: positionLiquidity,
+  sqrtPriceX96: priceToSqrtX96({ decimals0: 18, decimals1: 18, price: 1 }),
+};
+
+// A real VUSD/USDT snapshot (18/6 decimals) at ~$1.0007, taken with the pool
+// holding 26,484 VUSD and 31,660 USDT in ERC-20 balances.
+const vusdUsdt = {
+  currentTick: -276318,
+  decimals0: 18,
+  decimals1: 6,
+  initializedTicks: [
+    { liquidityNet: 15832704246747630n, tick: -278140 },
+    { liquidityNet: 6302778627602425n, tick: -277320 },
+    { liquidityNet: 130732401889084034n, tick: -276720 },
+    { liquidityNet: 456968676566802726n, tick: -276420 },
+    { liquidityNet: 946610042217059006n, tick: -276360 },
+    { liquidityNet: 1997166337273480336n, tick: -276340 },
+    { liquidityNet: 42575805005594985808n, tick: -276320 },
+    { liquidityNet: -44572971342868466144n, tick: -276310 },
+    { liquidityNet: -474186488246365959n, tick: -276300 },
+    { liquidityNet: -472423553970693047n, tick: -276270 },
+    { liquidityNet: -456968676566802726n, tick: -276220 },
+    { liquidityNet: -130732401889084034n, tick: -275920 },
+    { liquidityNet: -6302778627602425n, tick: -275370 },
+    { liquidityNet: -14034507619047145n, tick: -274840 },
+    { liquidityNet: -15832704246747630n, tick: -274500 },
+  ],
+  liquidity: 46144551162745885231n,
+  sqrtPriceX96: 79254568996878735356728n,
+};
+
+// A band no initialized tick falls inside: liquidity is uniform across it.
+const uniformPool = {
+  currentTick: priceToTick({ decimals0: 18, decimals1: 6, price: 1 }),
+  decimals0: 18,
+  decimals1: 6,
+  initializedTicks: [] as TickLiquidity[],
+  liquidity: 131831110600160155n,
+  sqrtPriceX96: priceToSqrtX96({ decimals0: 18, decimals1: 6, price: 1 }),
+};
+
+const atPrice = function <T extends { decimals0: number; decimals1: number }>(
+  pool: T,
+  price: number,
+) {
+  const { decimals0, decimals1 } = pool;
+  return {
+    ...pool,
+    currentTick: priceToTick({ decimals0, decimals1, price }),
+    sqrtPriceX96: priceToSqrtX96({ decimals0, decimals1, price }),
+  };
+};
+
 describe("computeBandAmounts", function () {
   it("holds only token0 when the price is below the band", function () {
     const { amount0, amount1 } = computeBandAmounts({
-      ...vusdUsdt,
+      ...atPrice(uniformPool, 0.5),
       lowerPrice: 0.96,
-      sqrtPriceX96: 1n, // far below the band
       upperPrice: 1.04,
     });
     expect(amount1).toBe(0n);
@@ -38,9 +97,8 @@ describe("computeBandAmounts", function () {
 
   it("holds only token1 when the price is above the band", function () {
     const { amount0, amount1 } = computeBandAmounts({
-      ...vusdUsdt,
+      ...atPrice(uniformPool, 2),
       lowerPrice: 0.96,
-      sqrtPriceX96: 2n ** 160n, // far above the band
       upperPrice: 1.04,
     });
     expect(amount0).toBe(0n);
@@ -49,29 +107,29 @@ describe("computeBandAmounts", function () {
 
   it("splits into both tokens when the price is inside the band", function () {
     const { amount0, amount1 } = computeBandAmounts({
-      ...vusdUsdt,
+      ...uniformPool,
       lowerPrice: 0.96,
       upperPrice: 1.04,
     });
     expect(amount0).toBeGreaterThan(0n);
     expect(amount1).toBeGreaterThan(0n);
-    // Sanity vs the known split (~2451 VUSD / ~2773 USDT).
+    // Sanity vs the known split (~2560 VUSD / ~2663 USDT).
     const vusd = Number(amount0) / 1e18;
     const usdt = Number(amount1) / 1e6;
-    expect(vusd).toBeGreaterThan(2400);
-    expect(vusd).toBeLessThan(2500);
-    expect(usdt).toBeGreaterThan(2700);
-    expect(usdt).toBeLessThan(2800);
+    expect(vusd).toBeGreaterThan(2500);
+    expect(vusd).toBeLessThan(2600);
+    expect(usdt).toBeGreaterThan(2600);
+    expect(usdt).toBeLessThan(2700);
   });
 
   it("holds more of each token in a wider band", function () {
     const narrow = computeBandAmounts({
-      ...vusdUsdt,
+      ...uniformPool,
       lowerPrice: 0.98,
       upperPrice: 1.02,
     });
     const wide = computeBandAmounts({
-      ...vusdUsdt,
+      ...uniformPool,
       lowerPrice: 0.9,
       upperPrice: 1.1,
     });
@@ -81,7 +139,7 @@ describe("computeBandAmounts", function () {
 
   it("splits evenly for a price-symmetric band at $1 (equal decimals)", function () {
     const { amount0, amount1 } = computeBandAmounts({
-      decimals0: 18,
+      ...uniformPool,
       decimals1: 18,
       liquidity: 10n ** 24n,
       lowerPrice: 0.5,
@@ -94,5 +152,80 @@ describe("computeBandAmounts", function () {
       amount0 > amount1 ? amount0 - amount1 : amount1 - amount0,
     );
     expect(diff / Number(amount0)).toBeLessThan(1e-4);
+  });
+
+  it("counts concentrated liquidity only where it is actually placed", function () {
+    const { amount0, amount1 } = computeBandAmounts({
+      ...narrowPool,
+      lowerPrice: 0.5,
+      upperPrice: 2,
+    });
+    // The pool's whole liquidity sits in a ten-tick position, so the band holds
+    // that position and nothing more — ~0.05% of what spreading the pool's
+    // current liquidity across the full band would claim.
+    const expected = Number(positionLiquidity) * (1 - 1 / 1.0001 ** 5);
+    expect(Number(amount0) / expected).toBeCloseTo(1, 3);
+    expect(Number(amount1) / expected).toBeCloseTo(1, 3);
+  });
+
+  it("stops growing once the band covers all the liquidity", function () {
+    const band = computeBandAmounts({
+      ...narrowPool,
+      lowerPrice: 0.5,
+      upperPrice: 2,
+    });
+    const wider = computeBandAmounts({
+      ...narrowPool,
+      lowerPrice: 0.1,
+      upperPrice: 10,
+    });
+    expect(wider.amount0).toBe(band.amount0);
+    expect(wider.amount1).toBe(band.amount1);
+  });
+
+  it("keeps a band within the pool's real balances", function () {
+    const { amount0, amount1 } = computeBandAmounts({
+      ...vusdUsdt,
+      lowerPrice: 0.96,
+      upperPrice: 1.04,
+    });
+    const vusd = Number(amount0) / 1e18;
+    const usdt = Number(amount1) / 1e6;
+    expect(vusd).toBeGreaterThan(23_000);
+    expect(vusd).toBeLessThan(26_484);
+    expect(usdt).toBeGreaterThan(15_000);
+    expect(usdt).toBeLessThan(31_660);
+  });
+
+  it("ignores initialized ticks outside the band", function () {
+    const band = { lowerPrice: 0.96, upperPrice: 1.04 };
+    const withDistantTicks = computeBandAmounts({
+      ...vusdUsdt,
+      ...band,
+      initializedTicks: [
+        { liquidityNet: 10n ** 30n, tick: -400_000 },
+        ...vusdUsdt.initializedTicks,
+        { liquidityNet: -(10n ** 30n), tick: -100_000 },
+      ],
+    });
+    // Only ticks between the band and the current price move the walk, which is
+    // what lets the on-chain read fetch a window rather than every tick.
+    expect(withDistantTicks).toEqual(
+      computeBandAmounts({ ...vusdUsdt, ...band }),
+    );
+  });
+
+  it("un-crosses ticks below the band when the price sits above it", function () {
+    const above = computeBandAmounts({
+      ...vusdUsdt,
+      lowerPrice: 0.96,
+      upperPrice: 0.99,
+    });
+    // Only the positions reaching down into $0.96–$0.99 are counted; spreading
+    // the liquidity active at the current price over that band instead would
+    // claim ~700k USDT.
+    expect(above.amount0).toBe(0n);
+    expect(Number(above.amount1) / 1e6).toBeGreaterThan(2000);
+    expect(Number(above.amount1) / 1e6).toBeLessThan(3000);
   });
 });

--- a/internal-dashboard/src/lib/v3PositionMath.test.ts
+++ b/internal-dashboard/src/lib/v3PositionMath.test.ts
@@ -139,11 +139,9 @@ describe("computeBandAmounts", function () {
 
   it("splits evenly for a price-symmetric band at $1 (equal decimals)", function () {
     const { amount0, amount1 } = computeBandAmounts({
-      ...uniformPool,
-      decimals1: 18,
+      ...atPrice({ ...uniformPool, decimals1: 18 }, 1),
       liquidity: 10n ** 24n,
       lowerPrice: 0.5,
-      sqrtPriceX96: priceToSqrtX96({ decimals0: 18, decimals1: 18, price: 1 }),
       upperPrice: 2,
     });
     // A band symmetric in price around the current price holds equal token

--- a/internal-dashboard/src/lib/v3PositionMath.ts
+++ b/internal-dashboard/src/lib/v3PositionMath.ts
@@ -19,6 +19,9 @@
 
 const Q96 = 2n ** 96n;
 
+// Ticks index the price grid as 1.0001^tick.
+const TICK_BASE = 1.0001;
+
 // SqrtPriceMath.getAmount0Delta (roundUp = false), verbatim.
 const getAmount0Delta = function (
   sqrtRatioAX96: bigint,
@@ -63,54 +66,96 @@ const priceToSqrtRatioX96 = function ({
   return BigInt(Math.floor(Math.sqrt(rawPrice) * 2 ** 96));
 };
 
-// Token amounts (raw units) the pool's current liquidity provides across a price
-// band, mirroring Position.amount0 / .amount1 with the band's sqrt-price bounds in
-// place of tick-derived ones. Assumes liquidity is uniform across the band (the
-// pool's current L) — an approximation for a dashboard readout, exact when the
-// band sits within one liquidity segment.
-export const computeBandAmounts = function ({
+const tickToSqrtRatioX96 = (tick: number) =>
+  BigInt(Math.floor(Math.sqrt(TICK_BASE ** tick) * 2 ** 96));
+
+// The tick whose price range contains a human price (token1 per token0).
+export const priceToTick = function ({
   decimals0,
   decimals1,
+  price,
+}: {
+  decimals0: number;
+  decimals1: number;
+  price: number;
+}) {
+  const rawPrice = price * 10 ** (decimals1 - decimals0);
+  return Math.floor(Math.log(rawPrice) / Math.log(TICK_BASE));
+};
+
+// How much liquidity enters (or leaves, when negative) as an initialized tick is
+// crossed upwards — the pool's `ticks(tick).liquidityNet`.
+export type TickLiquidity = { liquidityNet: bigint; tick: number };
+
+// Token amounts (raw units) the pool provides across a price band, mirroring
+// Position.amount0 / .amount1 with the band's sqrt-price bounds in place of
+// tick-derived ones. Liquidity is uniform only between initialized ticks, so the
+// band is cut at every one it contains and each slice is valued with the
+// liquidity actually active across it — the pool's current L covers only the
+// slice holding the current price.
+export const computeBandAmounts = function ({
+  currentTick,
+  decimals0,
+  decimals1,
+  initializedTicks,
   liquidity,
   lowerPrice,
   sqrtPriceX96,
   upperPrice,
 }: {
+  currentTick: number;
   decimals0: number;
   decimals1: number;
+  initializedTicks: TickLiquidity[];
   liquidity: bigint;
   lowerPrice: number;
   sqrtPriceX96: bigint;
   upperPrice: number;
 }): { amount0: bigint; amount1: bigint } {
-  const sqrtLowerX96 = priceToSqrtRatioX96({
-    decimals0,
-    decimals1,
-    price: lowerPrice,
-  });
-  const sqrtUpperX96 = priceToSqrtRatioX96({
-    decimals0,
-    decimals1,
-    price: upperPrice,
+  const lowerTick = priceToTick({ decimals0, decimals1, price: lowerPrice });
+  const upperTick = priceToTick({ decimals0, decimals1, price: upperPrice });
+
+  const sliceTicks = initializedTicks
+    .filter((entry) => entry.tick > lowerTick && entry.tick <= upperTick)
+    .sort((a, b) => a.tick - b.tick);
+
+  const bounds = [
+    priceToSqrtRatioX96({ decimals0, decimals1, price: lowerPrice }),
+    ...sliceTicks.map((entry) => tickToSqrtRatioX96(entry.tick)),
+    priceToSqrtRatioX96({ decimals0, decimals1, price: upperPrice }),
+  ];
+
+  // The pool reports the liquidity active at the current tick, so un-cross every
+  // initialized tick between there and the band's lower edge to reach the
+  // liquidity active in the band's first slice.
+  let sliceLiquidity = initializedTicks.reduce(function (total, entry) {
+    if (entry.tick > lowerTick && entry.tick <= currentTick) {
+      return total - entry.liquidityNet;
+    }
+    if (entry.tick > currentTick && entry.tick <= lowerTick) {
+      return total + entry.liquidityNet;
+    }
+    return total;
+  }, liquidity);
+
+  let amount0 = 0n;
+  let amount1 = 0n;
+  bounds.slice(0, -1).forEach(function (lower, index) {
+    if (index > 0) {
+      sliceLiquidity += sliceTicks[index - 1].liquidityNet;
+    }
+    const upper = bounds[index + 1];
+    if (sqrtPriceX96 <= lower) {
+      // Slice above the price: all token0.
+      amount0 += getAmount0Delta(lower, upper, sliceLiquidity);
+    } else if (sqrtPriceX96 >= upper) {
+      // Slice below the price: all token1.
+      amount1 += getAmount1Delta(lower, upper, sliceLiquidity);
+    } else {
+      amount0 += getAmount0Delta(sqrtPriceX96, upper, sliceLiquidity);
+      amount1 += getAmount1Delta(lower, sqrtPriceX96, sliceLiquidity);
+    }
   });
 
-  if (sqrtPriceX96 < sqrtLowerX96) {
-    // Price below the band: all token0.
-    return {
-      amount0: getAmount0Delta(sqrtLowerX96, sqrtUpperX96, liquidity),
-      amount1: 0n,
-    };
-  }
-  if (sqrtPriceX96 < sqrtUpperX96) {
-    // Price inside the band: split at the current price.
-    return {
-      amount0: getAmount0Delta(sqrtPriceX96, sqrtUpperX96, liquidity),
-      amount1: getAmount1Delta(sqrtLowerX96, sqrtPriceX96, liquidity),
-    };
-  }
-  // Price above the band: all token1.
-  return {
-    amount0: 0n,
-    amount1: getAmount1Delta(sqrtLowerX96, sqrtUpperX96, liquidity),
-  };
+  return { amount0, amount1 };
 };


### PR DESCRIPTION
### Description

The `$0.96–$1.04` view on the Sushi VUSD/USDT pool reported a TVL larger than the pool's own full range — ~$1.8M inside a ~$43k pool.

`computeBandAmounts` took the pool's current liquidity (the `L` active at the current tick) and spread it uniformly across the whole band. That `L` belongs to positions clustered around the price — roughly ±$0.0008 for this pool — so extrapolating it across a ±4% band overstated the amounts by ~43x. The value was unbounded relative to the pool's real reserves.

The band is now cut at every initialized tick it contains, and each slice valued with the liquidity actually active across it:

- **`src/lib/v3PoolState.ts`** (new) — reads `slot0`, `liquidity`, `tickSpacing`, the `tickBitmap` words spanning the band, and `ticks()` for each initialized tick found. Three multicalls; two words and 15 ticks for the configured band. No data API publishes the per-tick distribution (Sushi's GraphQL schema has no tick fields), so it has to come from chain.
- **`src/lib/v3PositionMath.ts`** — `computeBandAmounts` walks down from the pool's reported liquidity to recover the liquidity in the band's lowest slice, then walks up applying each tick's `liquidityNet`. Adds `priceToTick` and the `TickLiquidity` type.
- **`src/fetchers/fetchSushiPools.ts`** — one read spanning all configured bands so they share a snapshot; pools without bands skip it entirely.
- **`src/lib/sushiApi.ts`** — drops the now-unused `liquidity` / `sqrtPrice` fields.

Verified against the pool's own [Sushi page](https://www.sushi.com/ethereum/pool/v3/0x6c2bd2f9711f204e595d334c6b7b672851b7d699):

- Walking every tick reproduces their reported 25,861 VUSD / 27,305 USDT to within 0.03%, with `netSum` over all 16 initialized ticks landing at exactly 0.
- The outermost ticks read convert to 0.833945 and 1.2001 — exactly the bounds of their depth chart.
- A narrow read window (0.96–1.04) and a wide one (0.2–5) give byte-identical band amounts at the same block. Locked in as a unit test, since it's what makes the cheap windowed read safe.

The band now reads ~$38.8k of the pool's ~$53.2k, i.e. ~73% of liquidity within ±4% of peg.

### Screenshots

<img width="1948" height="222" alt="image" src="https://github.com/user-attachments/assets/8e917131-7903-466a-b97f-3b6075e0f016" />

### Related issue(s)

Closes #704

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
