### PR TITLE
Dedupe language-from-path detection

### DIFF
--- a/web/src/i18n/config.tsx
+++ b/web/src/i18n/config.tsx
@@ -3,18 +3,11 @@ import { useLayoutEffect } from "react";
 import { initReactI18next } from "react-i18next";
 import { useLocation, useParams } from "react-router";
 
+import { fallbackLng, getLanguageFromPath, supportedLngs } from "./language";
 import { resources } from "./resources";
 
-const fallbackLng = "en";
-export const supportedLngs = ["en", "es"];
-
-const getLanguageFromPath = function () {
-  const [, lang] = window.location.pathname.split("/");
-  return lang && supportedLngs.includes(lang) ? lang : fallbackLng;
-};
-
 export const initializeI18n = function () {
-  const lng = getLanguageFromPath();
+  const lng = getLanguageFromPath(window.location.pathname) ?? fallbackLng;
   document.documentElement.lang = lng;
   return i18n.use(initReactI18next).init({
     debug: import.meta.env.DEV,

--- a/web/src/i18n/language.ts
+++ b/web/src/i18n/language.ts
@@ -1,0 +1,7 @@
+export const fallbackLng = "en";
+export const supportedLngs = ["en", "es"] as const;
+
+export function getLanguageFromPath(pathname: string) {
+  const [, candidate] = pathname.split("/");
+  return supportedLngs.find((language) => language === candidate);
+}

--- a/web/src/i18n/path.ts
+++ b/web/src/i18n/path.ts
@@ -1,11 +1,10 @@
-import { supportedLngs } from "./config";
+import { getLanguageFromPath } from "./language";
 
 export function normalizePath(pathname: string) {
-  const locale = supportedLngs.find(
-    (candidate) =>
-      pathname === `/${candidate}` || pathname.startsWith(`/${candidate}/`),
-  );
-  const withoutLocale = locale ? pathname.slice(locale.length + 1) : pathname;
-  const withoutTrailingSlash = withoutLocale.replace(/\/$/, "");
+  const language = getLanguageFromPath(pathname);
+  const withoutLanguage = language
+    ? pathname.slice(language.length + 1)
+    : pathname;
+  const withoutTrailingSlash = withoutLanguage.replace(/\/$/, "");
   return withoutTrailingSlash || "/";
 }

--- a/web/test/i18n/language.test.ts
+++ b/web/test/i18n/language.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { getLanguageFromPath } from "../../src/i18n/language";
+
+describe("getLanguageFromPath", function () {
+  it("returns the language of the first path segment", function () {
+    expect(getLanguageFromPath("/en/swap")).toBe("en");
+    expect(getLanguageFromPath("/es/earn")).toBe("es");
+  });
+
+  it("returns the language for language-only paths", function () {
+    expect(getLanguageFromPath("/en")).toBe("en");
+    expect(getLanguageFromPath("/es/")).toBe("es");
+  });
+
+  it("returns undefined when the first segment is not a supported language", function () {
+    expect(getLanguageFromPath("/")).toBeUndefined();
+    expect(getLanguageFromPath("")).toBeUndefined();
+    expect(getLanguageFromPath("/swap")).toBeUndefined();
+    expect(getLanguageFromPath("/fr/swap")).toBeUndefined();
+  });
+
+  it("does not match a segment that merely starts with a language", function () {
+    expect(getLanguageFromPath("/ensure")).toBeUndefined();
+    expect(getLanguageFromPath("/english/swap")).toBeUndefined();
+  });
+
+  it("ignores languages in later segments of an absolute path", function () {
+    expect(getLanguageFromPath("/swap/en")).toBeUndefined();
+  });
+});

--- a/web/test/i18n/path.test.ts
+++ b/web/test/i18n/path.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizePath } from "./path";
+import { normalizePath } from "../../src/i18n/path";
 
 describe("normalizePath", function () {
   it("strips the locale prefix", function () {


### PR DESCRIPTION
### Description

`web/src/i18n/` had two independent rules to find the supported language in a pathname: `getLanguageFromPath` in `config.tsx` (from #741) and the `supportedLngs.find(...)` inside `normalizePath` in `path.ts`. Both encoded the same thing — the first path segment that matches `supportedLngs` — through different mechanisms.

A new `web/src/i18n/language.ts` now holds that rule, together with `supportedLngs` and `fallbackLng`. `normalizePath` and `initializeI18n` both call it. Behavior is unchanged.

The constants moved out of `config.tsx` on purpose. If the helper had stayed in `path.ts` and read `supportedLngs` from `config.tsx`, then `config.tsx` importing the helper would close an import cycle. Both files now depend on `language.ts`, which depends on nothing.

Two smaller points:

- The issue proposes the name `getLocaleFromPath`. I kept `getLanguageFromPath` instead, because every neighbouring name uses "language" — `supportedLngs`, `fallbackLng`, the `lang` route param, `useUnsupportedLanguageRedirect`, `i18n.changeLanguage`. Happy to rename if you prefer the issue's wording.
- `supportedLngs` is now `as const`, so the helper returns `"en" | "es" | undefined` instead of `string | undefined`, and no module can push to the array.

The i18n unit tests also moved from `web/src/i18n/` to `web/test/i18n/`, which matches where the rest of `web`'s unit tests live. Git tracked `path.test.ts` as a rename, so its history follows it.

### Screenshots

N/A — no UI change.

### Related issue(s)

Closes #743

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
