### PR TITLE
Add swap redeem-fee and simplify the CLI client

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -100,6 +100,7 @@ This is the list of commands available
 | `vetro-cli swap allowance --token <tok> --account <addr>` | `allowance`      | Gateway's spending allowance, in human units. `<tok>` may be a whitelisted token (swap-in) or a pegged token (one-step swap-out; the two-step queue needs no allowance) |
 | `vetro-cli swap mint-fee --token <tok>`                   | `getMintFee`     | Mint fee charged on a deposit of the whitelisted `<tok>`, in bps                                                                                                        |
 | `vetro-cli swap pegged-token --gateway <addr>`            | `getPeggedToken` | Gateway's pegged-token address                                                                                                                                          |
+| `vetro-cli swap redeem-fee --token <tok>`                 | `getRedeemFee`   | Redeem fee charged on a redeem into the whitelisted `<tok>`, in bps                                                                                                     |
 | `vetro-cli swap treasury --gateway <addr>`                | `getTreasury`    | Gateway's treasury address                                                                                                                                              |
 
 ### Swapping in

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "@hemilabs/anvil-fork-setup": "2.0.0",
     "@tsconfig/node24": "24.0.4",
     "@types/node": "24.1.0",
+    "@vetro-protocol/core": "workspace:*",
     "@vitest/coverage-v8": "4.1.9",
     "esbuild": "0.27.3",
     "typescript": "5.9.3",

--- a/packages/cli/src/features/swap/commands/redeemFee.ts
+++ b/packages/cli/src/features/swap/commands/redeemFee.ts
@@ -1,0 +1,30 @@
+import { getRedeemFee } from "@vetro-protocol/gateway/actions";
+import { type Command } from "commander";
+
+import { type GlobalOptions, createVetroClient } from "../../../lib/client.ts";
+import { printResult } from "../../../lib/output.ts";
+import { resolveWhitelistedToken } from "../../../lib/tokens.ts";
+
+export function register(swap: Command) {
+  swap
+    .command("redeem-fee")
+    .description("Print the redeem fee for a whitelisted token, in bps")
+    .requiredOption(
+      "--token <token>",
+      "Whitelisted token to receive, by symbol or address",
+    )
+    .action(async function (options: { token: string }, command: Command) {
+      const { client } = await createVetroClient(
+        command.optsWithGlobals<GlobalOptions>(),
+      );
+      const token = await resolveWhitelistedToken({
+        client,
+        value: options.token,
+      });
+      const fee = await getRedeemFee(client, {
+        address: token.gatewayAddress,
+        token: token.address,
+      });
+      printResult(fee);
+    });
+}

--- a/packages/cli/src/features/swap/index.ts
+++ b/packages/cli/src/features/swap/index.ts
@@ -5,9 +5,18 @@ import { register as approve } from "./commands/approve.ts";
 import { register as mint } from "./commands/mint.ts";
 import { register as mintFee } from "./commands/mintFee.ts";
 import { register as peggedToken } from "./commands/peggedToken.ts";
+import { register as redeemFee } from "./commands/redeemFee.ts";
 import { register as treasury } from "./commands/treasury.ts";
 
-const swapCommands = [allowance, approve, mint, mintFee, peggedToken, treasury];
+const swapCommands = [
+  allowance,
+  approve,
+  mint,
+  mintFee,
+  peggedToken,
+  redeemFee,
+  treasury,
+];
 
 export function register(program: Command) {
   const swap = program

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -1,4 +1,5 @@
-import { createMainnetClient } from "@vetro-protocol/core";
+import { createChainClient } from "@vetro-protocol/core";
+import { defineChain } from "viem";
 import { getChainId } from "viem/actions";
 import { mainnet } from "viem/chains";
 
@@ -8,8 +9,11 @@ export type GlobalOptions = { rpcUrl?: string };
 const localChainId = 31337;
 const supportedChainIds = [mainnet.id, localChainId];
 
+const mainnetOn = (rpcUrl: string) =>
+  defineChain({ ...mainnet, rpcUrls: { default: { http: [rpcUrl] } } });
+
 export async function createVetroClient({ rpcUrl }: GlobalOptions) {
-  const client = createMainnetClient(rpcUrl);
+  const client = createChainClient(rpcUrl ? mainnetOn(rpcUrl) : mainnet);
 
   const chainId = await getChainId(client);
   if (!supportedChainIds.includes(chainId)) {

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, http } from "viem";
+import { createMainnetClient } from "@vetro-protocol/core";
 import { getChainId } from "viem/actions";
 import { mainnet } from "viem/chains";
 
@@ -9,11 +9,7 @@ const localChainId = 31337;
 const supportedChainIds = [mainnet.id, localChainId];
 
 export async function createVetroClient({ rpcUrl }: GlobalOptions) {
-  const client = createPublicClient({
-    batch: { multicall: true },
-    chain: mainnet,
-    transport: http(rpcUrl),
-  });
+  const client = createMainnetClient(rpcUrl);
 
   const chainId = await getChainId(client);
   if (!supportedChainIds.includes(chainId)) {

--- a/packages/cli/test/client.test.ts
+++ b/packages/cli/test/client.test.ts
@@ -5,20 +5,26 @@ import { createVetroClient } from "../src/lib/client.ts";
 
 const rpcUrl = "https://rpc.example";
 
+// The transport batches, so it sends a JSON-RPC array and expects one back.
 const stubEndpointOnChain = (chainId: number) =>
   vi.stubGlobal(
     "fetch",
-    vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
-            id: 1,
-            jsonrpc: "2.0",
-            result: numberToHex(chainId),
-          }),
-          { headers: { "Content-Type": "application/json" } },
+    vi.fn(async function (_url: string, { body }: RequestInit) {
+      const request = JSON.parse(String(body)) as
+        | { id: number }[]
+        | { id: number };
+      const respond = ({ id }: { id: number }) => ({
+        id,
+        jsonrpc: "2.0",
+        result: numberToHex(chainId),
+      });
+      return new Response(
+        JSON.stringify(
+          Array.isArray(request) ? request.map(respond) : respond(request),
         ),
-    ),
+        { headers: { "Content-Type": "application/json" } },
+      );
+    }),
   );
 
 describe("createVetroClient", function () {

--- a/packages/cli/test/client.test.ts
+++ b/packages/cli/test/client.test.ts
@@ -6,26 +6,26 @@ import { createVetroClient } from "../src/lib/client.ts";
 const rpcUrl = "https://rpc.example";
 
 // The transport batches, so it sends a JSON-RPC array and expects one back.
-const stubEndpointOnChain = (chainId: number) =>
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(async function (_url: string, { body }: RequestInit) {
-      const request = JSON.parse(String(body)) as
-        | { id: number }[]
-        | { id: number };
-      const respond = ({ id }: { id: number }) => ({
-        id,
-        jsonrpc: "2.0",
-        result: numberToHex(chainId),
-      });
-      return new Response(
-        JSON.stringify(
-          Array.isArray(request) ? request.map(respond) : respond(request),
-        ),
-        { headers: { "Content-Type": "application/json" } },
-      );
-    }),
-  );
+const stubEndpointOnChain = function (chainId: number) {
+  const fetchMock = vi.fn(async function (_url: string, { body }: RequestInit) {
+    const request = JSON.parse(String(body)) as
+      | { id: number }[]
+      | { id: number };
+    const respond = ({ id }: { id: number }) => ({
+      id,
+      jsonrpc: "2.0",
+      result: numberToHex(chainId),
+    });
+    return new Response(
+      JSON.stringify(
+        Array.isArray(request) ? request.map(respond) : respond(request),
+      ),
+      { headers: { "Content-Type": "application/json" } },
+    );
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+};
 
 describe("createVetroClient", function () {
   afterEach(function () {
@@ -42,6 +42,20 @@ describe("createVetroClient", function () {
     stubEndpointOnChain(31337);
     const { chainId } = await createVetroClient({ rpcUrl });
     expect(chainId).toBe(31337);
+  });
+
+  it("reads from the endpoint as given, keeping a + in the path", async function () {
+    const fetchMock = stubEndpointOnChain(1);
+    const urlWithPlus = "https://rpc.example/v2/KEY+SUFFIX";
+    await createVetroClient({ rpcUrl: urlWithPlus });
+    expect(fetchMock).toHaveBeenCalledWith(urlWithPlus, expect.anything());
+  });
+
+  it("reads from an endpoint given with an uppercase scheme", async function () {
+    const fetchMock = stubEndpointOnChain(1);
+    await createVetroClient({ rpcUrl: "HTTPS://rpc.example" });
+    const [url] = fetchMock.mock.calls[0];
+    expect(new URL(url).host).toBe("rpc.example");
   });
 
   it("rejects a chain Vetro is not deployed on", async function () {

--- a/packages/cli/test/e2e/redeemFee.test.ts
+++ b/packages/cli/test/e2e/redeemFee.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, inject, it } from "vitest";
+
+import { runCli, runCliRaw, usdc, vusd } from "./helpers.ts";
+
+describe("swap redeem-fee", function () {
+  const rpcUrl = inject("anvilUrl");
+
+  const redeemFeeOnFork = (extra: string[] = []) => [
+    "swap",
+    "redeem-fee",
+    ...extra,
+    "--rpc-url",
+    rpcUrl,
+  ];
+
+  it("reads the redeem fee by symbol", async function () {
+    const fee = await runCli(redeemFeeOnFork(["--token", usdc.symbol]));
+    expect(fee).toMatch(/^\d+$/);
+  });
+
+  it("reads the redeem fee by address", async function () {
+    const fee = await runCli(redeemFeeOnFork(["--token", usdc.address]));
+    expect(fee).toMatch(/^\d+$/);
+  });
+
+  it("rejects a pegged token", async function () {
+    const { exitCode, stderr } = await runCliRaw(
+      redeemFeeOnFork(["--token", vusd.symbol]),
+    );
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(stderr).error).toBe(
+      `Not a whitelisted token: "${vusd.symbol}"`,
+    );
+  });
+
+  it("rejects a missing --token", async function () {
+    const { exitCode, stderr } = await runCliRaw(redeemFeeOnFork());
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("required option '--token <token>'");
+  });
+});

--- a/packages/core/src/createChainClient.ts
+++ b/packages/core/src/createChainClient.ts
@@ -1,0 +1,23 @@
+import {
+  type Chain,
+  createPublicClient,
+  type FallbackTransport,
+  type HttpTransport,
+  type PublicClient,
+} from "viem";
+
+import { createRpcTransport } from "./createRpcTransport.ts";
+
+/**
+ * Create a viem public client for a chain, with the transport and the batching
+ * options every Vetro client shares. The caller decides which RPC endpoints the
+ * chain carries; see `createMainnetClient` to take them from an env var.
+ */
+export const createChainClient = (
+  chain: Chain,
+): PublicClient<FallbackTransport | HttpTransport, Chain> =>
+  createPublicClient({
+    batch: { multicall: true },
+    chain,
+    transport: createRpcTransport(chain),
+  });

--- a/packages/core/src/createMainnetClient.ts
+++ b/packages/core/src/createMainnetClient.ts
@@ -7,5 +7,7 @@ import { updateRpcUrls } from "./utils/updateRpcUrls.ts";
  * Create a viem public client for Ethereum mainnet, reading the RPC endpoints
  * from an env var value. See `updateRpcUrls` for the accepted formats.
  */
-export const createMainnetClient = (rpcUrlEnv: string | undefined) =>
+export const createMainnetClient = (
+  rpcUrlEnv: string | undefined,
+): ReturnType<typeof createChainClient> =>
   createChainClient(updateRpcUrls(mainnet, rpcUrlEnv));

--- a/packages/core/src/createMainnetClient.ts
+++ b/packages/core/src/createMainnetClient.ts
@@ -1,27 +1,11 @@
-import {
-  type Chain,
-  createPublicClient,
-  type FallbackTransport,
-  type HttpTransport,
-  type PublicClient,
-} from "viem";
 import { mainnet } from "viem/chains";
 
-import { createRpcTransport } from "./createRpcTransport.ts";
+import { createChainClient } from "./createChainClient.ts";
 import { updateRpcUrls } from "./utils/updateRpcUrls.ts";
 
 /**
- * Create a viem public client for Ethereum mainnet from the given RPC URL
- * config. See `updateRpcUrls` for the accepted formats, and
- * `createRpcTransport` for how they become a transport.
+ * Create a viem public client for Ethereum mainnet, reading the RPC endpoints
+ * from an env var value. See `updateRpcUrls` for the accepted formats.
  */
-export const createMainnetClient = function (
-  rpcUrl: string | undefined,
-): PublicClient<FallbackTransport | HttpTransport, Chain> {
-  const chain = updateRpcUrls(mainnet, rpcUrl);
-  return createPublicClient({
-    batch: { multicall: true },
-    chain,
-    transport: createRpcTransport(chain),
-  });
-};
+export const createMainnetClient = (rpcUrlEnv: string | undefined) =>
+  createChainClient(updateRpcUrls(mainnet, rpcUrlEnv));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export { createChainClient } from "./createChainClient.ts";
 export { createMainnetClient } from "./createMainnetClient.ts";
 export { createRpcTransport } from "./createRpcTransport.ts";
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       '@types/node':
         specifier: 24.1.0
         version: 24.1.0
+      '@vetro-protocol/core':
+        specifier: workspace:*
+        version: link:../core
       '@vitest/coverage-v8':
         specifier: 4.1.9
         version: 4.1.9(vitest@4.1.9)


### PR DESCRIPTION
### Description

Two changes to `vetro-cli`:

- **`swap redeem-fee --token <tok>`** — new read command for a gateway's `getRedeemFee`, in bps. `getRedeemFee` is keyed by the **whitelisted** token you redeem into (the `tokenOut`), so the token is required and the gateway is inferred from it, like `swap mint-fee`. The issue listed it as taking no arguments; its table is updated to match.
- **`createVetroClient` now builds its client with `createChainClient`** from `@vetro-protocol/core`, instead of wiring up its own. `core` also exposes `createMainnetClient`, but that one reads the endpoints from an env var: it splits the value on `+` and matches the scheme case sensitively. The CLI takes one URL it already validated, so it passes that URL literally and keeps `createChainClient`, which holds the transport and the batching options every client shares. The supported-chain guard stays in the CLI — `core` has no equivalent. `core` is private, so it lands in `devDependencies` and esbuild inlines it into the bin.

The `fetch` stub in `client.test.ts` changed because the new transport batches: viem sends a JSON-RPC array now, so the stub mirrors the request shape. The guard assertions are unchanged. Two tests are added for the endpoint read as given: a key that contains `+`, and an uppercase scheme.

**Commits:**

25105f4b Add a swap redeem-fee read command
08c0762d Build the CLI client with createMainnetClient
6111c6b2 Read the CLI RPC URL exactly as it was given
9254cd51 Annotate the createMainnetClient return type

### Screenshots

N/A — no UI changes.

### Related issue(s)

Related to #445

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
