### PR TITLE
Handle unexpected SDK error events in forms

### DIFF
--- a/web/src/components/borrow/borrowForm.tsx
+++ b/web/src/components/borrow/borrowForm.tsx
@@ -215,6 +215,23 @@ export function BorrowForm({
     collateralAmount: collateralAmountBigInt,
     marketId,
     onEmitter(emitter) {
+      let supplyCollateralSucceeded = false;
+
+      const handleFailure = function (
+        status: "borrow-error" | "supply-collateral-error",
+      ) {
+        onFailed();
+        setFlowStatus(status);
+      };
+
+      const handleUnexpectedError = function () {
+        handleFailure(
+          supplyCollateralSucceeded
+            ? "borrow-error"
+            : "supply-collateral-error",
+        );
+      };
+
       emitter.on("user-signed-approval", () => setFlowStatus("approving"));
       emitter.on("approve-transaction-succeeded", () =>
         setFlowStatus("approved"),
@@ -231,9 +248,10 @@ export function BorrowForm({
       emitter.on("user-signed-supply-collateral", () =>
         setFlowStatus("supplying-collateral"),
       );
-      emitter.on("supply-collateral-transaction-succeeded", () =>
-        setFlowStatus("supplied-collateral"),
-      );
+      emitter.on("supply-collateral-transaction-succeeded", function () {
+        supplyCollateralSucceeded = true;
+        setFlowStatus("supplied-collateral");
+      });
       emitter.on("supply-collateral-transaction-reverted", () =>
         setFlowStatus("supply-collateral-error"),
       );
@@ -258,26 +276,17 @@ export function BorrowForm({
         setShowToast(true);
         watchToken();
       });
-      emitter.on("borrow-assets-transaction-reverted", function () {
-        onFailed();
-        setFlowStatus("borrow-error");
-      });
-      emitter.on("borrow-assets-failed", function () {
-        onFailed();
-        setFlowStatus("borrow-error");
-      });
-      emitter.on("borrow-assets-failed-validation", function () {
-        onFailed();
-        setFlowStatus("borrow-error");
-      });
-      emitter.on("user-signing-borrow-assets-error", function () {
-        onFailed();
-        setFlowStatus("borrow-error");
-      });
-      emitter.on("unexpected-error", function () {
-        onFailed();
-        setFlowStatus("borrow-error");
-      });
+      emitter.on("borrow-assets-transaction-reverted", () =>
+        handleFailure("borrow-error"),
+      );
+      emitter.on("borrow-assets-failed", () => handleFailure("borrow-error"));
+      emitter.on("borrow-assets-failed-validation", () =>
+        handleFailure("borrow-error"),
+      );
+      emitter.on("user-signing-borrow-assets-error", () =>
+        handleFailure("borrow-error"),
+      );
+      emitter.on("unexpected-error", handleUnexpectedError);
     },
   });
 

--- a/web/src/components/borrow/borrowForm.tsx
+++ b/web/src/components/borrow/borrowForm.tsx
@@ -274,6 +274,10 @@ export function BorrowForm({
         onFailed();
         setFlowStatus("borrow-error");
       });
+      emitter.on("unexpected-error", function () {
+        onFailed();
+        setFlowStatus("borrow-error");
+      });
     },
   });
 

--- a/web/src/components/borrow/borrowMoreForm.tsx
+++ b/web/src/components/borrow/borrowMoreForm.tsx
@@ -299,6 +299,10 @@ export function BorrowMoreForm({ market, onClose }: Props) {
         onFailed();
         setFlowStatus("borrow-error");
       });
+      emitter.on("unexpected-error", function () {
+        onFailed();
+        setFlowStatus("borrow-error");
+      });
     },
   });
 

--- a/web/src/components/borrow/repayLoanForm.tsx
+++ b/web/src/components/borrow/repayLoanForm.tsx
@@ -324,6 +324,10 @@ export function RepayLoanForm({ market, onClose }: Props) {
         onFailed();
         setFlowStatus("repay-error");
       });
+      emitter.on("unexpected-error", function () {
+        onFailed();
+        setFlowStatus("repay-error");
+      });
     },
     repayAmount: repayAmountBigInt,
   });

--- a/web/src/components/borrow/supplyCollateralForm.tsx
+++ b/web/src/components/borrow/supplyCollateralForm.tsx
@@ -317,6 +317,10 @@ export function SupplyCollateralForm({ market, onClose }: Props) {
         onFailed();
         setFlowStatus("supply-collateral-error");
       });
+      emitter.on("unexpected-error", function () {
+        onFailed();
+        setFlowStatus("supply-collateral-error");
+      });
     },
   });
 

--- a/web/src/components/borrow/withdrawCollateralForm.tsx
+++ b/web/src/components/borrow/withdrawCollateralForm.tsx
@@ -257,6 +257,7 @@ export function WithdrawCollateralForm({ market, onClose }: Props) {
       emitter.on("user-signing-withdraw-collateral-error", () =>
         setFlowStatus("withdraw-error"),
       );
+      emitter.on("unexpected-error", () => setFlowStatus("withdraw-error"));
     },
   });
 

--- a/web/src/components/bridgeForm/index.tsx
+++ b/web/src/components/bridgeForm/index.tsx
@@ -220,6 +220,10 @@ function BridgeFormContent({ tokens }: ContentProps) {
         onFailed();
         setFlowStatus("send-error");
       });
+      emitter.on("unexpected-error", function () {
+        onFailed();
+        setFlowStatus("send-error");
+      });
     },
     sourceChainId: fromToken.chainId,
     sourceTokenAddress: fromToken.address,

--- a/web/src/components/swapForm/cancelRedeemModal.tsx
+++ b/web/src/components/swapForm/cancelRedeemModal.tsx
@@ -65,6 +65,10 @@ export function CancelRedeemModal({
         onFailed();
         setIsCancelling(false);
       });
+      emitter.on("unexpected-error", function () {
+        onFailed();
+        setIsCancelling(false);
+      });
     },
     peggedToken,
     redeemableAmount,

--- a/web/src/components/swapForm/deposit.tsx
+++ b/web/src/components/swapForm/deposit.tsx
@@ -215,6 +215,10 @@ export function Deposit({
         onFailed();
         setFlowStatus("deposit-error");
       });
+      emitter.on("unexpected-error", function () {
+        onFailed();
+        setFlowStatus("deposit-error");
+      });
     },
     peggedToken: toToken,
     slippage,

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -164,6 +164,11 @@ export function OneStepRedeem({
   const redeemMutation = useRedeem({
     approveAmount,
     onEmitter(emitter) {
+      const handleFailure = function () {
+        onFailed();
+        setFlowStatus("redeem-error");
+      };
+
       emitter.on("user-signed-approval", () => setFlowStatus("approving"));
       emitter.on("approve-transaction-succeeded", () =>
         setFlowStatus("approved"),
@@ -191,22 +196,11 @@ export function OneStepRedeem({
         });
         setShowToast(true);
       });
-      emitter.on("redeem-transaction-reverted", function () {
-        onFailed();
-        setFlowStatus("redeem-error");
-      });
-      emitter.on("user-signing-redeem-error", function () {
-        onFailed();
-        setFlowStatus("redeem-error");
-      });
-      emitter.on("redeem-failed-validation", function () {
-        onFailed();
-        setFlowStatus("redeem-error");
-      });
-      emitter.on("unexpected-error", function () {
-        onFailed();
-        setFlowStatus("redeem-error");
-      });
+      emitter.on("redeem-transaction-reverted", handleFailure);
+      emitter.on("redeem-failed", handleFailure);
+      emitter.on("user-signing-redeem-error", handleFailure);
+      emitter.on("redeem-failed-validation", handleFailure);
+      emitter.on("unexpected-error", handleFailure);
     },
     peggedToken: fromToken,
     peggedTokenIn: amountBigInt,

--- a/web/src/components/swapForm/oneStepRedeem.tsx
+++ b/web/src/components/swapForm/oneStepRedeem.tsx
@@ -203,6 +203,10 @@ export function OneStepRedeem({
         onFailed();
         setFlowStatus("redeem-error");
       });
+      emitter.on("unexpected-error", function () {
+        onFailed();
+        setFlowStatus("redeem-error");
+      });
     },
     peggedToken: fromToken,
     peggedTokenIn: amountBigInt,

--- a/web/src/components/swapForm/redeemQueue.tsx
+++ b/web/src/components/swapForm/redeemQueue.tsx
@@ -158,6 +158,11 @@ function ActiveRedeemDrawer({
 
   const redeemMutation = useRedeem({
     onEmitter(emitter) {
+      const handleFailure = function () {
+        onFailed();
+        setFlowStatus("redeem-error");
+      };
+
       emitter.on("pre-redeem", () => setFlowStatus("redeem-ready"));
       emitter.on("user-signed-redeem", function (hash) {
         onTransactionHash(hash);
@@ -169,22 +174,11 @@ function ActiveRedeemDrawer({
         setFlowStatus("redeemed");
         onRedeemSuccess(toToken);
       });
-      emitter.on("redeem-transaction-reverted", function () {
-        onFailed();
-        setFlowStatus("redeem-error");
-      });
-      emitter.on("user-signing-redeem-error", function () {
-        onFailed();
-        setFlowStatus("redeem-error");
-      });
-      emitter.on("redeem-failed-validation", function () {
-        onFailed();
-        setFlowStatus("redeem-error");
-      });
-      emitter.on("unexpected-error", function () {
-        onFailed();
-        setFlowStatus("redeem-error");
-      });
+      emitter.on("redeem-transaction-reverted", handleFailure);
+      emitter.on("redeem-failed", handleFailure);
+      emitter.on("user-signing-redeem-error", handleFailure);
+      emitter.on("redeem-failed-validation", handleFailure);
+      emitter.on("unexpected-error", handleFailure);
     },
     peggedToken,
     peggedTokenIn: amountBigInt,

--- a/web/src/components/swapForm/redeemQueue.tsx
+++ b/web/src/components/swapForm/redeemQueue.tsx
@@ -181,6 +181,10 @@ function ActiveRedeemDrawer({
         onFailed();
         setFlowStatus("redeem-error");
       });
+      emitter.on("unexpected-error", function () {
+        onFailed();
+        setFlowStatus("redeem-error");
+      });
     },
     peggedToken,
     peggedTokenIn: amountBigInt,

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -170,6 +170,10 @@ export function TwoStepRedeem({
         onFailed();
         setFlowStatus("request-redeem-error");
       });
+      emitter.on("unexpected-error", function () {
+        onFailed();
+        setFlowStatus("request-redeem-error");
+      });
     },
     peggedToken: fromToken,
     peggedTokenAmount: amountBigInt,

--- a/web/src/components/swapForm/twoStepRedeem.tsx
+++ b/web/src/components/swapForm/twoStepRedeem.tsx
@@ -128,6 +128,11 @@ export function TwoStepRedeem({
     approveAmount,
     gatewayAddress: fromToken.gatewayAddress,
     onEmitter(emitter) {
+      const handleFailure = function () {
+        onFailed();
+        setFlowStatus("request-redeem-error");
+      };
+
       emitter.on("user-signed-approval", () => setFlowStatus("approving"));
       emitter.on("approve-transaction-succeeded", () =>
         setFlowStatus("approved"),
@@ -158,22 +163,11 @@ export function TwoStepRedeem({
           .getElementById("redeem-queue")
           ?.scrollIntoView({ behavior: "smooth" });
       });
-      emitter.on("request-redeem-transaction-reverted", function () {
-        onFailed();
-        setFlowStatus("request-redeem-error");
-      });
-      emitter.on("user-signing-request-redeem-error", function () {
-        onFailed();
-        setFlowStatus("request-redeem-error");
-      });
-      emitter.on("request-redeem-failed-validation", function () {
-        onFailed();
-        setFlowStatus("request-redeem-error");
-      });
-      emitter.on("unexpected-error", function () {
-        onFailed();
-        setFlowStatus("request-redeem-error");
-      });
+      emitter.on("request-redeem-transaction-reverted", handleFailure);
+      emitter.on("request-redeem-failed", handleFailure);
+      emitter.on("user-signing-request-redeem-error", handleFailure);
+      emitter.on("request-redeem-failed-validation", handleFailure);
+      emitter.on("unexpected-error", handleFailure);
     },
     peggedToken: fromToken,
     peggedTokenAmount: amountBigInt,


### PR DESCRIPTION
### Description

Adds `unexpected-error` event handling to the Swap, Bridge, and Borrow forms. Unexpected SDK failures now transition each flow to its existing error state instead of leaving the UI stuck in a pending state.

### Screenshots

N/A — no visual changes.

### Related issue(s)

Closes #793

### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.