### PR TITLE
Align token selector with input right edge

### DIFF
--- a/web/src/components/tokenInput/balance.tsx
+++ b/web/src/components/tokenInput/balance.tsx
@@ -8,9 +8,9 @@ type Props = {
 export const Balance = function ({ label, value }: Props) {
   const { address } = useAccount();
   return (
-    <>
+    <div className="flex items-center gap-1">
       <span className="text-gray-500">{label}:</span>
-      <span className="mr-1 text-gray-900">{address ? value : "-"}</span>
-    </>
+      <span className="text-gray-900">{address ? value : "-"}</span>
+    </div>
   );
 };

--- a/web/src/components/tokenInput/index.tsx
+++ b/web/src/components/tokenInput/index.tsx
@@ -47,7 +47,7 @@ export const TokenInput = ({
         ${fiatValue}
       </span>
       {balance || maxButton ? (
-        <div className="text-xsm flex items-center gap-1">
+        <div className="text-xsm flex items-center gap-2">
           {balance}
           {maxButton}
         </div>

--- a/web/src/components/tokenSelectorReadOnly/index.tsx
+++ b/web/src/components/tokenSelectorReadOnly/index.tsx
@@ -5,7 +5,7 @@ import { TokenDisplay } from "../tokenDisplay";
 type Props = Pick<Token, "logoURI" | "symbol">;
 
 export const TokenSelectorReadOnly = ({ logoURI, symbol }: Props) => (
-  <div className="flex items-center gap-1.5 py-1.5 pr-3 pl-1.5">
+  <div className="flex items-center gap-1.5">
     <TokenDisplay logoURI={logoURI} symbol={symbol} />
   </div>
 );

--- a/web/src/components/tokenSelectorSkeleton.tsx
+++ b/web/src/components/tokenSelectorSkeleton.tsx
@@ -1,7 +1,7 @@
 import Skeleton from "react-loading-skeleton";
 
 export const TokenSelectorSkeleton = () => (
-  <div className="flex items-center gap-1.5 rounded-full bg-white/5 py-1.5 pr-3 pl-1.5 leading-none shadow-sm">
+  <div className="flex items-center gap-1.5 rounded-full bg-white/5 p-1.5 pr-2 leading-none shadow-sm">
     <Skeleton circle height={20} width={20} />
     <Skeleton height={14} width={40} />
   </div>

--- a/web/stories/tokenInput.stories.tsx
+++ b/web/stories/tokenInput.stories.tsx
@@ -24,10 +24,10 @@ const tokens = knownTokens.filter((t) => storyTokens.includes(t.symbol));
 export const SwitchToken: Story = {
   args: {
     balance: (
-      <>
+      <div className="flex items-center gap-1">
         <span className="text-gray-500">Balance:</span>
-        <span className="mr-1 text-gray-900">2</span>
-      </>
+        <span className="text-gray-900">2</span>
+      </div>
     ),
     fiatValue: "0.00",
     label: "You are swapping",
@@ -66,10 +66,10 @@ export const SwitchToken: Story = {
 export const ReadOnlyToken: Story = {
   args: {
     balance: (
-      <>
+      <div className="flex items-center gap-1">
         <span className="text-gray-500">Available to withdraw:</span>
-        <span className="mr-1 text-gray-900">200</span>
-      </>
+        <span className="text-gray-900">200</span>
+      </div>
     ),
     fiatValue: "0.00",
     label: "You will withdraw",
@@ -97,10 +97,10 @@ export const ReadOnlyToken: Story = {
 export const WithHeaderAction: Story = {
   args: {
     balance: (
-      <>
+      <div className="flex items-center gap-1">
         <span className="text-gray-500">Balance:</span>
-        <span className="mr-1 text-gray-900">2</span>
-      </>
+        <span className="text-gray-900">2</span>
+      </div>
     ),
     fiatValue: "0.00",
     headerAction: (
@@ -145,10 +145,10 @@ export const WithHeaderAction: Story = {
 export const WithError: Story = {
   args: {
     balance: (
-      <>
+      <div className="flex items-center gap-1">
         <span className="text-gray-500">Balance:</span>
-        <span className="mr-1 text-gray-900">2</span>
-      </>
+        <span className="text-gray-900">2</span>
+      </div>
     ),
     errorKey: "insufficient-balance",
     fiatValue: "100.00",

--- a/web/stories/tokenInput.stories.tsx
+++ b/web/stories/tokenInput.stories.tsx
@@ -21,14 +21,21 @@ type Story = StoryObj<typeof meta>;
 const storyTokens = ["USDC", "USDT"];
 const tokens = knownTokens.filter((t) => storyTokens.includes(t.symbol));
 
+type Props = {
+  label: string;
+  value: string;
+};
+
+const StoryBalance = ({ label, value }: Props) => (
+  <div className="flex items-center gap-1">
+    <span className="text-gray-500">{label}:</span>
+    <span className="text-gray-900">{value}</span>
+  </div>
+);
+
 export const SwitchToken: Story = {
   args: {
-    balance: (
-      <div className="flex items-center gap-1">
-        <span className="text-gray-500">Balance:</span>
-        <span className="text-gray-900">2</span>
-      </div>
-    ),
+    balance: <StoryBalance label="Balance" value="2" />,
     fiatValue: "0.00",
     label: "You are swapping",
     maxButton: <MaxButton onClick={() => alert("max clicked")} />,
@@ -65,12 +72,7 @@ export const SwitchToken: Story = {
 
 export const ReadOnlyToken: Story = {
   args: {
-    balance: (
-      <div className="flex items-center gap-1">
-        <span className="text-gray-500">Available to withdraw:</span>
-        <span className="text-gray-900">200</span>
-      </div>
-    ),
+    balance: <StoryBalance label="Available to withdraw" value="200" />,
     fiatValue: "0.00",
     label: "You will withdraw",
     maxButton: <MaxButton onClick={() => alert("max clicked")} />,
@@ -96,12 +98,7 @@ export const ReadOnlyToken: Story = {
 
 export const WithHeaderAction: Story = {
   args: {
-    balance: (
-      <div className="flex items-center gap-1">
-        <span className="text-gray-500">Balance:</span>
-        <span className="text-gray-900">2</span>
-      </div>
-    ),
+    balance: <StoryBalance label="Balance" value="2" />,
     fiatValue: "0.00",
     headerAction: (
       <button
@@ -144,12 +141,7 @@ export const WithHeaderAction: Story = {
 
 export const WithError: Story = {
   args: {
-    balance: (
-      <div className="flex items-center gap-1">
-        <span className="text-gray-500">Balance:</span>
-        <span className="text-gray-900">2</span>
-      </div>
-    ),
+    balance: <StoryBalance label="Balance" value="2" />,
     errorKey: "insufficient-balance",
     fiatValue: "100.00",
     label: "You are swapping",


### PR DESCRIPTION
### Description

This PR better aligns the token selector inside Token Inputs

### Screenshots

Before

<img width="742" height="470" alt="image" src="https://github.com/user-attachments/assets/2d91ddc8-0a1e-4b68-811c-85384c5c0b58" />

Now

<img width="724" height="568" alt="image" src="https://github.com/user-attachments/assets/869d49e1-8c94-45d7-82e2-3515e2d6f426" />


### Related issue(s)

Closes #764

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A. (N/A — CSS class changes only; the 431 existing web tests pass.)
- [x] Documentation updated, or N/A. (N/A)
- [x] Environment variables set in CI, or N/A. (N/A)
