### PR TITLE
Fix flaky Earn exit ticket e2e test

### DIFF
--- a/web/e2e/earn.spec.ts
+++ b/web/e2e/earn.spec.ts
@@ -220,7 +220,10 @@ async function stakeVusd(assets: bigint) {
     args: [assets, TEST_ADDRESS],
     functionName: "deposit",
   });
-  await waitForTransactionReceipt(walletClient, { hash: depositHash });
+  const receipt = await waitForTransactionReceipt(walletClient, {
+    hash: depositHash,
+  });
+  expect(receipt.status).toBe("success");
 }
 
 test("withdraw VUSD from the Earn pool (whitelisted one-step exit)", async function ({
@@ -603,6 +606,11 @@ test("delete an exit ticket while it is in cooldown", async function ({
       address: sVusdAddress,
     }),
   ]);
+
+  // One block after the deposit, the gas estimate still sees a zero yield drip
+  // while the mined tx sees a non-zero one — the request then runs out of gas.
+  // Forwarding the clock puts both on the same side of the drip.
+  await fastForwardTime({ forkUrl: ANVIL_URL, seconds: 60 });
 
   const { assets, claimableAt, requestId, requestTxHash, shares } =
     await requestWithdrawVusd(WITHDRAW_AMOUNT);


### PR DESCRIPTION
### Description

The e2e test `delete an exit ticket while it is in cooldown` failed randomly in CI, always in the seeding step rather than the UI — `expect(receipt.status).toBe("success")` got `reverted`.

The cause is a gas estimation race, not the app. `StakingVault._pullYield()` runs before every vault write, and `YieldDistributor.pullYield()` only does its SSTORE + `safeTransfer` + event (~23k gas) once the linear drip `((endTime - lastUpdateTime) * rewardRate) / PRECISION` rounds above zero. `pullYield` stamps `lastUpdateTime` itself, so seeding the request one block after the deposit lands inside that window: viem sends the bare `eth_estimateGas` result as the gas limit, the estimate runs against the head block and sees a zero drip (225307), then the tx mines a second later where the drip is non-zero and needs 244816. It runs out of gas inside the vault proxy's delegatecall and mines as `reverted`.

The fix steps the fork clock 60s before the request, so the estimate and the mined tx land on the same side of the drip.

Why only this test: the window is one or two seconds wide, so it needs two vault writes almost adjacent. The `deposit` in `stakeVusd` follows a `lastUpdateTime` that is hours old, and the two UI-driven tests put browser latency between the stake and the request. This is the only place with two vault writes one block apart.

Also asserts the deposit receipt in `stakeVusd`, so a seeding failure names itself instead of surfacing later as a balance mismatch.

**Measured** on a single fork, same conditions both ways:

| | result |
| --- | --- |
| before | 10/20 failed |
| after | 30/30 passed |

The baseline gave an exact discriminator: every run whose request block was 2s after the head block failed, every 1s run passed. The verified run included 8 runs at that 2s spacing. Full spec run: `4 passed`.

### Screenshots

N/A — test-only change.

### Related issue(s)

Closes #723

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
