### PR TITLE
Document internal dashboard env vars

### DIFF
--- a/internal-dashboard/README.md
+++ b/internal-dashboard/README.md
@@ -15,7 +15,7 @@ that serves the static assets and injects security headers (see `src/index.ts`).
 
 ## Environment Variables
 
-Set these in `internal-dashboard/.env` (or a `.env.local` override) before you run `dev` or `build`.
+Set these in `internal-dashboard/.env` (or a `.env.local` override) before you run `dev` or `build`. The committed `.env` holds the public development values only.
 
 | Variable               | Required | Description                                                                                                                                                          |
 | ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -23,6 +23,8 @@ Set these in `internal-dashboard/.env` (or a `.env.local` override) before you r
 | `VITE_RPC_URL_MAINNET` | Yes      | RPC URL(s) for Ethereum mainnet. Several URLs joined by `+` become a fallback transport. Baked into the client bundle at build time, thus readable by every visitor. |
 
 The Worker builds its `connect-src` CSP directive from the same two variables (see `src/index.ts`), so an override is allowed by the CSP without more changes.
+
+For the deployed dashboard, set the production values as Cloudflare Workers Builds variables in the Cloudflare dashboard. Vite gives these priority over the committed `.env` at build time. Thus the paid RPC URL stays out of the repository.
 
 ## Development
 
@@ -35,4 +37,4 @@ pnpm tsc      # typecheck only
 
 ## Deployment
 
-Deployed to Cloudflare with `wrangler` (see `wrangler.jsonc`).
+Deployed to Cloudflare with `wrangler` (see `wrangler.jsonc`). The production environment variables come from the Cloudflare Workers Builds variables (see [Environment Variables](#environment-variables)).

--- a/internal-dashboard/README.md
+++ b/internal-dashboard/README.md
@@ -3,10 +3,26 @@
 Internal-facing dashboard for tracking various operational metrics. Each metric area
 lives on its own tab, mapped to a URL.
 
-- **Curve** (`/curve`) — liquidity on Curve pools _(placeholder for now)_.
+- **DEX** (`/dex`) — liquidity of the tracked Vetro pools on Curve, Sushi and
+  Uniswap. Each pool also has a detail view at `/dex/:poolId`.
+- **Hemi Earn** (`/hemi-earn`) — status of the Hemi Earn agent: keepers,
+  ownership, proxy implementation and its pending vault cooldowns.
+
+`/` and unknown paths redirect to the DEX tab.
 
 It's a Vite + React + TypeScript + Tailwind v4 SPA, deployed to Cloudflare via a Worker
 that serves the static assets and injects security headers (see `src/index.ts`).
+
+## Environment Variables
+
+Set these in `internal-dashboard/.env` (or a `.env.local` override) before you run `dev` or `build`.
+
+| Variable               | Required | Description                                                                                                                                                          |
+| ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VITE_PORTAL_API_URL`  | Yes      | Hemi Portal API base URL (used for token prices).                                                                                                                    |
+| `VITE_RPC_URL_MAINNET` | Yes      | RPC URL(s) for Ethereum mainnet. Several URLs joined by `+` become a fallback transport. Baked into the client bundle at build time, thus readable by every visitor. |
+
+The Worker builds its `connect-src` CSP directive from the same two variables (see `src/index.ts`), so an override is allowed by the CSP without more changes.
 
 ## Development
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12368,7 +12368,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
 
   '@vitest/eslint-plugin@1.6.6(eslint@8.57.0)(typescript@6.0.2)(vitest@4.1.9)':
     dependencies:
@@ -14444,13 +14444,14 @@ snapshots:
       esquery: 1.7.0
       jsonc-eslint-parser: 2.4.2
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.1(eslint@8.57.0)(typescript@6.0.2)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@6.0.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14471,7 +14472,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12368,7 +12368,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
 
   '@vitest/eslint-plugin@1.6.6(eslint@8.57.0)(typescript@6.0.2)(vitest@4.1.9)':
     dependencies:
@@ -14444,14 +14444,13 @@ snapshots:
       esquery: 1.7.0
       jsonc-eslint-parser: 2.4.2
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.53.1(eslint@8.57.0)(typescript@6.0.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14472,7 +14471,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.1(eslint@8.57.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
### Description

The dashboard already reads `VITE_RPC_URL_MAINNET` at build time, for the viem client and for the Worker `connect-src` alike, so a paid RPC needs no code change: set the variable in the Cloudflare Workers Builds variables and the build picks it up over the committed `.env`. This PR documents that, marks the variable as required (unset, viem's default endpoint is blocked by the CSP) and corrects the stale tab list.

### Screenshots

N/A — no UI changes.

### Related issue(s)

Closes #732

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Environment variables set in CI, or N/A.
- [x] Documentation updated, or N/A.
