### PR TITLE
Restore staking position on withdraw cancel

### DIFF
--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vetro-app-subgraph",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "MIT",
   "scripts": {
     "prebuild": "$npm_execpath run codegen",

--- a/subgraph/src/earn.ts
+++ b/subgraph/src/earn.ts
@@ -99,6 +99,22 @@ function handleDailyApr(
   }
 }
 
+function loadOrCreateUserStakingPosition(
+  vaultAddress: Address,
+  owner: Address,
+): UserStakingPosition {
+  const id = buildId(vaultAddress, owner.toHexString());
+  let position = UserStakingPosition.load(id);
+  if (position == null) {
+    position = new UserStakingPosition(id);
+    position.owner = owner;
+    position.shares = BigInt.fromI32(0);
+    position.stakingVaultAddress = vaultAddress;
+    position.totalCostBasis = BigInt.fromI32(0);
+  }
+  return position;
+}
+
 function loadOrCreateQueueSummary(
   vaultAddress: Address,
 ): ExitTicketQueueSummary {
@@ -168,17 +184,10 @@ export function handleBlock(block: ethereum.Block): void {
 
 export function handleDeposit(event: Deposit): void {
   const vaultAddress = dataSource.address();
-  const owner = event.params.owner;
-  const id = buildId(vaultAddress, owner.toHexString());
-
-  let entity = UserStakingPosition.load(id);
-  if (entity == null) {
-    entity = new UserStakingPosition(id);
-    entity.owner = owner;
-    entity.shares = BigInt.fromI32(0);
-    entity.stakingVaultAddress = vaultAddress;
-    entity.totalCostBasis = BigInt.fromI32(0);
-  }
+  const entity = loadOrCreateUserStakingPosition(
+    vaultAddress,
+    event.params.owner,
+  );
 
   entity.shares = entity.shares.plus(event.params.shares);
   entity.totalCostBasis = entity.totalCostBasis.plus(
@@ -240,15 +249,10 @@ export function handleTransfer(event: Transfer): void {
   const assetValueResult = vault.try_convertToAssets(value);
   const assetValue = assetValueResult.reverted ? value : assetValueResult.value;
 
-  const toId = buildId(vaultAddress, event.params.to.toHexString());
-  let toEntity = UserStakingPosition.load(toId);
-  if (toEntity == null) {
-    toEntity = new UserStakingPosition(toId);
-    toEntity.owner = event.params.to;
-    toEntity.shares = BigInt.fromI32(0);
-    toEntity.stakingVaultAddress = vaultAddress;
-    toEntity.totalCostBasis = BigInt.fromI32(0);
-  }
+  const toEntity = loadOrCreateUserStakingPosition(
+    vaultAddress,
+    event.params.to,
+  );
 
   toEntity.shares = toEntity.shares.plus(value);
   toEntity.totalCostBasis = toEntity.totalCostBasis.plus(assetValue.times(WAD));
@@ -282,6 +286,19 @@ export function handleWithdrawRequested(event: WithdrawRequested): void {
 
 export function handleWithdrawCancelled(event: WithdrawCancelled): void {
   const vaultAddress = dataSource.address();
+
+  const position = loadOrCreateUserStakingPosition(
+    vaultAddress,
+    event.params.owner,
+  );
+
+  position.shares = position.shares.plus(event.params.shares);
+  position.totalCostBasis = position.totalCostBasis.plus(
+    event.params.assets.times(WAD),
+  );
+
+  position.save();
+
   const id = buildId(vaultAddress, event.params.requestId.toString());
   const entity = ExitTicket.load(id);
   if (entity == null) {

--- a/subgraph/tests/earn.test.ts
+++ b/subgraph/tests/earn.test.ts
@@ -738,6 +738,56 @@ describe("handleWithdrawCancelled", function () {
     );
   });
 
+  test("restores shares and totalCostBasis when cancelled", function () {
+    handleDeposit(
+      createDepositEvent(
+        BigInt.fromString("3500000000000000000000"),
+        ownerAddress,
+        ownerAddress,
+        BigInt.fromString("3500000000000000000000"),
+      ),
+    );
+
+    const burntShares = BigInt.fromString("3480113636363636363636");
+    const requestId = BigInt.fromI32(1);
+    handleWithdrawRequested(
+      createWithdrawRequestedEvent(
+        BigInt.fromString("3500000000000000000000"),
+        BigInt.fromI32(1769817600),
+        ownerAddress,
+        requestId,
+        burntShares,
+      ),
+    );
+    handleTransfer(
+      createTransferEvent(ownerAddress, Address.zero(), burntShares),
+    );
+
+    handleWithdrawCancelled(
+      createWithdrawCancelledEvent(
+        BigInt.fromString("3500000000000000000000"),
+        ownerAddress,
+        requestId,
+        burntShares,
+      ),
+    );
+
+    const id = `${vaultAddressString}-${ownerAddressString}`;
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "shares",
+      "3500000000000000000000",
+    );
+    // The burn left 19.886...e36 behind. The cancel adds 3500e36 back.
+    assert.fieldEquals(
+      "UserStakingPosition",
+      id,
+      "totalCostBasis",
+      "3519886363636363636364000000000000000000",
+    );
+  });
+
   test("ignores missing ExitTicket on cancel", function () {
     const assets = BigInt.fromString("1000000000000000000");
     const requestId = BigInt.fromI32(999);


### PR DESCRIPTION
### Description

`cancelWithdraw` re-mints the shares the withdraw request burned, but that mint has no `Deposit` event, so `handleTransfer` skips it. Nothing restored the shares or their cost basis, and the Earn page then showed almost the whole position as "Earned amount".

`handleWithdrawCancelled` now restores both. Already indexed positions need a re-index.

### Screenshots

N/A

### Related issue(s)

Closes #770

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.