### PR TITLE
Fix allowance slot of cross-chain VUSD tokens

### DIFF
--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -90,6 +90,7 @@ export const knownTokens: Token[] = [
     chainId: arbitrum.id,
     decimals: 18,
     extensions: {
+      allowanceSlot: 6n,
       priceSymbol: "USDT",
     },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/vetrousd.svg",
@@ -101,6 +102,7 @@ export const knownTokens: Token[] = [
     chainId: base.id,
     decimals: 18,
     extensions: {
+      allowanceSlot: 6n,
       priceSymbol: "USDT",
     },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/vetrousd.svg",
@@ -112,6 +114,7 @@ export const knownTokens: Token[] = [
     chainId: bsc.id,
     decimals: 18,
     extensions: {
+      allowanceSlot: 6n,
       priceSymbol: "USDT",
     },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/vetrousd.svg",
@@ -123,6 +126,7 @@ export const knownTokens: Token[] = [
     chainId: hemi.id,
     decimals: 18,
     extensions: {
+      allowanceSlot: 6n,
       priceSymbol: "USDT",
     },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/vetrousd.svg",
@@ -134,6 +138,7 @@ export const knownTokens: Token[] = [
     chainId: optimism.id,
     decimals: 18,
     extensions: {
+      allowanceSlot: 6n,
       priceSymbol: "USDT",
     },
     logoURI: "https://hemilabs.github.io/token-list/l1Logos/vetrousd.svg",


### PR DESCRIPTION
### Description

The cross-chain VUSD OFT entries in `packages/core/src/tokens.ts` had no `extensions.allowanceSlot`, so `createErc20AllowanceStateOverride` fell back to the default slot `1n`. Those OFTs store `_allowances` at slot 6, so the override wrote to an unused slot and did nothing. The "skip approval for gas estimation" path then reverted for users with no allowance.

This adds `allowanceSlot: 6n` to the 5 entries: Arbitrum, Base, BSC, Hemi and Optimism.

### Screenshots

N/A — no UI change.

### Related issue(s)

Closes #754

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
