### PR TITLE
Set the html lang attribute per language

### DIFF
--- a/web/src/i18n/config.tsx
+++ b/web/src/i18n/config.tsx
@@ -8,14 +8,22 @@ import { resources } from "./resources";
 const fallbackLng = "en";
 export const supportedLngs = ["en", "es"];
 
-export const initializeI18n = () =>
-  i18n.use(initReactI18next).init({
+const getLanguageFromPath = function () {
+  const [, lang] = window.location.pathname.split("/");
+  return lang && supportedLngs.includes(lang) ? lang : fallbackLng;
+};
+
+export const initializeI18n = function () {
+  const lng = getLanguageFromPath();
+  document.documentElement.lang = lng;
+  return i18n.use(initReactI18next).init({
     debug: import.meta.env.DEV,
     fallbackLng,
-    lng: "en", // Default language
+    lng,
     resources,
     supportedLngs,
   });
+};
 
 /**
  * The caller must return early on a truthy result. <Navigate> navigates
@@ -39,9 +47,13 @@ export const I18nInitializer = function () {
 
   useLayoutEffect(
     function () {
-      if (lang && i18n.language !== lang) {
+      if (!lang) {
+        return;
+      }
+      if (i18n.language !== lang) {
         i18n.changeLanguage(lang);
       }
+      document.documentElement.lang = lang;
     },
     [lang],
   );


### PR DESCRIPTION
### Description

`web/index.html` hardcodes `<html lang="en">` and nothing updated it, so the attribute said `en` even on the Spanish routes. Screen readers thus applied English pronunciation rules to Spanish text, and browser translation prompts and `:lang()` selectors got the wrong value.

`initializeI18n` now reads the language from the first path segment. It sets `document.documentElement.lang` and gives i18next the same value as `lng`, so the attribute and the strings agree at the first paint. `I18nInitializer` keeps the attribute in sync on each later route change. An unknown or missing segment falls back to `en`, which matches the router redirects.

### Screenshots

N/A — no visual change.

### Related issue(s)

Closes #740

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
