### PR TITLE
Share pool info cells and make the row scrollable

### DIFF
--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -1,14 +1,12 @@
-import { ExternalLink } from "components/base/externalLink";
 import { useApy } from "hooks/useApy";
-import { useMainnet } from "hooks/useMainnet";
 import { usePoolDeposits } from "hooks/usePoolDeposits";
 import { usePrices } from "hooks/usePrices";
 import { useVaultPeggedToken } from "hooks/useVaultPeggedToken";
 import { useTranslation } from "react-i18next";
 import { formatTokenAmountUsd } from "utils/currency";
-import { formatEvmAddress } from "utils/format";
 import type { Address } from "viem";
 
+import { PoolContract } from "./poolContract";
 import { PoolInfoButtons } from "./poolInfoButtons";
 import { PoolInfoItem } from "./poolInfoItem";
 import { PoolInfoStakedAmount } from "./poolInfoStakedAmount";
@@ -19,11 +17,8 @@ type Props = {
 };
 
 export function PoolInfoBar({ stakingVaultAddress }: Props) {
-  const chain = useMainnet();
   const { t } = useTranslation();
   const { data: peggedToken } = useVaultPeggedToken(stakingVaultAddress);
-
-  const explorerBaseUrl = chain.blockExplorers!.default.url;
 
   const { data: apy, isLoading: isLoadingApy } = useApy(stakingVaultAddress);
   const { data: poolDeposits, isLoading: isLoadingDeposits } =
@@ -52,16 +47,7 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
     <div className="flex flex-col gap-6 border-b border-gray-200 bg-white p-4 sm:gap-4 md:flex-row md:items-center md:justify-between md:px-16 md:py-6">
       <div className="grid min-w-0 grid-cols-2 gap-4 sm:flex sm:items-center sm:justify-center-safe sm:gap-6 sm:overflow-x-auto md:justify-start md:gap-8">
         <PoolToken peggedToken={peggedToken} />
-        <div className="contents md:*:w-32">
-          <PoolInfoItem label={t("pages.earn.pool-info.pool-contract")}>
-            <ExternalLink
-              className="text-xsm font-semibold text-gray-600 transition-colors hover:text-gray-900"
-              href={`${explorerBaseUrl}/address/${stakingVaultAddress}`}
-            >
-              {formatEvmAddress(stakingVaultAddress)}
-            </ExternalLink>
-          </PoolInfoItem>
-        </div>
+        <PoolContract address={stakingVaultAddress} />
         <PoolInfoItem
           isLoading={isLoadingDeposits || (!prices && !isPricesError)}
           label={t("pages.earn.pool-info.pool-deposits")}

--- a/web/src/pages/earn/components/poolInfoBar/index.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/index.tsx
@@ -1,12 +1,10 @@
 import { ExternalLink } from "components/base/externalLink";
-import { TokenLogo } from "components/tokenLogo";
 import { useApy } from "hooks/useApy";
 import { useMainnet } from "hooks/useMainnet";
 import { usePoolDeposits } from "hooks/usePoolDeposits";
 import { usePrices } from "hooks/usePrices";
 import { useVaultPeggedToken } from "hooks/useVaultPeggedToken";
 import { useTranslation } from "react-i18next";
-import Skeleton from "react-loading-skeleton";
 import { formatTokenAmountUsd } from "utils/currency";
 import { formatEvmAddress } from "utils/format";
 import type { Address } from "viem";
@@ -14,6 +12,7 @@ import type { Address } from "viem";
 import { PoolInfoButtons } from "./poolInfoButtons";
 import { PoolInfoItem } from "./poolInfoItem";
 import { PoolInfoStakedAmount } from "./poolInfoStakedAmount";
+import { PoolToken } from "./poolToken";
 
 type Props = {
   stakingVaultAddress: Address;
@@ -51,23 +50,8 @@ export function PoolInfoBar({ stakingVaultAddress }: Props) {
 
   return (
     <div className="flex flex-col gap-6 border-b border-gray-200 bg-white p-4 sm:gap-4 md:flex-row md:items-center md:justify-between md:px-16 md:py-6">
-      <div className="grid grid-cols-2 gap-4 sm:flex sm:items-center sm:justify-center sm:gap-6 md:justify-start md:gap-8">
-        {peggedToken ? (
-          <div
-            className={`flex size-10 items-center justify-center rounded-lg ${
-              peggedToken.symbol === "vetBTC"
-                ? "bg-vetbtc-logo/10"
-                : "bg-blue-800/10"
-            }`}
-          >
-            <TokenLogo {...peggedToken} />
-          </div>
-        ) : (
-          <Skeleton borderRadius={8} height={40} width={40} />
-        )}
-        <div className="contents md:*:w-16">
-          <PoolInfoItem label="Token" value={peggedToken?.symbol} />
-        </div>
+      <div className="grid min-w-0 grid-cols-2 gap-4 sm:flex sm:items-center sm:justify-center-safe sm:gap-6 sm:overflow-x-auto md:justify-start md:gap-8">
+        <PoolToken peggedToken={peggedToken} />
         <div className="contents md:*:w-32">
           <PoolInfoItem label={t("pages.earn.pool-info.pool-contract")}>
             <ExternalLink

--- a/web/src/pages/earn/components/poolInfoBar/poolContract.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/poolContract.tsx
@@ -1,0 +1,31 @@
+import { ExternalLink } from "components/base/externalLink";
+import { useMainnet } from "hooks/useMainnet";
+import { useTranslation } from "react-i18next";
+import { formatEvmAddress } from "utils/format";
+import type { Address } from "viem";
+
+import { PoolInfoItem } from "./poolInfoItem";
+
+type Props = {
+  address: Address;
+};
+
+export function PoolContract({ address }: Props) {
+  const chain = useMainnet();
+  const { t } = useTranslation();
+
+  const explorerBaseUrl = chain.blockExplorers!.default.url;
+
+  return (
+    <div className="contents md:*:w-32">
+      <PoolInfoItem label={t("pages.earn.pool-info.pool-contract")}>
+        <ExternalLink
+          className="text-xsm font-semibold text-gray-600 transition-colors hover:text-gray-900"
+          href={`${explorerBaseUrl}/address/${address}`}
+        >
+          {formatEvmAddress(address)}
+        </ExternalLink>
+      </PoolInfoItem>
+    </div>
+  );
+}

--- a/web/src/pages/earn/components/poolInfoBar/poolInfoButtons.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/poolInfoButtons.tsx
@@ -80,7 +80,7 @@ export function PoolInfoButtons({ stakingVaultAddress }: Props) {
 
   return (
     <>
-      <div className="flex w-full gap-3 *:flex-1 md:w-auto md:*:flex-initial">
+      <div className="flex w-full gap-3 *:flex-1 md:w-auto md:shrink-0 md:*:flex-initial">
         <Button onClick={handleOpenDeposit} size="xSmall" variant="primary">
           {t("pages.earn.pool-info.deposit")}
         </Button>

--- a/web/src/pages/earn/components/poolInfoBar/poolInfoItem.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/poolInfoItem.tsx
@@ -24,7 +24,7 @@ export function PoolInfoItem({ children, isLoading, label, value }: Props) {
   }
 
   return (
-    <div className="relative flex flex-col">
+    <div className="relative flex flex-col sm:shrink-0 sm:whitespace-nowrap">
       <span className="text-b-regular text-gray-500">{label}</span>
       {renderValue()}
     </div>

--- a/web/src/pages/earn/components/poolInfoBar/poolToken.tsx
+++ b/web/src/pages/earn/components/poolInfoBar/poolToken.tsx
@@ -1,0 +1,35 @@
+import type { Token } from "@vetro-protocol/core";
+import { TokenLogo } from "components/tokenLogo";
+import Skeleton from "react-loading-skeleton";
+
+import { PoolInfoItem } from "./poolInfoItem";
+
+type Props = {
+  peggedToken: Token | undefined;
+};
+
+export const PoolToken = ({ peggedToken }: Props) => (
+  <>
+    {peggedToken ? (
+      <div
+        className={`flex size-10 shrink-0 items-center justify-center rounded-lg ${
+          peggedToken.symbol === "vetBTC"
+            ? "bg-vetbtc-logo/10"
+            : "bg-blue-800/10"
+        }`}
+      >
+        <TokenLogo {...peggedToken} />
+      </div>
+    ) : (
+      <Skeleton
+        borderRadius={8}
+        containerClassName="shrink-0"
+        height={40}
+        width={40}
+      />
+    )}
+    <div className="contents md:*:w-16">
+      <PoolInfoItem label="Token" value={peggedToken?.symbol} />
+    </div>
+  </>
+);


### PR DESCRIPTION
### Description

Groundwork for the target fixed yield pools list: the cells that both pool rows have in common are now shared components, and the row scrolls instead of squeezing when it runs out of width.

`PoolToken` (logo + symbol) and `PoolContract` (explorer link) move out of the variable row's `PoolInfoBar` into their own components under `poolInfoBar/`. Both take their data as props — `peggedToken` and `address` — so each row can feed them from its own hook instead of sharing a data source. No behaviour change: the symbol-conditional logo background (`vetBTC` vs the rest) and the loading skeleton moved with them.


**Commits:**

3f6a34cd Extract PoolToken into a shared component
bb138003 Extract PoolContract into a shared component
458bfff5 Keep pool action buttons from shrinking

### Screenshots

App looks the same as before 

<img width="546" height="597" alt="image" src="https://github.com/user-attachments/assets/2c21ed8d-584c-40d8-8d60-e50d2674aa08" />

<img width="1179" height="469" alt="image" src="https://github.com/user-attachments/assets/e4fef737-90d9-4346-a189-6dd2a81cf87c" />


<img width="1117" height="322" alt="image" src="https://github.com/user-attachments/assets/62a1d3f6-d8e2-4780-aecd-4b58607b115a" />


### Related issue(s)

Related to #646

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
