### PR TITLE
Add svetBTC to the Bridge page

### DIFF
--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -3,6 +3,14 @@ import { arbitrum, base, bsc, hemi, mainnet, optimism } from "viem/chains";
 import { sVetBtcAddress, sVusdAddress } from "./stakingVaultAddresses.ts";
 import type { Token } from "./types.ts";
 
+// The staking vaults are OZ 5.x upgradeable contracts, which store ERC20 state
+// in an ERC-7201 namespace ("openzeppelin.storage.ERC20") instead of at small
+// sequential slots. Inside that struct, _balances is at offset 0 and
+// _allowances at offset 1, so the slot below is `ERC20StorageLocation + 1`
+// (see `ERC20Upgradeable.sol` in @openzeppelin/contracts-upgradeable v5).
+const erc7201Erc20AllowanceSlot =
+  0x52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace01n;
+
 export const knownTokens: Token[] = [
   {
     address: "0x06ea695B91700071B161A434fED42D1DcbAD9f00",
@@ -174,8 +182,7 @@ export const knownTokens: Token[] = [
     chainId: mainnet.id,
     decimals: 18,
     extensions: {
-      allowanceSlot:
-        0x52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace01n,
+      allowanceSlot: erc7201Erc20AllowanceSlot,
       isVaultShare: true,
     },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/svetbtc.svg",
@@ -247,14 +254,7 @@ export const knownTokens: Token[] = [
     chainId: mainnet.id,
     decimals: 18,
     extensions: {
-      // The sVUSD vault is an OZ 5.x upgradeable contract, which stores ERC20
-      // state in an ERC-7201 namespace ("openzeppelin.storage.ERC20") instead
-      // of at small sequential slots. Inside that struct, _balances is at
-      // offset 0 and _allowances at offset 1, so the slot below is
-      // `ERC20StorageLocation + 1` (see `ERC20Upgradeable.sol` in
-      // @openzeppelin/contracts-upgradeable v5).
-      allowanceSlot:
-        0x52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace01n,
+      allowanceSlot: erc7201Erc20AllowanceSlot,
       isVaultShare: true,
     },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/svusd.svg",

--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -174,6 +174,68 @@ export const knownTokens: Token[] = [
     chainId: mainnet.id,
     decimals: 18,
     extensions: {
+      allowanceSlot:
+        0x52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace01n,
+      isVaultShare: true,
+    },
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/svetbtc.svg",
+    name: "Staked Vetro BTC",
+    symbol: "svetBTC",
+  },
+  {
+    address: "0x54181404A037757eb5271Ee4a02CA51844f25eaA",
+    chainId: arbitrum.id,
+    decimals: 18,
+    extensions: {
+      allowanceSlot: 6n,
+      isVaultShare: true,
+    },
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/svetbtc.svg",
+    name: "Staked Vetro BTC",
+    symbol: "svetBTC",
+  },
+  {
+    address: "0x781aea37b81F3CF3Fb9a97E9568BdAF36d2DEF3d",
+    chainId: base.id,
+    decimals: 18,
+    extensions: {
+      allowanceSlot: 6n,
+      isVaultShare: true,
+    },
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/svetbtc.svg",
+    name: "Staked Vetro BTC",
+    symbol: "svetBTC",
+  },
+  {
+    address: "0x37D8C0AFeeF48AA9D925475CF6c73E4D8c74d931",
+    chainId: bsc.id,
+    decimals: 18,
+    extensions: {
+      allowanceSlot: 6n,
+      isVaultShare: true,
+    },
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/svetbtc.svg",
+    name: "Staked Vetro BTC",
+    symbol: "svetBTC",
+  },
+  {
+    address: "0xD8D63De3b64bd06d99F8F5AD8B78Ed2fE7525eC0",
+    chainId: hemi.id,
+    decimals: 18,
+    extensions: {
+      allowanceSlot: 6n,
+      isVaultShare: true,
+    },
+    logoURI: "https://hemilabs.github.io/token-list/l1Logos/svetbtc.svg",
+    name: "Staked Vetro BTC",
+    symbol: "svetBTC",
+  },
+  {
+    address: "0x62D2A7D31e8a61a7aCD472c98c657E053EB01b96",
+    chainId: optimism.id,
+    decimals: 18,
+    extensions: {
+      allowanceSlot: 6n,
       isVaultShare: true,
     },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/svetbtc.svg",

--- a/web/src/utils/bridgeableTokens.ts
+++ b/web/src/utils/bridgeableTokens.ts
@@ -1,4 +1,4 @@
-import { sVusdAddress } from "@vetro-protocol/earn";
+import { sVetBtcAddress, sVusdAddress } from "@vetro-protocol/earn";
 import type { Address, Chain } from "viem";
 import { arbitrum, base, bsc, hemi, mainnet, optimism } from "viem/chains";
 
@@ -71,6 +71,38 @@ export const bridgeableTokens: BridgeTokenChainEntry[] = [
   },
   {
     address: "0x92273Ca3356379C2fe870FE3805cc5e7aB6d19c6",
+    chainId: optimism.id,
+    sharedDecimals: 6,
+  },
+  // svetBTC
+  {
+    address: sVetBtcAddress,
+    chainId: mainnet.id,
+    oftAdapterAddress: "0x010F0Bd6576949e6ac6eEa11Ed8C535388340e94",
+    sharedDecimals: 6,
+  },
+  {
+    address: "0xD8D63De3b64bd06d99F8F5AD8B78Ed2fE7525eC0",
+    chainId: hemi.id,
+    sharedDecimals: 6,
+  },
+  {
+    address: "0x54181404A037757eb5271Ee4a02CA51844f25eaA",
+    chainId: arbitrum.id,
+    sharedDecimals: 6,
+  },
+  {
+    address: "0x781aea37b81F3CF3Fb9a97E9568BdAF36d2DEF3d",
+    chainId: base.id,
+    sharedDecimals: 6,
+  },
+  {
+    address: "0x37D8C0AFeeF48AA9D925475CF6c73E4D8c74d931",
+    chainId: bsc.id,
+    sharedDecimals: 6,
+  },
+  {
+    address: "0x62D2A7D31e8a61a7aCD472c98c657E053EB01b96",
     chainId: optimism.id,
     sharedDecimals: 6,
   },


### PR DESCRIPTION
### Description

Enable svetBTC on the Bridge page: the OFT adapter on Ethereum, and the OFT on Hemi, Arbitrum, Base, BSC, and Optimism. The addresses come from vetro-protocol/vetro-contracts#111.

Note: I have not tested with real funds it works

### Screenshots

<img width="1160" height="1096" alt="image" src="https://github.com/user-attachments/assets/5429c2db-8111-47bf-b1c1-ed73b8c23052" />

<img width="1150" height="1062" alt="image" src="https://github.com/user-attachments/assets/d726c888-97ee-403a-be16-39079c70c64a" />

<img width="1000" height="1238" alt="image" src="https://github.com/user-attachments/assets/3e0d5746-6dc2-4e83-ac05-25fccd5f6731" />

### Related issue(s)

Closes #737

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
