### PR TITLE
Stop price network calls in Storybook

### DIFF
--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -1,8 +1,11 @@
 import type { Preview } from "@storybook/react";
+import { sb } from "storybook/test";
 
 import "react-loading-skeleton/dist/skeleton.css";
 
 import "../src/index.css";
+
+sb.mock(import("../src/fetchers/fetchPrices.ts"));
 
 const preview: Preview = {
   parameters: {

--- a/web/stories/fiatValue.stories.tsx
+++ b/web/stories/fiatValue.stories.tsx
@@ -1,10 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Token } from "@vetro-protocol/core";
+import { mocked } from "storybook/test";
 import { parseUnits } from "viem";
 import { createConfig, http, WagmiProvider } from "wagmi";
 
 import { RenderFiatValue } from "../src/components/base/fiatValue";
+import { fetchPrices } from "../src/fetchers/fetchPrices";
 import { mainnet } from "../src/networks/mainnet";
 
 const usdc: Token = {
@@ -15,6 +17,8 @@ const usdc: Token = {
   name: "USD Coin",
   symbol: "USDC",
 };
+
+const prices = { USDC: "1.00" };
 
 const wagmiConfig = createConfig({
   chains: [mainnet],
@@ -28,9 +32,13 @@ const queryClient = new QueryClient({
     },
   },
 });
-queryClient.setQueryData(["prices", mainnet.id], { USDC: "1.00" });
+queryClient.setQueryData(["prices", mainnet.id], prices);
 
 const meta = {
+  beforeEach() {
+    mocked(fetchPrices).mockResolvedValue(prices);
+    return () => mocked(fetchPrices).mockReset();
+  },
   component: RenderFiatValue,
   decorators: [
     (Story) => (


### PR DESCRIPTION
### Description

The FiatValue stories rendered a real price query. React Query refetched every 60 seconds, so the stories hit the portal price API and the mainnet RPC on a loop. The portal API blocks localhost, so the refetch failed and the Loading and Error stories showed `-` instead of the skeleton.

`fetchers/fetchPrices` is now automocked in the Storybook preview file, and the story supplies the resolved value. Verified in the browser over 80 seconds: without the mock the Loading story makes 3 calls to `/prices` and 4 to the mainnet RPC; with it, zero.

### Screenshots

N/A — Storybook only, no product UI change.

### Related issue(s)

Closes #731

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.