### PR TITLE
Update target-yield-earn package

### DIFF
--- a/packages/target-yield-earn/package.json
+++ b/packages/target-yield-earn/package.json
@@ -17,11 +17,12 @@
   },
   "scripts": {
     "build": "tsc --noEmit",
-    "build:esm": "tsc -p tsconfig.build.json --outDir ./_esm --sourceMap",
+    "postbuild": "pnpm bundle && pnpm build:types",
     "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
+    "bundle": "node ../../scripts/bundle-package.js",
     "clean": "rm -rf ./_esm ./_types",
     "prepack": "cp ../../LICENSE LICENSE",
-    "prepublishOnly": "pnpm clean && pnpm build:esm && pnpm build:types",
+    "prepublishOnly": "pnpm clean && pnpm build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@tsconfig/node24": "24.0.4",
     "@types/node": "24.1.0",
+    "@vetro-protocol/core": "workspace:*",
     "@vitest/coverage-v8": "4.1.9",
     "typescript": "5.9.3",
     "viem": "2.44.4",

--- a/packages/target-yield-earn/src/actions/index.ts
+++ b/packages/target-yield-earn/src/actions/index.ts
@@ -1,1 +1,1 @@
-export * from "./public/index.js";
+export * from "./public/index.ts";

--- a/packages/target-yield-earn/src/actions/public/getCurrentRate.ts
+++ b/packages/target-yield-earn/src/actions/public/getCurrentRate.ts
@@ -1,8 +1,8 @@
+import { isAddressValid } from "@vetro-protocol/core";
 import { type Address, type Client } from "viem";
 import { readContract } from "viem/actions";
 
-import { targetYieldEarnVaultAbi } from "../../abi/targetYieldEarnVaultAbi.js";
-import { isAddressValid } from "../../utils/isAddressValid.js";
+import { targetYieldEarnVaultAbi } from "../../abi/targetYieldEarnVaultAbi.ts";
 
 export async function getCurrentRate(
   client: Client,

--- a/packages/target-yield-earn/src/actions/public/getEpochId.ts
+++ b/packages/target-yield-earn/src/actions/public/getEpochId.ts
@@ -1,8 +1,8 @@
+import { isAddressValid } from "@vetro-protocol/core";
 import { type Address, type Client } from "viem";
 import { readContract } from "viem/actions";
 
-import { targetYieldEarnVaultAbi } from "../../abi/targetYieldEarnVaultAbi.js";
-import { isAddressValid } from "../../utils/isAddressValid.js";
+import { targetYieldEarnVaultAbi } from "../../abi/targetYieldEarnVaultAbi.ts";
 
 export async function getEpochId(
   client: Client,

--- a/packages/target-yield-earn/src/actions/public/getMaxRequestDeposit.ts
+++ b/packages/target-yield-earn/src/actions/public/getMaxRequestDeposit.ts
@@ -1,8 +1,8 @@
+import { isAddressValid } from "@vetro-protocol/core";
 import { type Address, type Client } from "viem";
 import { readContract } from "viem/actions";
 
-import { targetYieldEarnVaultAbi } from "../../abi/targetYieldEarnVaultAbi.js";
-import { isAddressValid } from "../../utils/isAddressValid.js";
+import { targetYieldEarnVaultAbi } from "../../abi/targetYieldEarnVaultAbi.ts";
 
 export async function getMaxRequestDeposit(
   client: Client,

--- a/packages/target-yield-earn/src/actions/public/getMaxRequestRedeem.ts
+++ b/packages/target-yield-earn/src/actions/public/getMaxRequestRedeem.ts
@@ -1,8 +1,8 @@
+import { isAddressValid } from "@vetro-protocol/core";
 import { type Address, type Client } from "viem";
 import { readContract } from "viem/actions";
 
-import { targetYieldEarnVaultAbi } from "../../abi/targetYieldEarnVaultAbi.js";
-import { isAddressValid } from "../../utils/isAddressValid.js";
+import { targetYieldEarnVaultAbi } from "../../abi/targetYieldEarnVaultAbi.ts";
 
 export async function getMaxRequestRedeem(
   client: Client,

--- a/packages/target-yield-earn/src/actions/public/index.ts
+++ b/packages/target-yield-earn/src/actions/public/index.ts
@@ -1,7 +1,7 @@
 // The vault is an ERC-7540 async vault, so we re-export the ERC-7540 reads it supports
 export { pendingDepositRequest } from "viem-erc7540/actions";
 
-export * from "./getCurrentRate.js";
-export * from "./getEpochId.js";
-export * from "./getMaxRequestDeposit.js";
-export * from "./getMaxRequestRedeem.js";
+export * from "./getCurrentRate.ts";
+export * from "./getEpochId.ts";
+export * from "./getMaxRequestDeposit.ts";
+export * from "./getMaxRequestRedeem.ts";

--- a/packages/target-yield-earn/src/index.ts
+++ b/packages/target-yield-earn/src/index.ts
@@ -6,15 +6,15 @@ import {
   getMaxRequestDeposit,
   getMaxRequestRedeem,
   pendingDepositRequest,
-} from "./actions/public/index.js";
+} from "./actions/public/index.ts";
 
-export { targetYieldEarnVaultAbi } from "./abi/targetYieldEarnVaultAbi.js";
+export { targetYieldEarnVaultAbi } from "./abi/targetYieldEarnVaultAbi.ts";
 
 export {
   maxExitWindowSeconds,
   minEpochDurationSeconds,
   minExitWindowSeconds,
-} from "./constants.js";
+} from "./constants.ts";
 
 // Export factory functions for .extend() pattern
 export const targetYieldEarnPublicActions = () => (client: Client) => ({

--- a/packages/target-yield-earn/src/utils/isAddressValid.ts
+++ b/packages/target-yield-earn/src/utils/isAddressValid.ts
@@ -1,6 +1,0 @@
-import { type Address, isAddress, isAddressEqual, zeroAddress } from "viem";
-
-export const isAddressValid = (
-  address: Address | undefined,
-): address is Address =>
-  !!address && isAddress(address) && !isAddressEqual(address, zeroAddress);

--- a/packages/target-yield-earn/test/public/getCurrentRate.test.ts
+++ b/packages/target-yield-earn/test/public/getCurrentRate.test.ts
@@ -2,7 +2,7 @@ import { type Address, type Client, zeroAddress } from "viem";
 import { readContract } from "viem/actions";
 import { describe, expect, it, vi } from "vitest";
 
-import { getCurrentRate } from "../../src/actions/public/getCurrentRate";
+import { getCurrentRate } from "../../src/actions/public/getCurrentRate.ts";
 
 vi.mock("viem/actions", () => ({
   readContract: vi.fn(),

--- a/packages/target-yield-earn/test/public/getEpochId.test.ts
+++ b/packages/target-yield-earn/test/public/getEpochId.test.ts
@@ -2,7 +2,7 @@ import { type Address, type Client, zeroAddress } from "viem";
 import { readContract } from "viem/actions";
 import { describe, expect, it, vi } from "vitest";
 
-import { getEpochId } from "../../src/actions/public/getEpochId";
+import { getEpochId } from "../../src/actions/public/getEpochId.ts";
 
 vi.mock("viem/actions", () => ({
   readContract: vi.fn(),

--- a/packages/target-yield-earn/test/public/getMaxRequestDeposit.test.ts
+++ b/packages/target-yield-earn/test/public/getMaxRequestDeposit.test.ts
@@ -2,7 +2,7 @@ import { type Address, type Client, zeroAddress } from "viem";
 import { readContract } from "viem/actions";
 import { describe, expect, it, vi } from "vitest";
 
-import { getMaxRequestDeposit } from "../../src/actions/public/getMaxRequestDeposit";
+import { getMaxRequestDeposit } from "../../src/actions/public/getMaxRequestDeposit.ts";
 
 vi.mock("viem/actions", () => ({
   readContract: vi.fn(),

--- a/packages/target-yield-earn/test/public/getMaxRequestRedeem.test.ts
+++ b/packages/target-yield-earn/test/public/getMaxRequestRedeem.test.ts
@@ -2,7 +2,7 @@ import { type Address, type Client, zeroAddress } from "viem";
 import { readContract } from "viem/actions";
 import { describe, expect, it, vi } from "vitest";
 
-import { getMaxRequestRedeem } from "../../src/actions/public/getMaxRequestRedeem";
+import { getMaxRequestRedeem } from "../../src/actions/public/getMaxRequestRedeem.ts";
 
 vi.mock("viem/actions", () => ({
   readContract: vi.fn(),

--- a/packages/target-yield-earn/tsconfig.json
+++ b/packages/target-yield-earn/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "noEmit": true
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,6 +399,9 @@ importers:
       '@types/node':
         specifier: 24.1.0
         version: 24.1.0
+      '@vetro-protocol/core':
+        specifier: workspace:*
+        version: link:../core
       '@vitest/coverage-v8':
         specifier: 4.1.9
         version: 4.1.9(vitest@4.1.9)


### PR DESCRIPTION
### Description

Follow-up of #708 - this PR gives `target-yield-earn` the same treatment as `earn`, `treasury`, `gateway` and `bridge`: it takes `isAddressValid` from the `core` package, switches relative imports to the `.ts` extension so consumers can import the package through its exports with no build step, and publishes through esbuild (which inlines the private `@vetro-protocol/core`).

### Screenshots

N/A

### Related issue(s)

Related to #659
Related to #695

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
