### PR TITLE
Add "Variable yield pools" section on Earn

### DIFF
--- a/web/src/components/base/sectionHeader.tsx
+++ b/web/src/components/base/sectionHeader.tsx
@@ -5,7 +5,7 @@ type Props = {
   title: string;
 };
 
-export const TopSection = ({ children, title }: Props) => (
+export const SectionHeader = ({ children, title }: Props) => (
   <div className="flex w-full flex-col gap-3 border-b border-gray-200 bg-gray-100 px-4 py-4 md:flex-row md:items-center md:justify-between md:px-16 md:py-6">
     <h4 className="text-base font-semibold tracking-tight text-gray-900">
       {title}

--- a/web/src/components/borrow/marketsTable.tsx
+++ b/web/src/components/borrow/marketsTable.tsx
@@ -1,8 +1,8 @@
 import { type ColumnDef } from "@tanstack/react-table";
 import { I18nLink } from "components/base/i18nLink";
+import { SectionHeader } from "components/base/sectionHeader";
 import { Table } from "components/base/table";
 import { Header } from "components/base/table/header";
-import { TopSection } from "components/base/table/topSection";
 import { CollateralCell } from "components/borrow/collateralCell";
 import { TokenValueCell } from "components/borrow/tokenValueCell";
 import { TokenLogo } from "components/tokenLogo";
@@ -127,7 +127,7 @@ export function MarketsTable({ marketIds }: Props) {
 
   return (
     <div className="border-t border-gray-200">
-      <TopSection title={t("pages.borrow.markets-title")} />
+      <SectionHeader title={t("pages.borrow.markets-title")} />
       <Table
         columns={columns}
         data={data}

--- a/web/src/components/borrow/positionsTable.tsx
+++ b/web/src/components/borrow/positionsTable.tsx
@@ -1,7 +1,7 @@
 import { type ColumnDef } from "@tanstack/react-table";
+import { SectionHeader } from "components/base/sectionHeader";
 import { Table } from "components/base/table";
 import { Header } from "components/base/table/header";
-import { TopSection } from "components/base/table/topSection";
 import { useBorrowAction } from "hooks/borrow/useBorrowAction";
 import { type MarketData, useMarketsData } from "hooks/borrow/useMarketsData";
 import {
@@ -247,7 +247,7 @@ export function PositionsTable({ marketIds }: Props) {
 
   return (
     <div id="borrow-positions" ref={ref}>
-      <TopSection title={t("pages.borrow.positions-title")} />
+      <SectionHeader title={t("pages.borrow.positions-title")} />
       <Table
         columns={columns}
         data={data}

--- a/web/src/components/swapForm/redeemQueue.tsx
+++ b/web/src/components/swapForm/redeemQueue.tsx
@@ -1,6 +1,6 @@
 import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import type { FetchStatus, QueryStatus } from "@tanstack/react-query";
-import { TopSection } from "components/base/table/topSection";
+import { SectionHeader } from "components/base/sectionHeader";
 import { useActivityTracking } from "hooks/useActivityTracking";
 import { useAmount } from "hooks/useAmount";
 import {
@@ -245,7 +245,7 @@ export function RedeemQueue({ peggedToken, whitelistedTokens }: Props) {
 
   return (
     <>
-      <TopSection title={t("pages.swap.redeem-queue.title")} />
+      <SectionHeader title={t("pages.swap.redeem-queue.title")} />
       <RedeemQueueTable
         data={rows}
         loading={isLoading}

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -381,7 +381,10 @@
         "from-pools_other": "From {{count}} pools",
         "staked-balance": "Your staked balance"
       },
-      "title": "Stake assets to earn variable yield."
+      "title": "Stake assets to earn variable yield.",
+      "variable-yield": {
+        "title": "Variable yield pools"
+      }
     },
     "faq": {
       "title": "Hello Faq"

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -387,7 +387,10 @@
         "from-pools_other": "De {{count}} fondos",
         "staked-balance": "Su balance stakeado"
       },
-      "title": "Haga stake de activos para ganar un rendimiento variable."
+      "title": "Haga stake de activos para ganar un rendimiento variable.",
+      "variable-yield": {
+        "title": "Fondos de rendimiento variable"
+      }
     },
     "faq": {
       "title": "Hola FAQ"

--- a/web/src/pages/earn/components/exitTickets/index.tsx
+++ b/web/src/pages/earn/components/exitTickets/index.tsx
@@ -4,10 +4,10 @@ import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { Badge } from "components/base/badge";
 import { Button } from "components/base/button";
 import { FilterMenu } from "components/base/filterMenu";
+import { SectionHeader } from "components/base/sectionHeader";
 import { StatusBadge } from "components/base/statusBadge";
 import { Table } from "components/base/table";
 import { Header } from "components/base/table/header";
-import { TopSection } from "components/base/table/topSection";
 import { Toast } from "components/base/toast";
 import { Tooltip } from "components/tooltip";
 import { TableCellsIcon } from "pages/earn/icons/tableCellsIcon";
@@ -254,7 +254,7 @@ export function ExitTickets() {
   return (
     <div id="exit-tickets">
       {/* Title row */}
-      <TopSection title={t("pages.earn.exit-tickets.title")}>
+      <SectionHeader title={t("pages.earn.exit-tickets.title")}>
         <div className="flex items-center gap-3">
           <FilterMenu
             icon={<TableCellsIcon />}
@@ -280,7 +280,7 @@ export function ExitTickets() {
             onWithdrawAll={() => setIsWithdrawAllDrawerOpen(true)}
           />
         </div>
-      </TopSection>
+      </SectionHeader>
       {/* Table */}
       <Table
         columns={columns}

--- a/web/src/pages/earn/components/exitTickets/skeleton.tsx
+++ b/web/src/pages/earn/components/exitTickets/skeleton.tsx
@@ -1,5 +1,5 @@
+import { SectionHeader } from "components/base/sectionHeader";
 import { Table } from "components/base/table";
-import { TopSection } from "components/base/table/topSection";
 import { useTranslation } from "react-i18next";
 
 import { getColumns } from ".";
@@ -18,7 +18,7 @@ export function ExitTicketsSkeleton() {
 
   return (
     <div>
-      <TopSection title={t("pages.earn.exit-tickets.title")} />
+      <SectionHeader title={t("pages.earn.exit-tickets.title")} />
       <Table
         columns={columns}
         data={emptyArray}

--- a/web/src/pages/earn/components/fixedTermEarn/index.tsx
+++ b/web/src/pages/earn/components/fixedTermEarn/index.tsx
@@ -1,8 +1,8 @@
-import { TopSection } from "components/base/table/topSection";
+import { SectionHeader } from "components/base/sectionHeader";
 import { useTranslation } from "react-i18next";
 
 export function FixedTermEarn() {
   const { t } = useTranslation();
 
-  return <TopSection title={t("pages.earn.fixed-term.title")} />;
+  return <SectionHeader title={t("pages.earn.fixed-term.title")} />;
 }

--- a/web/src/pages/earn/index.tsx
+++ b/web/src/pages/earn/index.tsx
@@ -1,5 +1,6 @@
 import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { PageTitle } from "components/base/pageTitle";
+import { SectionHeader } from "components/base/sectionHeader";
 import { StripedDivider } from "components/stripedDivider";
 import { Suspense, lazy } from "react";
 import { useTranslation } from "react-i18next";
@@ -27,6 +28,7 @@ export function Earn() {
       <div className="flex flex-col border-y border-gray-200 bg-gray-100 *:-mt-px md:flex-row md:justify-center md:gap-14 md:px-14 md:*:w-[267px]">
         <EarnStats />
       </div>
+      <SectionHeader title={t("pages.earn.variable-yield.title")} />
       {stakingVaultAddresses.map((stakingVaultAddress) => (
         <PoolInfoBar
           key={stakingVaultAddress}

--- a/web/stories/sectionHeader.stories.tsx
+++ b/web/stories/sectionHeader.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Button } from "../src/components/base/button";
+import { SectionHeader } from "../src/components/base/sectionHeader";
+
+const meta = {
+  component: SectionHeader,
+  title: "Components/SectionHeader",
+} satisfies Meta<typeof SectionHeader>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "Exit tickets",
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    children: (
+      <div className="flex items-center gap-3">
+        <Button size="small" variant="secondary">
+          View settings
+        </Button>
+        <div className="h-3 w-0.5 rounded-full bg-gray-200" />
+        <Button size="small">Withdraw all</Button>
+      </div>
+    ),
+    title: "Exit tickets",
+  },
+};


### PR DESCRIPTION
### Description

Adds the "Variable yield pools" section header above the staking pool list on the Earn page, per the Figma design.

Getting there needed a small refactor first. The header component lived at `components/base/table/topSection.tsx` and was named `TopSection` for its position above a table — but it has no table coupling, and `FixedTermEarn` already rendered it standalone with no table at all. Adding a second table-less usage made the name and location actively misleading, so it moved to `components/base/sectionHeader.tsx` as `SectionHeader`. That turned the feature itself into a one-line addition.

**Commits:**

7fce4d36 Rename TopSection to SectionHeader
ff8b4007 Add "Variable yield pools" header on Earn

### Screenshots

<img width="2324" height="670" alt="image" src="https://github.com/user-attachments/assets/c3e227d9-8181-4f8a-86e2-b6d6ff4b5ccd" />


### Related issue(s)

Related to #709

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
