### PR TITLE
Update bridge package

### DIFF
--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -17,11 +17,12 @@
   },
   "scripts": {
     "build": "tsc --noEmit",
-    "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",
     "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
+    "prebundle": "pnpm build",
+    "bundle": "node ../../scripts/bundle-package.js",
     "clean": "rm -rf ./_esm ./_types",
     "prepack": "cp ../../LICENSE LICENSE",
-    "prepublishOnly": "pnpm clean && pnpm build:esm && pnpm build:types",
+    "prepublishOnly": "pnpm clean && pnpm bundle && pnpm build:types",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@tsconfig/node24": "24.0.4",
     "@types/node": "24.1.0",
+    "@vetro-protocol/core": "workspace:*",
     "@vitest/coverage-v8": "4.1.9",
     "typescript": "5.9.3",
     "viem": "2.44.4",

--- a/packages/bridge/src/actions/index.ts
+++ b/packages/bridge/src/actions/index.ts
@@ -1,7 +1,7 @@
 // Public actions
-export * from "./public/approvalRequired.js";
-export * from "./public/quoteSend.js";
-export * from "./public/token.js";
+export * from "./public/approvalRequired.ts";
+export * from "./public/quoteSend.ts";
+export * from "./public/token.ts";
 
 // Wallet actions
-export * from "./wallet/send.js";
+export * from "./wallet/send.ts";

--- a/packages/bridge/src/actions/public/approvalRequired.ts
+++ b/packages/bridge/src/actions/public/approvalRequired.ts
@@ -1,8 +1,8 @@
+import { isAddressValid } from "@vetro-protocol/core";
 import { type Address, type Client } from "viem";
 import { readContract } from "viem/actions";
 
-import { oftAbi } from "../../abi/oftAbi.js";
-import { isAddressValid } from "../../utils/isAddressValid.js";
+import { oftAbi } from "../../abi/oftAbi.ts";
 
 export type ApprovalRequiredParams = {
   oftAddress: Address;

--- a/packages/bridge/src/actions/public/quoteSend.ts
+++ b/packages/bridge/src/actions/public/quoteSend.ts
@@ -1,11 +1,11 @@
+import { isAddressValid } from "@vetro-protocol/core";
 import { type Client } from "viem";
 import { readContract } from "viem/actions";
 
-import { oftAbi } from "../../abi/oftAbi.js";
-import { getLayerZeroEid } from "../../layerZeroEids.js";
-import type { MessagingFee, QuoteSendParams } from "../../types.js";
-import { addressToBytes32 } from "../../utils/addressToBytes32.js";
-import { isAddressValid } from "../../utils/isAddressValid.js";
+import { oftAbi } from "../../abi/oftAbi.ts";
+import { getLayerZeroEid } from "../../layerZeroEids.ts";
+import type { MessagingFee, QuoteSendParams } from "../../types.ts";
+import { addressToBytes32 } from "../../utils/addressToBytes32.ts";
 
 export async function quoteSend(
   client: Client,

--- a/packages/bridge/src/actions/public/token.ts
+++ b/packages/bridge/src/actions/public/token.ts
@@ -1,8 +1,8 @@
+import { isAddressValid } from "@vetro-protocol/core";
 import { type Address, type Client } from "viem";
 import { readContract } from "viem/actions";
 
-import { oftAbi } from "../../abi/oftAbi.js";
-import { isAddressValid } from "../../utils/isAddressValid.js";
+import { oftAbi } from "../../abi/oftAbi.ts";
 
 export type TokenParams = {
   oftAddress: Address;

--- a/packages/bridge/src/actions/wallet/send.ts
+++ b/packages/bridge/src/actions/wallet/send.ts
@@ -1,3 +1,4 @@
+import { isAddressValid } from "@vetro-protocol/core";
 import { EventEmitter } from "events";
 import { toPromiseEvent } from "to-promise-event";
 import {
@@ -14,13 +15,12 @@ import {
 } from "viem/actions";
 import { allowance, approve } from "viem-erc20/actions";
 
-import { oftAbi } from "../../abi/oftAbi.js";
-import { getLayerZeroEid, layerZeroEids } from "../../layerZeroEids.js";
-import type { MessagingFee, SendEvents, SendParams } from "../../types.js";
-import { addressToBytes32 } from "../../utils/addressToBytes32.js";
-import { isAddressValid } from "../../utils/isAddressValid.js";
-import { approvalRequired } from "../public/approvalRequired.js";
-import { token } from "../public/token.js";
+import { oftAbi } from "../../abi/oftAbi.ts";
+import { getLayerZeroEid, layerZeroEids } from "../../layerZeroEids.ts";
+import type { MessagingFee, SendEvents, SendParams } from "../../types.ts";
+import { addressToBytes32 } from "../../utils/addressToBytes32.ts";
+import { approvalRequired } from "../public/approvalRequired.ts";
+import { token } from "../public/token.ts";
 
 const canSend = function ({
   amount,

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -1,19 +1,19 @@
 import type { Client, WalletClient } from "viem";
 
-import { approvalRequired } from "./actions/public/approvalRequired.js";
-import { quoteSend } from "./actions/public/quoteSend.js";
-import { token } from "./actions/public/token.js";
-import { send } from "./actions/wallet/send.js";
-import type { SendParams } from "./types.js";
+import { approvalRequired } from "./actions/public/approvalRequired.ts";
+import { quoteSend } from "./actions/public/quoteSend.ts";
+import { token } from "./actions/public/token.ts";
+import { send } from "./actions/wallet/send.ts";
+import type { SendParams } from "./types.ts";
 
 // Export ABI
-export { oftAbi } from "./abi/oftAbi.js";
+export { oftAbi } from "./abi/oftAbi.ts";
 
 // Export types
-export type { SendEvents } from "./types.js";
+export type { SendEvents } from "./types.ts";
 
 // Export encoders
-export { encodeSend } from "./actions/wallet/send.js";
+export { encodeSend } from "./actions/wallet/send.ts";
 
 // Export factory functions for .extend() pattern
 export const bridgePublicActions = () => (client: Client) => ({

--- a/packages/bridge/src/utils/isAddressValid.ts
+++ b/packages/bridge/src/utils/isAddressValid.ts
@@ -1,6 +1,0 @@
-import { type Address, isAddress, isAddressEqual, zeroAddress } from "viem";
-
-export const isAddressValid = (
-  address: Address | undefined,
-): address is Address =>
-  !!address && isAddress(address) && !isAddressEqual(address, zeroAddress);

--- a/packages/bridge/test/public/approvalRequired.test.ts
+++ b/packages/bridge/test/public/approvalRequired.test.ts
@@ -2,7 +2,7 @@ import { type Address, type Client, zeroAddress } from "viem";
 import { readContract } from "viem/actions";
 import { describe, expect, it, vi } from "vitest";
 
-import { approvalRequired } from "../../src/actions/public/approvalRequired";
+import { approvalRequired } from "../../src/actions/public/approvalRequired.ts";
 
 vi.mock("viem/actions", () => ({
   readContract: vi.fn(),

--- a/packages/bridge/test/public/quoteSend.test.ts
+++ b/packages/bridge/test/public/quoteSend.test.ts
@@ -3,7 +3,7 @@ import { readContract } from "viem/actions";
 import { hemi } from "viem/chains";
 import { describe, expect, it, vi } from "vitest";
 
-import { quoteSend } from "../../src/actions/public/quoteSend";
+import { quoteSend } from "../../src/actions/public/quoteSend.ts";
 
 vi.mock("viem/actions", () => ({
   readContract: vi.fn(),

--- a/packages/bridge/test/public/token.test.ts
+++ b/packages/bridge/test/public/token.test.ts
@@ -2,7 +2,7 @@ import { type Address, type Client, zeroAddress } from "viem";
 import { readContract } from "viem/actions";
 import { describe, expect, it, vi } from "vitest";
 
-import { token } from "../../src/actions/public/token";
+import { token } from "../../src/actions/public/token.ts";
 
 vi.mock("viem/actions", () => ({
   readContract: vi.fn(),

--- a/packages/bridge/test/wallet/send.test.ts
+++ b/packages/bridge/test/wallet/send.test.ts
@@ -15,7 +15,7 @@ import { bsc, hemi } from "viem/chains";
 import { allowance, approve } from "viem-erc20/actions";
 import { describe, expect, it, vi } from "vitest";
 
-import { send } from "../../src/actions/wallet/send";
+import { send } from "../../src/actions/wallet/send.ts";
 
 vi.mock("viem/actions", () => ({
   readContract: vi.fn(),

--- a/packages/bridge/tsconfig.json
+++ b/packages/bridge/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "noEmit": true
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       '@types/node':
         specifier: 24.1.0
         version: 24.1.0
+      '@vetro-protocol/core':
+        specifier: workspace:*
+        version: link:../core
       '@vitest/coverage-v8':
         specifier: 4.1.9
         version: 4.1.9(vitest@4.1.9)

--- a/web/src/fetchers/fetchBridgeNetworkFee.ts
+++ b/web/src/fetchers/fetchBridgeNetworkFee.ts
@@ -1,8 +1,7 @@
 import { estimateFeesQueryOptions } from "@hemilabs/react-hooks/useEstimateFees";
 import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
 import type { QueryClient } from "@tanstack/react-query";
-import { oftAbi } from "@vetro-protocol/bridge";
-import { encodeSend } from "@vetro-protocol/bridge/actions";
+import { approvalRequired, encodeSend } from "@vetro-protocol/bridge/actions";
 import { previewBridgeQueryOptions } from "hooks/usePreviewBridge";
 import { tokenPricesOptions } from "hooks/useTokenPrices";
 import { config } from "providers/web3Provider";
@@ -10,7 +9,7 @@ import type { BridgeableToken } from "types";
 import { createErc20AllowanceStateOverride } from "utils/erc20StateOverride";
 import { weiToUsd } from "utils/fees";
 import { type Address, type Chain, type Client } from "viem";
-import { estimateGas, readContract } from "viem/actions";
+import { estimateGas } from "viem/actions";
 
 import { estimateApprovalGasUnits } from "./estimateApprovalGasUnits";
 
@@ -59,7 +58,7 @@ export const fetchBridgeNetworkFee = async function ({
     throw new Error("Insufficient token balance");
   }
 
-  const [fee, approvalRequired] = await Promise.all([
+  const [fee, needsApproval] = await Promise.all([
     queryClient.ensureQueryData(
       previewBridgeQueryOptions({
         amount,
@@ -70,14 +69,10 @@ export const fetchBridgeNetworkFee = async function ({
         sourceChainId,
       }),
     ),
-    readContract(client, {
-      abi: oftAbi,
-      address: oftAddress,
-      functionName: "approvalRequired",
-    }),
+    approvalRequired(client, { oftAddress }),
   ]);
 
-  const approvalGasPromise = approvalRequired
+  const approvalGasPromise = needsApproval
     ? estimateApprovalGasUnits({
         amount,
         approveAmount,
@@ -98,7 +93,7 @@ export const fetchBridgeNetworkFee = async function ({
       recipient,
       refundAddress: owner,
     }),
-    stateOverride: approvalRequired
+    stateOverride: needsApproval
       ? createErc20AllowanceStateOverride({
           owner,
           spender: oftAddress,

--- a/web/test/fetchers/fetchBridgeNetworkFee.test.ts
+++ b/web/test/fetchers/fetchBridgeNetworkFee.test.ts
@@ -1,10 +1,11 @@
 import { estimateFeesQueryOptions } from "@hemilabs/react-hooks/useEstimateFees";
 import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
+import { approvalRequired } from "@vetro-protocol/bridge/actions";
 import { previewBridgeQueryKey } from "hooks/usePreviewBridge";
 import { tokenPricesOptions } from "hooks/useTokenPrices";
 import type { BridgeableToken } from "types";
 import { type Address, type Client, parseEther, zeroAddress } from "viem";
-import { estimateGas, readContract } from "viem/actions";
+import { estimateGas } from "viem/actions";
 import { bsc, hemi, mainnet } from "viem/chains";
 import { describe, expect, it, vi } from "vitest";
 
@@ -17,12 +18,12 @@ vi.mock("../../src/fetchers/estimateApprovalGasUnits", () => ({
 }));
 
 vi.mock("@vetro-protocol/bridge/actions", () => ({
+  approvalRequired: vi.fn(),
   encodeSend: vi.fn().mockReturnValue("0x"),
 }));
 
 vi.mock("viem/actions", () => ({
   estimateGas: vi.fn(),
-  readContract: vi.fn(),
 }));
 
 vi.mock("utils/erc20StateOverride", () => ({
@@ -109,7 +110,7 @@ describe("fetchBridgeNetworkFee", function () {
     const networkFeeWei = parseEther("0.01");
     const queryClient = createPrepopulatedQueryClient();
 
-    vi.mocked(readContract).mockResolvedValue(true);
+    vi.mocked(approvalRequired).mockResolvedValue(true);
     vi.mocked(estimateApprovalGasUnits).mockResolvedValue(approvalGas);
     vi.mocked(estimateGas).mockResolvedValue(sendGas);
     mockNetworkFeeAndPrices({
@@ -143,7 +144,7 @@ describe("fetchBridgeNetworkFee", function () {
     const networkFeeWei = parseEther("0.01");
     const queryClient = createPrepopulatedQueryClient();
 
-    vi.mocked(readContract).mockResolvedValue(false);
+    vi.mocked(approvalRequired).mockResolvedValue(false);
     vi.mocked(estimateGas).mockResolvedValue(sendGas);
     mockNetworkFeeAndPrices({
       networkFeeWei,
@@ -174,7 +175,7 @@ describe("fetchBridgeNetworkFee", function () {
     const nativeFee = 12_345n;
     const queryClient = createPrepopulatedQueryClient({ nativeFee });
 
-    vi.mocked(readContract).mockResolvedValue(false);
+    vi.mocked(approvalRequired).mockResolvedValue(false);
     vi.mocked(estimateGas).mockResolvedValue(180_000n);
     mockNetworkFeeAndPrices({
       networkFeeWei: 0n,
@@ -210,7 +211,7 @@ describe("fetchBridgeNetworkFee", function () {
       chainId: bsc.id,
     } as BridgeableToken;
 
-    vi.mocked(readContract).mockResolvedValue(false);
+    vi.mocked(approvalRequired).mockResolvedValue(false);
     vi.mocked(estimateGas).mockResolvedValue(sendGas);
     mockNetworkFeeAndPrices({
       networkFeeWei,
@@ -253,7 +254,7 @@ describe("fetchBridgeNetworkFee", function () {
       }),
     ).rejects.toThrow("Insufficient token balance");
 
-    expect(readContract).not.toHaveBeenCalled();
+    expect(approvalRequired).not.toHaveBeenCalled();
     expect(estimateGas).not.toHaveBeenCalled();
     expect(estimateApprovalGasUnits).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
### Description

Follow-up of #705 - this PR gives the `bridge` package the same treatment as `earn`, `treasury` and `gateway`: it takes `isAddressValid` from the `core` package, switches relative imports to the `.ts` extension so consumers can import the package through its exports with no build step, and publishes through esbuild (which inlines the private `@vetro-protocol/core`).

It also replaces the one inline OFT call left in `web`: `fetchBridgeNetworkFee` was reading `approvalRequired()` with `oftAbi` + `readContract` instead of using the package action.

**Commits:**

83220a52 Bundle bridge and take isAddressValid from core
62c65e24 Read approvalRequired via the bridge package

### Screenshots

N/A

### Related issue(s)

Related to #695
Related to #659

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
