### PR TITLE
Include Storybook in the web typecheck

### DIFF
--- a/web/stories/activityList.stories.tsx
+++ b/web/stories/activityList.stories.tsx
@@ -128,6 +128,7 @@ export const List: Story = {
   args: {},
   render: () => (
     <ActivityList
+      hasTransactions
       items={[
         {
           date: MOCK_DATE,

--- a/web/stories/allocationLegend.stories.tsx
+++ b/web/stories/allocationLegend.stories.tsx
@@ -1,8 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { AllocationLegend } from "../src/pages/analytics/components/allocationCard/allocationLegend";
+import { formatUsd } from "../src/utils/currency";
 
 const meta = {
+  args: {
+    formatAmount: formatUsd,
+  },
   component: AllocationLegend,
   title: "Analytics/AllocationLegend",
 } satisfies Meta<typeof AllocationLegend>;

--- a/web/stories/fiatValue.stories.tsx
+++ b/web/stories/fiatValue.stories.tsx
@@ -2,8 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Token } from "@vetro-protocol/core";
 import { parseUnits } from "viem";
+import { createConfig, http, WagmiProvider } from "wagmi";
 
 import { RenderFiatValue } from "../src/components/base/fiatValue";
+import { mainnet } from "../src/networks/mainnet";
 
 const usdc: Token = {
   address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
@@ -14,22 +16,36 @@ const usdc: Token = {
   symbol: "USDC",
 };
 
-const createQueryClient = function (prices?: Record<string, string>) {
-  const client = new QueryClient({
+const wagmiConfig = createConfig({
+  chains: [mainnet],
+  transports: { [mainnet.id]: http() },
+});
+
+const createQueryClient = function () {
+  const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
         retry: false,
       },
     },
   });
-  if (prices) {
-    client.setQueryData(["token-price"], prices);
-  }
-  return client;
+  queryClient.setQueryData(["prices", mainnet.id], { USDC: "1.00" });
+  return queryClient;
 };
+
+const queryClient = createQueryClient();
 
 const meta = {
   component: RenderFiatValue,
+  decorators: [
+    (Story) => (
+      <WagmiProvider config={wagmiConfig}>
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      </WagmiProvider>
+    ),
+  ],
   title: "Components/FiatValue",
 } satisfies Meta<typeof RenderFiatValue>;
 
@@ -43,13 +59,6 @@ export const WithValue: StoryType = {
     token: usdc,
     value: parseUnits("125.50", usdc.decimals),
   },
-  decorators: [
-    (Story) => (
-      <QueryClientProvider client={createQueryClient({ USDC: "1.00" })}>
-        <Story />
-      </QueryClientProvider>
-    ),
-  ],
 };
 
 export const Loading: StoryType = {
@@ -58,13 +67,6 @@ export const Loading: StoryType = {
     token: usdc,
     value: undefined,
   },
-  decorators: [
-    (Story) => (
-      <QueryClientProvider client={createQueryClient()}>
-        <Story />
-      </QueryClientProvider>
-    ),
-  ],
 };
 
 export const Error: StoryType = {
@@ -73,11 +75,4 @@ export const Error: StoryType = {
     token: usdc,
     value: undefined,
   },
-  decorators: [
-    (Story) => (
-      <QueryClientProvider client={createQueryClient()}>
-        <Story />
-      </QueryClientProvider>
-    ),
-  ],
 };

--- a/web/stories/fiatValue.stories.tsx
+++ b/web/stories/fiatValue.stories.tsx
@@ -21,19 +21,14 @@ const wagmiConfig = createConfig({
   transports: { [mainnet.id]: http() },
 });
 
-const createQueryClient = function () {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
     },
-  });
-  queryClient.setQueryData(["prices", mainnet.id], { USDC: "1.00" });
-  return queryClient;
-};
-
-const queryClient = createQueryClient();
+  },
+});
+queryClient.setQueryData(["prices", mainnet.id], { USDC: "1.00" });
 
 const meta = {
   component: RenderFiatValue,

--- a/web/stories/modal.stories.tsx
+++ b/web/stories/modal.stories.tsx
@@ -24,23 +24,21 @@ export const Default: Story = {
         <Button onClick={() => setIsOpen(true)}>Open Modal</Button>
         {isOpen && (
           <Modal onClose={() => setIsOpen(false)}>
-            <div className="flex w-sm flex-col gap-6 rounded-lg bg-white p-6 shadow-xl">
-              <div className="flex flex-col gap-2">
-                <h4 className="text-base font-semibold text-gray-900">
-                  Modal Title
-                </h4>
-                <p className="text-xsm font-normal text-gray-500">
-                  Click outside or press Escape to close.
-                </p>
+            {({ close }) => (
+              <div className="flex w-sm flex-col gap-6 rounded-lg bg-white p-6 shadow-xl">
+                <div className="flex flex-col gap-2">
+                  <h4 className="text-base font-semibold text-gray-900">
+                    Modal Title
+                  </h4>
+                  <p className="text-xsm font-normal text-gray-500">
+                    Click outside or press Escape to close.
+                  </p>
+                </div>
+                <Button onClick={close} size="xSmall" variant="secondary">
+                  Close
+                </Button>
               </div>
-              <Button
-                onClick={() => setIsOpen(false)}
-                size="xSmall"
-                variant="secondary"
-              >
-                Close
-              </Button>
-            </div>
+            )}
           </Modal>
         )}
       </>

--- a/web/stories/searchInput.stories.tsx
+++ b/web/stories/searchInput.stories.tsx
@@ -3,7 +3,14 @@ import { useState } from "react";
 
 import { SearchInput } from "../src/components/base/searchInput";
 
+const placeholder = "Search token name or address...";
+
 const meta = {
+  args: {
+    onChange: () => undefined,
+    placeholder,
+    value: "",
+  },
   component: SearchInput,
   title: "Components/SearchInput",
 } satisfies Meta<typeof SearchInput>;
@@ -12,12 +19,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const placeholder = "Search token name or address...";
-
 export const Default: Story = {
-  args: {
-    placeholder,
-  },
   render: function Render(args) {
     const [value, setValue] = useState("");
 
@@ -30,9 +32,6 @@ export const Default: Story = {
 };
 
 export const Filled: Story = {
-  args: {
-    placeholder,
-  },
   render: function Render(args) {
     const [value, setValue] = useState("USDC");
 
@@ -45,9 +44,6 @@ export const Filled: Story = {
 };
 
 export const States: Story = {
-  args: {
-    placeholder,
-  },
   render: function Render(args) {
     const [empty, setEmpty] = useState("");
     const [filled, setFilled] = useState("USDC");

--- a/web/stories/segmentedControl.stories.tsx
+++ b/web/stories/segmentedControl.stories.tsx
@@ -60,7 +60,7 @@ const labeledTokens = tokenSymbols
 
 export const WithTokenLabels: Story = {
   render: function Component() {
-    const [value, setValue] = useState<TokenSymbol>(labeledTokens[0].symbol);
+    const [value, setValue] = useState<TokenSymbol>(tokenSymbols[0]);
 
     return (
       <div className="flex justify-center">

--- a/web/stories/shadow.stories.tsx
+++ b/web/stories/shadow.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { ComponentProps } from "react";
+import type { ComponentProps } from "react";
 
 const meta: Meta<ComponentProps<"div">> = {
   argTypes: {

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -7,12 +7,14 @@
     "types": ["node"]
   },
   "include": [
+    ".storybook",
     "e2e",
     "global.d.ts",
     "playwright.config.ts",
     "reset.d.ts",
     "scripts",
     "src",
+    "stories",
     "test"
   ],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
### Description

The `web` workspace did not compile its Storybook stories. `web/tsconfig.json` left `stories` and `.storybook` out of `include`, so `tsc` never saw them, and a component prop change could break a story with nothing to report it.

This adds both to the include list. `pnpm --filter web build` runs `tsc && vite build`, so the stories are now covered by the build and by the `JS Checks` CI job.

Six stories had already drifted from their components and are fixed here:

- `activityList` — pass the required `hasTransactions`
- `allocationLegend` — set `formatAmount` in the meta args, using the same `formatUsd` default that `AllocationCard` applies
- `modal` — `children` is now a `({ close }) => ReactNode` render prop
- `searchInput` — move the required `value` and `onChange` into the meta args
- `segmentedControl` — seed the state from `tokenSymbols[0]`, which is typed as `TokenSymbol`
- `shadow` — use a type-only import for `ComponentProps`

A seventh, `fiatValue`, was broken at runtime in a way the typecheck does not catch: all three of its stories rendered `-`. It had no `WagmiProvider`, so `usePublicClient` threw, and the component's own `<ErrorBoundary fallback="-">` turned that crash into the fallback. It also seeded the query key `["token-price"]`, while `usePrices` reads `["prices", chainId]`. Both are fixed, and the three stories now render `125.50`, a skeleton, and `-` respectively.

### Screenshots

No application UI changes — the only visual changes are in Storybook. Every changed story was checked in a real browser: `tsc`, `eslint`, `prettier --check` pass, `storybook:build` completes, and no story logs a console error.

### Related issue(s)

Closes #725

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
