### PR TITLE
Show the 404 page for unknown paths

### DIFF
--- a/web/e2e/earn.spec.ts
+++ b/web/e2e/earn.spec.ts
@@ -73,9 +73,7 @@ test("deposit VUSD into the Earn pool", async function ({
     page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
   ).toBeVisible({ timeout: 30_000 });
 
-  // Navigate to Earn from the navbar. Routes are locale-prefixed (/en/earn), so
-  // a bare page.goto("/earn") is parsed as lang="earn" and falls back to the
-  // default page — clicking the nav link is both correct and what a user does.
+  // Navigate to Earn from the navbar, like a user would.
   await page.getByRole("link", { name: "Earn" }).click();
   await expect(page).toHaveURL(/\/en\/earn/);
 

--- a/web/e2e/notFound.spec.ts
+++ b/web/e2e/notFound.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+
+const notFoundTitle = "Page not found";
+const notFoundDescription = "The page you're trying to access does not exist.";
+
+test("renders the 404 page on an unknown path", async function ({ page }) {
+  await page.goto("/en/this-page-does-not-exist");
+
+  await expect(
+    page.getByRole("heading", { name: notFoundTitle }),
+  ).toBeVisible();
+  await expect(page.getByText(notFoundDescription)).toBeVisible();
+  await expect(page).toHaveURL(/\/en\/this-page-does-not-exist$/);
+});
+
+test("renders the 404 page on an unknown path with no language prefix", async function ({
+  page,
+}) {
+  await page.goto("/this-page-does-not-exist");
+
+  await expect(
+    page.getByRole("heading", { name: notFoundTitle }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/en\/this-page-does-not-exist$/);
+});
+
+test("renders the 404 page on an unsupported language", async function ({
+  page,
+}) {
+  await page.goto("/fr/swap");
+
+  await expect(
+    page.getByRole("heading", { name: notFoundTitle }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/en\/fr\/swap$/);
+});
+
+test("the root path redirects to swap", async function ({ page }) {
+  await page.goto("/");
+
+  await expect(page).toHaveURL(/\/en\/swap$/);
+  await expect(
+    page.getByRole("heading", { name: "Swap your tokens with Vetro assets" }),
+  ).toBeVisible();
+});
+
+test("the 404 page links back to swap", async function ({ page }) {
+  await page.goto("/en/this-page-does-not-exist");
+
+  await page.getByRole("link", { name: "Take me back to swap" }).click();
+
+  await expect(page).toHaveURL(/\/en\/swap$/);
+});

--- a/web/e2e/notFound.spec.ts
+++ b/web/e2e/notFound.spec.ts
@@ -26,6 +26,30 @@ test("renders the 404 page on an unknown path with no language prefix", async fu
   );
 });
 
+test("renders the requested page when the path has no language prefix", async function ({
+  page,
+}) {
+  await page.goto("/contact");
+
+  await expect(page).toHaveURL(/\/en\/contact$/);
+  await expect(
+    page.getByRole("heading", {
+      name: "Tell us what happened so we can help",
+    }),
+  ).toBeVisible();
+});
+
+test("preserves a deep link when the path has no language prefix", async function ({
+  page,
+}) {
+  const marketId =
+    "0x7d1306d23f9f1e419697b8275001db9ea74b3c75190a7db8f5d81fed2fb94561";
+
+  await page.goto(`/borrow/${marketId}`);
+
+  await expect(page).toHaveURL(new RegExp(`/en/borrow/${marketId}$`));
+});
+
 test("renders the 404 page on an unsupported language", async function ({
   page,
 }) {

--- a/web/e2e/notFound.spec.ts
+++ b/web/e2e/notFound.spec.ts
@@ -16,12 +16,14 @@ test("renders the 404 page on an unknown path", async function ({ page }) {
 test("renders the 404 page on an unknown path with no language prefix", async function ({
   page,
 }) {
-  await page.goto("/this-page-does-not-exist");
+  await page.goto("/this-page-does-not-exist?foo=bar#section");
 
   await expect(
     page.getByRole("heading", { name: notFoundTitle }),
   ).toBeVisible();
-  await expect(page).toHaveURL(/\/en\/this-page-does-not-exist$/);
+  await expect(page).toHaveURL(
+    /\/en\/this-page-does-not-exist\?foo=bar#section$/,
+  );
 });
 
 test("renders the 404 page on an unsupported language", async function ({

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -5,7 +5,7 @@ import { AppViewport } from "components/base/appViewport";
 import { ErrorBoundary } from "components/base/errorBoundary";
 import { GeoRestrictionRibbon } from "components/geoRestrictionRibbon";
 import { Header } from "components/header";
-import { I18nInitializer } from "i18n/config";
+import { I18nInitializer, useUnsupportedLanguageRedirect } from "i18n/config";
 import { NuqsAdapter } from "nuqs/adapters/react-router/v8";
 import { Analytics } from "pages/analytics";
 import { Borrow } from "pages/borrow";
@@ -50,6 +50,12 @@ const AppNotifications = lazy(() =>
  */
 function LanguageRoutes() {
   const { pathname } = useLocation();
+  const unsupportedLanguageRedirect = useUnsupportedLanguageRedirect();
+
+  if (unsupportedLanguageRedirect) {
+    return <Navigate replace to={unsupportedLanguageRedirect} />;
+  }
+
   return (
     <ErrorBoundary
       fallback={

--- a/web/src/i18n/config.tsx
+++ b/web/src/i18n/config.tsx
@@ -18,8 +18,10 @@ export const initializeI18n = () =>
   });
 
 /**
- * Callers must redirect during render — the language routes include an index
- * route that navigates to Swap, and it wins if both redirects run from effects.
+ * The caller must return early on a truthy result. <Navigate> navigates
+ * from an effect, so rendering it alongside the language routes lets the
+ * index route's redirect to Swap win — the early return keeps that route
+ * from ever mounting.
  */
 export const useUnsupportedLanguageRedirect = function () {
   const { lang } = useParams<{ lang: string }>();

--- a/web/src/i18n/config.tsx
+++ b/web/src/i18n/config.tsx
@@ -1,7 +1,7 @@
 import i18n from "i18next";
 import { useLayoutEffect } from "react";
 import { initReactI18next } from "react-i18next";
-import { useNavigate, useParams } from "react-router";
+import { useLocation, useParams } from "react-router";
 
 import { resources } from "./resources";
 
@@ -17,22 +17,31 @@ export const initializeI18n = () =>
     supportedLngs,
   });
 
+/**
+ * Callers must redirect during render — the language routes include an index
+ * route that navigates to Swap, and it wins if both redirects run from effects.
+ */
+export const useUnsupportedLanguageRedirect = function () {
+  const { lang } = useParams<{ lang: string }>();
+  const { hash, pathname, search } = useLocation();
+
+  if (!lang || supportedLngs.includes(lang)) {
+    return undefined;
+  }
+  return `/${fallbackLng}${pathname}${search}${hash}`;
+};
+
 // Component to sync the route language parameter with i18n
 export const I18nInitializer = function () {
   const { lang } = useParams<{ lang: string }>();
-  const navigate = useNavigate();
 
   useLayoutEffect(
     function () {
-      if (lang && !supportedLngs.includes(lang)) {
-        navigate(`/${fallbackLng}`, { replace: true });
-        return;
-      }
       if (lang && i18n.language !== lang) {
         i18n.changeLanguage(lang);
       }
     },
-    [lang, navigate],
+    [lang],
   );
 
   return null;


### PR DESCRIPTION
### Description

Adds the E2E coverage for the 404 page (the last unchecked item under "Misc" in #694) — and fixes the routing bug that writing the test exposed.

An unsupported language prefix redirected to `/en` and threw away the rest of the path, so unknown paths never reached the 404 page at all. The blast radius was wider than just 404s:

| URL | Before | After |
| --- | --- | --- |
| `/borrwo` (typo) | `/en/swap` — Swap, no 404 | `/en/borrwo` — 404 |
| `/borrow` (valid page, no prefix) | `/en/swap` — **wrong page** | `/en/borrow` — Borrow |
| `/swap?amount=5` | `/en/swap` — query dropped | `/en/swap?amount=5` — kept |
| `/fr/swap` (unsupported language) | `/en` — Swap | `/en/fr/swap` — 404 |
| `/`, `/en`, `/es/earn`, `/en/borrwo` | unchanged | unchanged |

Any unprefixed valid path (`/borrow`, `/earn`, `/analytics`) silently landed on Swap; only `/swap` appeared to work, coincidentally, because Swap is the index redirect target. Query strings were dropped on those paths too, which matters since the Swap form keeps state in the URL via nuqs.

The fix prefixes the fallback language onto the current path instead of replacing it, preserving search and hash. The redirect had to move out of `I18nInitializer`'s layout effect and into `LanguageRoutes`' render: the language routes include an index route that navigates to Swap, and it wins the race if both redirects run from effects (the first attempt produced `/en/this-page-does-not-exist/swap`). That constraint is the one comment left on the new hook.

Two deliberate behavior changes worth calling out for review: an unsupported language now 404s rather than falling back to English Swap, and that includes region-tagged prefixes like `/en-US/swap`.

### Screenshots

N/A — no new UI. The `NotFound` page already existed; this only changes which URLs route to it.

### Related issue(s)

Related to #694

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
