### PR TITLE
Catch package changes that break dependents

### DIFF
--- a/.claude/skills/run-checks/SKILL.md
+++ b/.claude/skills/run-checks/SKILL.md
@@ -20,13 +20,20 @@ a filter (`...<pkg>`) adds dependents, so a change in a shared package still
 re-tests `web`/`api`. (A _trailing_ `...` would instead pull in the package's
 dependencies — the wrong direction here.)
 
-- Changed a **package** (`packages/*`) — its typecheck _is_ its `build`
-  (`tsc --noEmit`, no bundle):
+- Changed a **package** (`packages/*`) — its typecheck _is_ its `build`:
 
   ```bash
-  pnpm --filter @vetro-protocol/<pkg> run build          # typecheck the package
+  pnpm --filter '...@vetro-protocol/<pkg>' run build     # its + dependents' builds
   pnpm --filter '...@vetro-protocol/<pkg>' run test      # its + dependents' tests
   ```
+
+  Packages are consumed as source (`exports` points at `src/`), so each
+  dependent's `build:types` recompiles the changed package's files under _its
+  own_ tsconfig, where a narrower `lib`/`types` set can reject code the package's
+  own build accepts (e.g. an ambient global like `URL`). Selecting the apps too
+  is deliberate: their `build` bundles with Vite, which catches what `tsc`
+  cannot — a broken `exports` map, an import the bundler can't resolve, or a
+  node-only builtin pulled into browser code.
 
 - Changed an **app** (`web`, `api`, `internal-dashboard`):
 
@@ -56,7 +63,7 @@ change, a full local pass before pushing can be worth it: run the §1 steps
 across every workspace instead of a scoped filter.
 
 ```bash
-# typecheck everything — apps via tsc, packages via build (= tsc --noEmit)
+# typecheck everything — apps via tsc, packages via build
 pnpm -r --if-present run tsc && pnpm --filter='./packages/*' run build
 # test every app + package (subgraph matchstick excluded — run it separately if you touched it)
 pnpm --filter='!vetro-app-subgraph' -r --if-present run test
@@ -88,9 +95,9 @@ Run it when a web change warrants a full assertive pass.
 - **One fork at a time.** e2e specs share Anvil port `8545` and dev-server port
   `5174`. Never run two specs concurrently, and never `pnpm --filter web dev`
   while a spec runs — they collide.
-- **Typecheck is two passes:** apps via `tsc`, packages via `build` (= `tsc
---noEmit`). The `--if-present` on the `tsc` pass just skips workspaces without a
-  `tsc` script — packages aren't missed, they're covered by the `build` pass.
+- **Typecheck is two passes:** apps via `tsc`, packages via `build`. The
+  `--if-present` on the `tsc` pass just skips workspaces without a `tsc` script —
+  packages aren't missed, they're covered by the `build` pass.
 - **knip is whole-repo** (can't be meaningfully scoped) — it analyzes every
   workspace and only ignores `web/scripts/*` as a path (see
   [`.knip.json`](../../../.knip.json)). Run it in a whole-repo pass or leave it to

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,10 @@
   "description": "Shared Vetro Protocol types, token metadata and utilities.",
   "scripts": {
     "build": "tsc --noEmit",
+    "postbuild": "pnpm bundle && pnpm build:types",
+    "build:types": "tsc -p tsconfig.build.json --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
+    "bundle": "node ../../scripts/bundle-package.js",
+    "clean": "rm -rf ./_esm ./_types",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
### Description

Follow-up to #717, which broke CI in a way the local checks couldn't catch: a change in `@vetro-protocol/core` passed the package's own build but failed treasury's. Packages are consumed as source, so each dependent recompiles them under its own tsconfig, where a narrower `lib`/`types` set rejects code the package's own build accepts — in that case an ambient `URL` global.

- The `run-checks` skill's scoped recipe now builds the changed package **and its dependents**, which is the only step that compiles a package under a consumer's tsconfig. It also covers the apps, whose Vite bundle catches broken `exports` maps and unresolvable imports that `tsc` can't see. Three stale "(= `tsc --noEmit`)" glosses are gone too, since a package `build` now bundles and emits declarations.
- `packages/core` had no `build:types`, so it never typechecked its own `src` the way its consumers do — its own build sees `@types/node` (pulled in via `vitest.config.ts`) while consumers' builds don't. It now uses the same `tsconfig.build.json` and bundle pipeline as the other packages.

Verified by dropping a `URL.canParse` line into `packages/core/src` and confirming the new command reproduces the same `TS2552` that CI reported.

### Screenshots

N/A — tooling only.

### Related issue(s)

No issue — follow-up to #717.

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
