### PR TITLE
Fix skeleton alignment while prices load

### DIFF
--- a/web/src/components/base/cryptoValue.tsx
+++ b/web/src/components/base/cryptoValue.tsx
@@ -39,5 +39,5 @@ export const RenderCryptoValue = function ({
     return <>-</>;
   }
   // Loading state
-  return <Skeleton className="h-full" containerClassName="basis-1/3" />;
+  return <Skeleton className="h-full" inline width={80} />;
 };

--- a/web/src/components/base/cryptoValue.tsx
+++ b/web/src/components/base/cryptoValue.tsx
@@ -39,5 +39,5 @@ export const RenderCryptoValue = function ({
     return <>-</>;
   }
   // Loading state
-  return <Skeleton className="h-full" inline width={80} />;
+  return <Skeleton inline width={80} />;
 };

--- a/web/src/components/base/dollarSign.tsx
+++ b/web/src/components/base/dollarSign.tsx
@@ -1,0 +1,1 @@
+export const DollarSign = () => <span className="mr-1">$</span>;

--- a/web/src/components/base/fiatValue.tsx
+++ b/web/src/components/base/fiatValue.tsx
@@ -44,7 +44,7 @@ const RenderFiatValueUnsafe = function ({
   }
 
   // Loading state (either balance or prices are loading)
-  return <Skeleton className="h-full" inline width={32} />;
+  return <Skeleton inline width={32} />;
 };
 
 export const RenderFiatValue = (

--- a/web/src/components/base/fiatValue.tsx
+++ b/web/src/components/base/fiatValue.tsx
@@ -44,7 +44,7 @@ const RenderFiatValueUnsafe = function ({
   }
 
   // Loading state (either balance or prices are loading)
-  return <Skeleton className="h-full" containerClassName="w-8" />;
+  return <Skeleton className="h-full" inline width={32} />;
 };
 
 export const RenderFiatValue = (

--- a/web/src/components/borrow/borrowProgressDrawer.tsx
+++ b/web/src/components/borrow/borrowProgressDrawer.tsx
@@ -1,5 +1,6 @@
 import type { Token } from "@vetro-protocol/core";
 import { Button } from "components/base/button";
+import { DollarSign } from "components/base/dollarSign";
 import { DrawerTitle } from "components/base/drawer/drawerTitle";
 import { RenderFiatValue } from "components/base/fiatValue";
 import {
@@ -61,7 +62,7 @@ export function BorrowProgressDrawer({
           amount={collateralAmount}
           detail={
             <>
-              <span className="mr-1">$</span>
+              <DollarSign />
               <RenderFiatValue
                 token={collateralToken}
                 value={parsedCollateralAmount}
@@ -76,7 +77,7 @@ export function BorrowProgressDrawer({
           amount={borrowAmount}
           detail={
             <>
-              <span className="mr-1">$</span>
+              <DollarSign />
               <RenderFiatValue token={borrowToken} value={parsedBorrowAmount} />
             </>
           }

--- a/web/src/components/borrow/marketInfoCards.tsx
+++ b/web/src/components/borrow/marketInfoCards.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "components/base/badge";
 import { RenderCryptoValue } from "components/base/cryptoValue";
+import { DollarSign } from "components/base/dollarSign";
 import { RenderFiatValue } from "components/base/fiatValue";
 import { InfoCard } from "components/base/infoCard";
 import { BoltIcon } from "components/icons/boltIcon";
@@ -28,7 +29,7 @@ export function MarketInfoCards({ market }: { market: MarketData }) {
             label={t("pages.borrow.pool-size")}
             render={(collateralAssets) => (
               <>
-                <span className="mr-1">$</span>
+                <DollarSign />
                 <RenderFiatValue
                   token={market.collateralToken}
                   value={collateralAssets}
@@ -55,7 +56,7 @@ export function MarketInfoCards({ market }: { market: MarketData }) {
             label={t("pages.borrow.available-to-borrow")}
             render={(liquidity) => (
               <>
-                <span className="mr-1">$</span>
+                <DollarSign />
                 <RenderFiatValue token={market.loanToken} value={liquidity} />
               </>
             )}

--- a/web/src/components/borrow/tokenValueCell.tsx
+++ b/web/src/components/borrow/tokenValueCell.tsx
@@ -1,6 +1,7 @@
 import { type QueryStatus } from "@tanstack/react-query";
 import type { Token } from "@vetro-protocol/core";
 import { RenderCryptoValue } from "components/base/cryptoValue";
+import { DollarSign } from "components/base/dollarSign";
 import { RenderFiatValue } from "components/base/fiatValue";
 
 type Props = {
@@ -22,7 +23,7 @@ export const TokenValueCell = ({
     <span
       className={`text-b-medium ${align === "left" ? "text-left" : "text-right"} text-gray-900`}
     >
-      <span className="mr-1">$</span>
+      <DollarSign />
       <RenderFiatValue queryStatus={status} token={token} value={value} />
     </span>
     <span className="text-caption text-gray-500 *:w-full">

--- a/web/src/components/bridgeForm/bridgeFees.tsx
+++ b/web/src/components/bridgeForm/bridgeFees.tsx
@@ -1,14 +1,13 @@
 import type { Token } from "@vetro-protocol/core";
+import { DollarSign } from "components/base/dollarSign";
 import { FeeDetails } from "components/feeDetails";
 import { FeesContainer } from "components/feesContainer";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { formatFiatNumber } from "utils/format";
 
-const DollarSign = () => <span>$</span>;
-
 const Container = ({ children }: { children: ReactNode }) => (
-  <div className="flex items-center gap-x-1">{children}</div>
+  <div className="flex items-center">{children}</div>
 );
 
 type FeeData = {

--- a/web/src/components/swapForm/swapFees.tsx
+++ b/web/src/components/swapForm/swapFees.tsx
@@ -1,5 +1,6 @@
 import type { FetchStatus, QueryStatus } from "@tanstack/react-query";
 import type { Token } from "@vetro-protocol/core";
+import { DollarSign } from "components/base/dollarSign";
 import { RenderFiatValue } from "components/base/fiatValue";
 import { FeeDetails } from "components/feeDetails";
 import { FeesContainer } from "components/feesContainer";
@@ -8,8 +9,6 @@ import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { formatFiatNumber } from "utils/format";
 import { getNativeToken } from "utils/nativeToken";
-
-const DollarSign = () => <span>$</span>;
 
 type FeeData = {
   data: bigint | undefined;
@@ -33,7 +32,7 @@ type Props = {
 };
 
 const Container = ({ children }: { children: ReactNode }) => (
-  <div className="flex items-center gap-x-1">{children}</div>
+  <div className="flex items-center">{children}</div>
 );
 
 export const SwapFees = function ({

--- a/web/src/components/swapForm/swapProgressDrawer.tsx
+++ b/web/src/components/swapForm/swapProgressDrawer.tsx
@@ -64,7 +64,7 @@ export function SwapProgressDrawer({
             amount={fromAmount}
             detail={
               <>
-                $
+                <span className="mr-1">$</span>
                 <RenderFiatValue
                   token={fromToken}
                   value={parseTokenUnits(fromAmount, fromToken)}
@@ -81,7 +81,7 @@ export function SwapProgressDrawer({
               amount={outputValue}
               detail={
                 <>
-                  $
+                  <span className="mr-1">$</span>
                   <RenderFiatValue
                     queryStatus={isOutputError ? "error" : "success"}
                     token={toToken}

--- a/web/src/components/swapForm/swapProgressDrawer.tsx
+++ b/web/src/components/swapForm/swapProgressDrawer.tsx
@@ -1,4 +1,5 @@
 import { Button } from "components/base/button";
+import { DollarSign } from "components/base/dollarSign";
 import { DrawerTitle } from "components/base/drawer/drawerTitle";
 import { RenderFiatValue } from "components/base/fiatValue";
 import {
@@ -64,7 +65,7 @@ export function SwapProgressDrawer({
             amount={fromAmount}
             detail={
               <>
-                <span className="mr-1">$</span>
+                <DollarSign />
                 <RenderFiatValue
                   token={fromToken}
                   value={parseTokenUnits(fromAmount, fromToken)}
@@ -81,7 +82,7 @@ export function SwapProgressDrawer({
               amount={outputValue}
               detail={
                 <>
-                  <span className="mr-1">$</span>
+                  <DollarSign />
                   <RenderFiatValue
                     queryStatus={isOutputError ? "error" : "success"}
                     token={toToken}

--- a/web/src/components/tokenSelectorModal/tokenRow.tsx
+++ b/web/src/components/tokenSelectorModal/tokenRow.tsx
@@ -49,7 +49,8 @@ export function TokenRow<T extends Token>({
             <RenderCryptoValue status={status} token={token} value={balance} />
           </div>
           <span className="text-b-regular text-gray-500">
-            $<BridgeTokenFiatValue token={token} value={balance} />
+            <span className="mr-1">$</span>
+            <BridgeTokenFiatValue token={token} value={balance} />
           </span>
         </div>
       ) : null}

--- a/web/src/components/tokenSelectorModal/tokenRow.tsx
+++ b/web/src/components/tokenSelectorModal/tokenRow.tsx
@@ -1,6 +1,7 @@
 import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
 import type { Token } from "@vetro-protocol/core";
 import { RenderCryptoValue } from "components/base/cryptoValue";
+import { DollarSign } from "components/base/dollarSign";
 import { BridgeTokenFiatValue } from "components/bridgeForm/bridgeTokenFiatValue";
 import { TokenChainLogo } from "components/bridgeForm/tokenChainLogo";
 import { TokenLogo } from "components/tokenLogo";
@@ -49,7 +50,7 @@ export function TokenRow<T extends Token>({
             <RenderCryptoValue status={status} token={token} value={balance} />
           </div>
           <span className="text-b-regular text-gray-500">
-            <span className="mr-1">$</span>
+            <DollarSign />
             <BridgeTokenFiatValue token={token} value={balance} />
           </span>
         </div>

--- a/web/src/pages/earn/components/exitTickets/withdrawAllProgressDrawer.tsx
+++ b/web/src/pages/earn/components/exitTickets/withdrawAllProgressDrawer.tsx
@@ -87,7 +87,8 @@ const Row = ({ amount, peggedToken, status }: RowProps) => (
       })}
       detail={
         <>
-          $<RenderFiatValue token={peggedToken} value={amount} />
+          <span className="mr-1">$</span>
+          <RenderFiatValue token={peggedToken} value={amount} />
         </>
       }
       token={peggedToken}

--- a/web/src/pages/earn/components/exitTickets/withdrawAllProgressDrawer.tsx
+++ b/web/src/pages/earn/components/exitTickets/withdrawAllProgressDrawer.tsx
@@ -1,5 +1,6 @@
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { Button } from "components/base/button";
+import { DollarSign } from "components/base/dollarSign";
 import { DrawerTitle } from "components/base/drawer/drawerTitle";
 import { RenderFiatValue } from "components/base/fiatValue";
 import { Spinner } from "components/base/spinner";
@@ -87,7 +88,7 @@ const Row = ({ amount, peggedToken, status }: RowProps) => (
       })}
       detail={
         <>
-          <span className="mr-1">$</span>
+          <DollarSign />
           <RenderFiatValue token={peggedToken} value={amount} />
         </>
       }

--- a/web/src/pages/earn/components/stakeForm/stakeDepositProgressDrawer.tsx
+++ b/web/src/pages/earn/components/stakeForm/stakeDepositProgressDrawer.tsx
@@ -1,5 +1,6 @@
 import type { Token } from "@vetro-protocol/core";
 import { RenderCryptoValue } from "components/base/cryptoValue";
+import { DollarSign } from "components/base/dollarSign";
 import { DrawerTitle } from "components/base/drawer/drawerTitle";
 import { RenderFiatValue } from "components/base/fiatValue";
 import {
@@ -124,7 +125,7 @@ export function StakeDepositProgressDrawer({
 
   const fiatDetail = (
     <>
-      <span className="mr-1">$</span>
+      <DollarSign />
       <RenderFiatValue token={peggedToken} value={assets} />
     </>
   );

--- a/web/src/pages/earn/components/stakeForm/stakeDepositProgressDrawer.tsx
+++ b/web/src/pages/earn/components/stakeForm/stakeDepositProgressDrawer.tsx
@@ -124,7 +124,8 @@ export function StakeDepositProgressDrawer({
 
   const fiatDetail = (
     <>
-      $<RenderFiatValue token={peggedToken} value={assets} />
+      <span className="mr-1">$</span>
+      <RenderFiatValue token={peggedToken} value={assets} />
     </>
   );
 

--- a/web/src/pages/earn/components/stakeForm/stakeWithdrawProgressDrawer.tsx
+++ b/web/src/pages/earn/components/stakeForm/stakeWithdrawProgressDrawer.tsx
@@ -111,7 +111,8 @@ function InstantWithdrawSummary({
 
   const fiatDetail = (
     <>
-      $<RenderFiatValue token={peggedToken} value={assets} />
+      <span className="mr-1">$</span>
+      <RenderFiatValue token={peggedToken} value={assets} />
     </>
   );
 
@@ -152,7 +153,8 @@ function QueuedWithdrawSummary({
       amount={amount}
       detail={
         <>
-          $<RenderFiatValue token={peggedToken} value={assets} />
+          <span className="mr-1">$</span>
+          <RenderFiatValue token={peggedToken} value={assets} />
         </>
       }
       label={t("pages.earn.stake.you-are-requesting-to-withdraw")}

--- a/web/src/pages/earn/components/stakeForm/stakeWithdrawProgressDrawer.tsx
+++ b/web/src/pages/earn/components/stakeForm/stakeWithdrawProgressDrawer.tsx
@@ -1,5 +1,6 @@
 import type { Token } from "@vetro-protocol/core";
 import { RenderCryptoValue } from "components/base/cryptoValue";
+import { DollarSign } from "components/base/dollarSign";
 import { DrawerTitle } from "components/base/drawer/drawerTitle";
 import { RenderFiatValue } from "components/base/fiatValue";
 import {
@@ -111,7 +112,7 @@ function InstantWithdrawSummary({
 
   const fiatDetail = (
     <>
-      <span className="mr-1">$</span>
+      <DollarSign />
       <RenderFiatValue token={peggedToken} value={assets} />
     </>
   );
@@ -153,7 +154,7 @@ function QueuedWithdrawSummary({
       amount={amount}
       detail={
         <>
-          <span className="mr-1">$</span>
+          <DollarSign />
           <RenderFiatValue token={peggedToken} value={assets} />
         </>
       }

--- a/web/src/pages/earn/components/stakedBalanceStat/index.tsx
+++ b/web/src/pages/earn/components/stakedBalanceStat/index.tsx
@@ -1,6 +1,7 @@
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { Badge } from "components/base/badge";
+import { DollarSign } from "components/base/dollarSign";
 import { RenderFiatValue } from "components/base/fiatValue";
 import { InfoCard } from "components/base/infoCard";
 import { BoltIcon } from "components/icons/boltIcon";
@@ -44,7 +45,7 @@ function PoolRow({ balance, stakingVaultAddress }: PoolRowProps) {
         {peggedToken.symbol}
       </span>
       <span className="text-xsm font-medium text-white">
-        <span className="mr-1">$</span>
+        <DollarSign />
         <RenderFiatValue token={peggedToken} value={balance} />
       </span>
       <span className="text-xsm font-medium text-gray-400">

--- a/web/src/pages/earn/components/stakedBalanceStat/index.tsx
+++ b/web/src/pages/earn/components/stakedBalanceStat/index.tsx
@@ -44,7 +44,8 @@ function PoolRow({ balance, stakingVaultAddress }: PoolRowProps) {
         {peggedToken.symbol}
       </span>
       <span className="text-xsm font-medium text-white">
-        $<RenderFiatValue token={peggedToken} value={balance} />
+        <span className="mr-1">$</span>
+        <RenderFiatValue token={peggedToken} value={balance} />
       </span>
       <span className="text-xsm font-medium text-gray-400">
         ({formattedTokenAmount} {peggedToken.symbol})

--- a/web/stories/dollarSign.stories.tsx
+++ b/web/stories/dollarSign.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { DollarSign } from "../src/components/base/dollarSign";
+
+const meta: Meta<typeof DollarSign> = {
+  component: DollarSign,
+  title: "Components/DollarSign",
+};
+
+export default meta;
+type Story = StoryObj<typeof DollarSign>;
+
+export const Default: Story = {};
+
+export const InText: Story = {
+  render: () => (
+    <p className="text-b-regular text-gray-500">
+      <DollarSign />
+      1,234.56
+    </p>
+  ),
+};
+
+export const InFlexRow: Story = {
+  render: () => (
+    <div className="flex items-center">
+      <DollarSign />
+      <span>1,234.56</span>
+    </div>
+  ),
+};


### PR DESCRIPTION
### Description

Fixes some alignment issues in the loading skeletons and adds the missing 4px margin after the `$`.

### Screenshots

<img width="464" height="277" alt="image" src="https://github.com/user-attachments/assets/bdf8a661-cd26-416a-97f5-e20946e87448" />

(Example from storybook)

### Related issue(s)

Closes #778

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.