### PR TITLE
Run bundle and types build in CI for all packages

### DIFF
--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -17,12 +17,12 @@
   },
   "scripts": {
     "build": "tsc --noEmit",
+    "postbuild": "pnpm bundle && pnpm build:types",
     "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
-    "prebundle": "pnpm build",
     "bundle": "node ../../scripts/bundle-package.js",
     "clean": "rm -rf ./_esm ./_types",
     "prepack": "cp ../../LICENSE LICENSE",
-    "prepublishOnly": "pnpm clean && pnpm bundle && pnpm build:types",
+    "prepublishOnly": "pnpm clean && pnpm build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -17,12 +17,12 @@
   },
   "scripts": {
     "build": "tsc --noEmit",
+    "postbuild": "pnpm bundle && pnpm build:types",
     "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
-    "prebundle": "pnpm build",
     "bundle": "node ../../scripts/bundle-package.js",
     "clean": "rm -rf ./_esm ./_types",
     "prepack": "cp ../../LICENSE LICENSE",
-    "prepublishOnly": "pnpm clean && pnpm bundle && pnpm build:types",
+    "prepublishOnly": "pnpm clean && pnpm build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },

--- a/packages/treasury/package.json
+++ b/packages/treasury/package.json
@@ -17,12 +17,12 @@
   },
   "scripts": {
     "build": "tsc --noEmit",
+    "postbuild": "pnpm bundle && pnpm build:types",
     "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
-    "prebundle": "pnpm build",
     "bundle": "node ../../scripts/bundle-package.js",
     "clean": "rm -rf ./_esm ./_types",
     "prepack": "cp ../../LICENSE LICENSE",
-    "prepublishOnly": "pnpm clean && pnpm bundle && pnpm build:types",
+    "prepublishOnly": "pnpm clean && pnpm build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },


### PR DESCRIPTION
### Description

Follow-up of #711. CI only runs `pnpm run --recursive build`, which under the `prebundle` layout is just `tsc --noEmit` - the esbuild bundle and the declaration emit were never exercised until publish time, so a break in either would surface during a release rather than on the PR that caused it.

`earn` already solved this in #698 by hanging both off a `postbuild` hook, and #711 did the same for `target-yield-earn`. This applies it to the three that were left: `bridge`, `gateway` and `treasury` now run `postbuild: pnpm bundle && pnpm build:types` and reduce `prepublishOnly` to `pnpm clean && pnpm build`, so CI and publish run the same pipeline. All five publishable packages now share an identical build script block.

### Screenshots

N/A

### Related issue(s)

Related to #659
Related to #695

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
