### PR TITLE
Return checksummed addresses from the API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,4 +33,6 @@ The `web/` app exposes the Swap, Earn, Borrow, Bridge, and Analytics pages. The 
 
 ### API project
 
+Return every address in the checksummed format. External sources — subgraphs, third-party APIs — may return addresses in lowercase, so convert them with `checksumAddress` from `viem` before they go into a response.
+
 When changing the API in `api/src/` in a way that affects external behavior — adding, removing, or modifying an endpoint's URL, params, response shape, sample data, or error semantics — review and update `api/README.md` in the same change. Code is the source of truth; the README must reflect it.

--- a/api/README.md
+++ b/api/README.md
@@ -263,6 +263,10 @@ Returns all user's variable stake exit tickets to i.e. allow claiming the withdr
 
 The `owner` and `stakingVaultAddress` fields are returned in the checksummed format.
 
+The `cancelTxHash` and `claimTxHash` fields are optional and mutually exclusive: a
+ticket in cooldown or ready to claim has neither, a cancelled ticket has
+`cancelTxHash` and a claimed ticket has `claimTxHash`.
+
 #### Sample Response
 
 ```jsonc
@@ -275,8 +279,7 @@ The `owner` and `stakingVaultAddress` fields are returned in the checksummed for
     "assets": "1050000000000000000",
     "shares": "1000000000000000000",
     "claimableAt": 1700000000,
-    "cancelTxHash": "0x0000000000000000000000000000000000000000000000000000000000000003", // set once the ticket is cancelled
-    "claimTxHash": "0x0000000000000000000000000000000000000000000000000000000000000004", // set once the ticket is claimed
+    "claimTxHash": "0x0000000000000000000000000000000000000000000000000000000000000004",
   },
 ]
 ```

--- a/api/README.md
+++ b/api/README.md
@@ -261,6 +261,8 @@ Returns a summary of the exit tickets queue for the gateway's staking vault: the
 
 Returns all user's variable stake exit tickets to i.e. allow claiming the withdrawn pegged token.
 
+The `owner`, `receiver` and `stakingVaultAddress` fields are returned in the checksummed format.
+
 #### Sample Response
 
 ```jsonc

--- a/api/README.md
+++ b/api/README.md
@@ -261,7 +261,7 @@ Returns a summary of the exit tickets queue for the gateway's staking vault: the
 
 Returns all user's variable stake exit tickets to i.e. allow claiming the withdrawn pegged token.
 
-The `owner`, `receiver` and `stakingVaultAddress` fields are returned in the checksummed format.
+The `owner` and `stakingVaultAddress` fields are returned in the checksummed format.
 
 #### Sample Response
 
@@ -275,7 +275,8 @@ The `owner`, `receiver` and `stakingVaultAddress` fields are returned in the che
     "assets": "1050000000000000000",
     "shares": "1000000000000000000",
     "claimableAt": 1700000000,
-    // Optionally: cancelTxHash, claimTxHash and receiver address
+    "cancelTxHash": "0x0000000000000000000000000000000000000000000000000000000000000003", // set once the ticket is cancelled
+    "claimTxHash": "0x0000000000000000000000000000000000000000000000000000000000000004", // set once the ticket is claimed
   },
 ]
 ```

--- a/api/README.md
+++ b/api/README.md
@@ -266,7 +266,6 @@ Returns all user's variable stake exit tickets to i.e. allow claiming the withdr
 ```jsonc
 [
   {
-    "id": "0x...",
     "requestId": "1",
     "requestTxHash": "0x0000000000000000000000000000000000000000000000000000000000000001",
     "stakingVaultAddress": "0x0000000000000000000000000000000000000002",

--- a/api/src/borrow.ts
+++ b/api/src/borrow.ts
@@ -1,3 +1,5 @@
+import { isAddressEqual } from "viem";
+
 import * as morpho from "./morpho.ts";
 import { vusdAddress } from "./vusd.ts";
 
@@ -16,7 +18,7 @@ export async function validateMarketId({
   const loanAssetAddress = await morpho.getLoanAssetAddress({
     marketId,
   });
-  if (loanAssetAddress === vusdAddress) {
+  if (isAddressEqual(loanAssetAddress, vusdAddress)) {
     return true;
   }
   if (whitelistedMarketIds.includes(marketId)) {

--- a/api/src/morpho.ts
+++ b/api/src/morpho.ts
@@ -1,3 +1,4 @@
+import { type Address } from "viem";
 import { mainnet } from "viem/chains";
 
 import * as graphql from "./graphql.ts";
@@ -10,7 +11,7 @@ export async function getLoanAssetAddress({
   marketId,
 }: {
   marketId: string;
-}): Promise<string> {
+}): Promise<Address> {
   const query = `
     query ($chainId: Int!, $marketId: String!) {
       marketById(marketId: $marketId, chainId: $chainId) {
@@ -26,7 +27,7 @@ export async function getLoanAssetAddress({
   const { marketById } = await graphql.runQuery<{
     marketById: {
       loanAsset: {
-        address: string;
+        address: Address;
       };
     };
   }>(morphoApiUrl, query, variables);

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -228,7 +228,6 @@ type ExitTicket = {
   cancelTxHash?: Hash;
   claimableAt: number;
   claimTxHash?: Hash;
-  id: string;
   owner: Address;
   receiver?: Address;
   requestId: string;

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -225,11 +225,11 @@ export async function getUserRewards({
 
 type ExitTicket = {
   assets: string;
-  cancelTxHash?: Hash;
+  cancelTxHash?: Hash | null;
   claimableAt: number;
-  claimTxHash?: Hash;
+  claimTxHash?: Hash | null;
   owner: Address;
-  receiver?: Address;
+  receiver?: Address | null;
   requestId: string;
   requestTxHash: Hash;
   shares: string;

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -279,7 +279,14 @@ export async function getUserExitTickets({
       `Got exactly 100 exit tickets for ${address}. Implement pagination!`,
     );
   }
-  return exitTickets;
+  return exitTickets.map((ticket) => ({
+    ...ticket,
+    owner: checksumAddress(ticket.owner),
+    receiver: ticket.receiver
+      ? checksumAddress(ticket.receiver)
+      : ticket.receiver,
+    stakingVaultAddress: checksumAddress(ticket.stakingVaultAddress),
+  }));
 }
 
 /**

--- a/api/src/variable-stake.ts
+++ b/api/src/variable-stake.ts
@@ -229,7 +229,6 @@ type ExitTicket = {
   claimableAt: number;
   claimTxHash?: Hash | null;
   owner: Address;
-  receiver?: Address | null;
   requestId: string;
   requestTxHash: Hash;
   shares: string;
@@ -257,7 +256,6 @@ export async function getUserExitTickets({
         claimableAt
         claimTxHash
         owner
-        receiver
         requestId
         requestTxHash
         shares
@@ -282,9 +280,6 @@ export async function getUserExitTickets({
   return exitTickets.map((ticket) => ({
     ...ticket,
     owner: checksumAddress(ticket.owner),
-    receiver: ticket.receiver
-      ? checksumAddress(ticket.receiver)
-      : ticket.receiver,
     stakingVaultAddress: checksumAddress(ticket.stakingVaultAddress),
   }));
 }

--- a/api/test/variable-stake.test.ts
+++ b/api/test/variable-stake.test.ts
@@ -488,10 +488,9 @@ describe("variable-stake/getCostBasis", function () {
 
 describe("variable-stake/getUserExitTickets", function () {
   const owner: Address = "0x2f1f8B6D6b5A09b6a0a1A9A1d8B2eA3D0e7b1a4c";
-  const receiver: Address = "0x9AE1D5c2B3B0F7A6C5d4E3f2A1b0c9d8e7f6A5B4";
   const subgraphUrl = "https://subgraph.test";
 
-  const subgraphTicket = (overrides = {}) => ({
+  const exitTicket = {
     assets: "1050000000000000000",
     claimableAt: 1_700_000_000,
     owner: owner.toLowerCase(),
@@ -499,30 +498,9 @@ describe("variable-stake/getUserExitTickets", function () {
     requestTxHash: `0x${"1".repeat(64)}`,
     shares: "1000000000000000000",
     stakingVaultAddress: sVusdAddress.toLowerCase(),
-    ...overrides,
-  });
+  };
 
   it("returns the addresses in checksummed format", async function () {
-    const exitTicket = subgraphTicket({ receiver: receiver.toLowerCase() });
-    vi.mocked(graphql.runQuery).mockResolvedValue({
-      exitTickets: [exitTicket],
-    });
-
-    const [ticket] = await getUserExitTickets({
-      address: owner,
-      url: subgraphUrl,
-    });
-
-    expect(ticket).toEqual({
-      ...exitTicket,
-      owner,
-      receiver,
-      stakingVaultAddress: sVusdAddress,
-    });
-  });
-
-  it("keeps a null receiver as is", async function () {
-    const exitTicket = subgraphTicket({ receiver: null });
     vi.mocked(graphql.runQuery).mockResolvedValue({
       exitTickets: [exitTicket],
     });

--- a/api/test/variable-stake.test.ts
+++ b/api/test/variable-stake.test.ts
@@ -14,7 +14,12 @@ import { describe, expect, it, vi } from "vitest";
 
 import * as graphql from "../src/graphql.ts";
 import * as merkl from "../src/merkl.ts";
-import { getApy, getCostBasis, getUserRewards } from "../src/variable-stake.ts";
+import {
+  getApy,
+  getCostBasis,
+  getUserExitTickets,
+  getUserRewards,
+} from "../src/variable-stake.ts";
 
 vi.mock("../src/graphql.ts", () => ({
   runQuery: vi.fn(),
@@ -478,5 +483,59 @@ describe("variable-stake/getCostBasis", function () {
     expect(result[sVusdAddress]).toBe(10n ** 18n);
     // 8e36 / 1e18 = 8e18
     expect(result[sVetBtcAddress]).toBe(8n * 10n ** 18n);
+  });
+});
+
+describe("variable-stake/getUserExitTickets", function () {
+  const owner: Address = "0x2f1f8B6D6b5A09b6a0a1A9A1d8B2eA3D0e7b1a4c";
+  const receiver: Address = "0x9AE1D5c2B3B0F7A6C5d4E3f2A1b0c9d8e7f6A5B4";
+  const subgraphUrl = "https://subgraph.test";
+
+  const subgraphTicket = (overrides = {}) => ({
+    assets: "1050000000000000000",
+    claimableAt: 1_700_000_000,
+    owner: owner.toLowerCase(),
+    requestId: "1",
+    requestTxHash: `0x${"1".repeat(64)}`,
+    shares: "1000000000000000000",
+    stakingVaultAddress: sVusdAddress.toLowerCase(),
+    ...overrides,
+  });
+
+  it("returns the addresses in checksummed format", async function () {
+    const exitTicket = subgraphTicket({ receiver: receiver.toLowerCase() });
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      exitTickets: [exitTicket],
+    });
+
+    const [ticket] = await getUserExitTickets({
+      address: owner,
+      url: subgraphUrl,
+    });
+
+    expect(ticket).toEqual({
+      ...exitTicket,
+      owner,
+      receiver,
+      stakingVaultAddress: sVusdAddress,
+    });
+  });
+
+  it("keeps a null receiver as is", async function () {
+    const exitTicket = subgraphTicket({ receiver: null });
+    vi.mocked(graphql.runQuery).mockResolvedValue({
+      exitTickets: [exitTicket],
+    });
+
+    const [ticket] = await getUserExitTickets({
+      address: owner,
+      url: subgraphUrl,
+    });
+
+    expect(ticket).toEqual({
+      ...exitTicket,
+      owner,
+      stakingVaultAddress: sVusdAddress,
+    });
   });
 });


### PR DESCRIPTION
### Description

The API returned the exit tickets from the subgraph as they came. The subgraph stores addresses in lowercase, so `owner` and `stakingVaultAddress` reached the consumer lowercased, while every other address the API returns is checksummed. A consumer comparing them with a strict equality misses the match — the Earn page groups tickets by `ticket.stakingVaultAddress`, and its optimistic tickets carry the checksummed vault address, so the same vault produced two groups.

`getUserExitTickets` now converts those two fields with `checksumAddress` before the response. I checked every other subgraph query in `api/src`: `getCostBasis` already checksums its vault keys, and the rest (`getExitTicketQueueSize`, the share value, APY and total deposits histories) return no address at all.

The exit ticket response also loses its `receiver` field. `subgraph/schema.graphql` declares it, but no handler in `subgraph/src/earn.ts` ever sets it — `handleWithdrawClaimed` drops the `receiver` the `WithdrawClaimed` event carries — so the API always returned `null` for it. The query no longer asks for it. `cancelTxHash` and `claimTxHash` are nullable for real, so they are now typed `?: Hash | null` to match what the subgraph sends.

Two related changes: `CLAUDE.md` states the convention — worded for any external source, since third-party APIs lowercase addresses too — and `validateMarketId` compares the Morpho loan asset with `isAddressEqual` instead of `===`.

**Commits:**

98b63cb7 Add checksummed address convention for the API
85c92895 Drop the id field exit tickets never return
453fdfbd Return checksummed addresses in exit tickets
194fbe4a Compare the loan asset with isAddressEqual
27a6b132 Allow null in the optional exit ticket fields
027fcb3d Drop the receiver field from exit tickets

### Screenshots

N/A — no UI change.

### Related issue(s)

Closes #736

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
