### PR TITLE
Fix core types build broken by fallback RPC

### DIFF
--- a/packages/core/src/createMainnetClient.ts
+++ b/packages/core/src/createMainnetClient.ts
@@ -1,4 +1,10 @@
-import { createPublicClient } from "viem";
+import {
+  type Chain,
+  createPublicClient,
+  type FallbackTransport,
+  type HttpTransport,
+  type PublicClient,
+} from "viem";
 import { mainnet } from "viem/chains";
 
 import { createRpcTransport } from "./createRpcTransport.ts";
@@ -9,7 +15,9 @@ import { updateRpcUrls } from "./utils/updateRpcUrls.ts";
  * config. See `updateRpcUrls` for the accepted formats, and
  * `createRpcTransport` for how they become a transport.
  */
-export const createMainnetClient = function (rpcUrl: string | undefined) {
+export const createMainnetClient = function (
+  rpcUrl: string | undefined,
+): PublicClient<FallbackTransport | HttpTransport, Chain> {
   const chain = updateRpcUrls(mainnet, rpcUrl);
   return createPublicClient({
     batch: { multicall: true },


### PR DESCRIPTION
### Description

The build is currently broken on `master`. Two PRs were green on their own and only break in combination: #717 added a `fallback()` transport to `createRpcTransport`, and #718 gave `packages/core` the same `build:types` step the other packages have. The first commit where both exist is the merge of #717, so master was the first build to run them together.

Why inference stopped working: `tsc --noEmit` only has to *know* a type, but declaration emit has to *write it down by name*. The inferred type of `createMainnetClient` includes viem's fallback transport, whose shape mentions `OnResponseFn` — a type viem declares internally but does not export from its package root. There is no name tsc can legally write for it, so it tried to point at `viem/_types/...` and failed with TS2742.

Annotating the return type as `PublicClient<FallbackTransport | HttpTransport, Chain>` gives tsc names it can write, so it never expands into viem's internals. Annotating `createRpcTransport` as `Transport` also compiles, but then tsc inlines the whole client surface and the emitted declaration goes from ~500 bytes to 275 KB.

### Screenshots

N/A — no UI changes.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
