### PR TITLE
Fix flaky Earn test

### DIFF
--- a/web/e2e/earn.spec.ts
+++ b/web/e2e/earn.spec.ts
@@ -89,7 +89,7 @@ test("deposit VUSD into the Earn pool", async function ({
     }),
   ]);
 
-  await page.goto("/");
+  await page.goto("/earn");
 
   // The mock wallet auto-connects silently via EIP-6963 (see fixtures/wallet),
   // so just wait for the header button to switch from "Connect wallet" to the
@@ -97,10 +97,6 @@ test("deposit VUSD into the Earn pool", async function ({
   await expect(
     page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
   ).toBeVisible({ timeout: 30_000 });
-
-  // Navigate to Earn from the navbar, like a user would.
-  await page.getByRole("link", { name: "Earn" }).click();
-  await expect(page).toHaveURL(/\/en\/earn/);
 
   // The Earn page renders one PoolInfoBar per vault (VUSD, vetBTC). Scope the
   // Deposit click to the bar that shows the "VUSD" token symbol so the test
@@ -281,14 +277,11 @@ test("withdraw VUSD from the Earn pool (whitelisted one-step exit)", async funct
     }),
   ]);
 
-  await page.goto("/");
+  await page.goto("/earn");
 
   await expect(
     page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
   ).toBeVisible({ timeout: 30_000 });
-
-  await page.getByRole("link", { name: "Earn" }).click();
-  await expect(page).toHaveURL(/\/en\/earn/);
 
   // Scope to the VUSD pool bar and open its Withdraw drawer. The bar is the only
   // element holding both the "VUSD" label and a Withdraw button; `.last()` picks
@@ -396,14 +389,11 @@ test("withdraw VUSD from the Earn pool (two-step cooldown exit)", async function
     route.fulfill({ json: exitTicketsBody }),
   );
 
-  await page.goto("/");
+  await page.goto("/earn");
 
   await expect(
     page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
   ).toBeVisible({ timeout: 30_000 });
-
-  await page.getByRole("link", { name: "Earn" }).click();
-  await expect(page).toHaveURL(/\/en\/earn/);
 
   // Open the VUSD pool's Withdraw drawer (same locator as the one-step test).
   const vusdPool = page
@@ -685,14 +675,11 @@ test("delete an exit ticket while it is in cooldown", async function ({
     route.fulfill({ json: exitTicketsBody }),
   );
 
-  await page.goto("/");
+  await page.goto("/earn");
 
   await expect(
     page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
   ).toBeVisible({ timeout: 30_000 });
-
-  await page.getByRole("link", { name: "Earn" }).click();
-  await expect(page).toHaveURL(/\/en\/earn/);
 
   const exitTickets = page.locator("#exit-tickets");
   await expect(exitTickets.getByText("Cooldown in progress")).toBeVisible({
@@ -894,14 +881,11 @@ test("withdraw all the ready exit tickets", async function ({
     route.fulfill({ json: exitTicketsBody }),
   );
 
-  await page.goto("/");
+  await page.goto("/earn");
 
   await expect(
     page.getByRole("button", { name: /^0x[a-f0-9]{4}/i }),
   ).toBeVisible({ timeout: 30_000 });
-
-  await page.getByRole("link", { name: "Earn" }).click();
-  await expect(page).toHaveURL(/\/en\/earn/);
 
   const exitTickets = page.locator("#exit-tickets");
   await expect(exitTickets.getByText("Ready to withdraw")).toHaveCount(3, {


### PR DESCRIPTION
### Description

<!-- Explain the changes included in this PR and why are relevant or what
problem does it solve. -->

This PR intends to fix some Earn tests that were failing occasionally.

The problem was the following:

The app redirects automatically from `/` => `/en` => `/en/swap`

The navbar renders on all of these pages (as it's not dependent on the page the user is on- the navbar is always the same). What would happen ocasionally is that the test would start on `/`, and then the test would click on the `/earn` link in the navbar before the last redirect took place. Because of this, the user would be redirected to `/en/earn` and then, on top of that, to `/en/swap` - this caused the Earn page not to render at all - causing the test to fail.

For regular users, this is not a problem because it happens at the milliseconds level. For automated tests, it was "random" as it depended on how long the redirects would take.

Found with AI's help - let's see if this fixes it

The fix: Just start on `/earn` directly at the beginning of the test.

### Screenshots

<!-- For UI changes, include screenshots or even videos if possible. -->
N/A

### Related issue(s)

<!-- Link the PR to the corresponding issues. To link more than one issue, add
new lines with the proper keyword. Remove the lines that are not applicable. -->

Related to #728

### Checklist

<!-- Check all the following questions. If any item is not applicable to this
PR and it says "or N/A", mark it as well. -->

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
