### PR TITLE
Allow supply and borrow on existing positions

### DIFF
--- a/web/src/components/borrow/borrowForm.tsx
+++ b/web/src/components/borrow/borrowForm.tsx
@@ -243,7 +243,11 @@ export function BorrowForm({
 
   const handleBorrowFailure = function () {
     onFailed();
-    setFlowStatus("borrow-error");
+    setFlowStatus(
+      supplyCollateralSucceeded.current
+        ? "borrow-error"
+        : "supply-collateral-error",
+    );
   };
 
   const borrowMutation = useSupplyAndBorrow({

--- a/web/src/components/borrow/borrowForm.tsx
+++ b/web/src/components/borrow/borrowForm.tsx
@@ -362,6 +362,12 @@ export function BorrowForm({
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (!inputError) {
+      if (supplyCollateralSucceeded.current) {
+        handleRetry();
+        onDrawerOpenChange(true);
+        return;
+      }
+
       supplyCollateralSucceeded.current = false;
       setStartedWithApproval(!!needsApproval);
       setFlowStatus(needsApproval ? "approving" : "supply-collateral-ready");

--- a/web/src/components/borrow/borrowForm.tsx
+++ b/web/src/components/borrow/borrowForm.tsx
@@ -129,6 +129,12 @@ function getInputError({
   return undefined;
 }
 
+const getActivityType = (position?: AccrualPosition) =>
+  position ? "borrow-more" : "open-position";
+
+const getInputContainerClassName = (position?: AccrualPosition) =>
+  `flex flex-col gap-1 ${position ? "border-t border-gray-200 p-6" : "p-2 md:px-1.5 xl:px-2"}`;
+
 type Props = {
   borrowInput: string;
   collateralInput: string;
@@ -216,39 +222,35 @@ export function BorrowForm({
     collateralToken,
     marketId,
   });
+  const activityType = getActivityType(position);
 
   const { onCompleted, onFailed, onPending, onTransactionHash } =
     useActivityTracking({
       page: "borrow",
-      text: t("pages.borrow.activity.open-position-text", {
+      text: t(`pages.borrow.activity.${activityType}-text`, {
         amount: borrowInput,
         symbol: loanToken.symbol,
       }),
-      title: `${t("nav.borrow")} · ${t("pages.borrow.activity.open-position-title", { symbol: loanToken.symbol })}`,
+      title: `${t("nav.borrow")} · ${t(`pages.borrow.activity.${activityType}-title`, { symbol: loanToken.symbol })}`,
     });
+
+  const handleBorrowSuccess = function () {
+    onCompleted();
+    setFlowStatus("borrowed");
+    setShowToast(true);
+    watchToken();
+  };
+
+  const handleBorrowFailure = function () {
+    onFailed();
+    setFlowStatus("borrow-error");
+  };
 
   const borrowMutation = useSupplyAndBorrow({
     borrowAmount: borrowAmountBigInt,
     collateralAmount: collateralAmountBigInt,
     marketId,
     onEmitter(emitter) {
-      let supplyCollateralSucceeded = false;
-
-      const handleFailure = function (
-        status: "borrow-error" | "supply-collateral-error",
-      ) {
-        onFailed();
-        setFlowStatus(status);
-      };
-
-      const handleUnexpectedError = function () {
-        handleFailure(
-          supplyCollateralSucceeded
-            ? "borrow-error"
-            : "supply-collateral-error",
-        );
-      };
-
       emitter.on("user-signed-approval", () => setFlowStatus("approving"));
       emitter.on("approve-transaction-succeeded", () =>
         setFlowStatus("approved"),
@@ -287,37 +289,14 @@ export function BorrowForm({
         onPending();
         setFlowStatus("borrowing");
       });
-      emitter.on("borrow-assets-transaction-succeeded", function () {
-        onCompleted();
-        setFlowStatus("borrowed");
-        setShowToast(true);
-        watchToken();
-      });
-      emitter.on("borrow-assets-transaction-reverted", () =>
-        handleFailure("borrow-error"),
-      );
-      emitter.on("borrow-assets-failed", () => handleFailure("borrow-error"));
-      emitter.on("borrow-assets-failed-validation", () =>
-        handleFailure("borrow-error"),
-      );
-      emitter.on("user-signing-borrow-assets-error", () =>
-        handleFailure("borrow-error"),
-      );
-      emitter.on("unexpected-error", handleUnexpectedError);
+      emitter.on("borrow-assets-transaction-succeeded", handleBorrowSuccess);
+      emitter.on("borrow-assets-transaction-reverted", handleBorrowFailure);
+      emitter.on("borrow-assets-failed", handleBorrowFailure);
+      emitter.on("borrow-assets-failed-validation", handleBorrowFailure);
+      emitter.on("user-signing-borrow-assets-error", handleBorrowFailure);
+      emitter.on("unexpected-error", handleBorrowFailure);
     },
   });
-
-  const handleBorrowMoreSuccess = function () {
-    onCompleted();
-    setFlowStatus("borrowed");
-    setShowToast(true);
-    watchToken();
-  };
-
-  const handleBorrowMoreFailure = function () {
-    onFailed();
-    setFlowStatus("borrow-error");
-  };
 
   const borrowMoreMutation = useBorrowMoreAssets({
     borrowAmount: borrowAmountBigInt,
@@ -329,15 +308,12 @@ export function BorrowForm({
         onPending();
         setFlowStatus("borrowing");
       });
-      emitter.on(
-        "borrow-assets-transaction-succeeded",
-        handleBorrowMoreSuccess,
-      );
-      emitter.on("borrow-assets-transaction-reverted", handleBorrowMoreFailure);
-      emitter.on("borrow-assets-failed", handleBorrowMoreFailure);
-      emitter.on("borrow-assets-failed-validation", handleBorrowMoreFailure);
-      emitter.on("user-signing-borrow-assets-error", handleBorrowMoreFailure);
-      emitter.on("unexpected-error", handleBorrowMoreFailure);
+      emitter.on("borrow-assets-transaction-succeeded", handleBorrowSuccess);
+      emitter.on("borrow-assets-transaction-reverted", handleBorrowFailure);
+      emitter.on("borrow-assets-failed", handleBorrowFailure);
+      emitter.on("borrow-assets-failed-validation", handleBorrowFailure);
+      emitter.on("user-signing-borrow-assets-error", handleBorrowFailure);
+      emitter.on("unexpected-error", handleBorrowFailure);
     },
   });
 
@@ -393,7 +369,7 @@ export function BorrowForm({
   return (
     <>
       <form className="flex flex-col bg-white" onSubmit={handleSubmit}>
-        <div className="flex flex-col gap-1 p-2 md:px-1.5 xl:px-2">
+        <div className={getInputContainerClassName(position)}>
           <TokenInput
             balance={
               <Balance

--- a/web/src/components/borrow/borrowForm.tsx
+++ b/web/src/components/borrow/borrowForm.tsx
@@ -2,7 +2,7 @@ import { useAddTokenToWallet } from "@hemilabs/react-hooks/useAddTokenToWallet";
 import { useNativeBalance } from "@hemilabs/react-hooks/useNativeBalance";
 import { useNeedsApproval } from "@hemilabs/react-hooks/useNeedsApproval";
 import { useTokenBalance } from "@hemilabs/react-hooks/useTokenBalance";
-import { getChainAddresses } from "@morpho-org/blue-sdk";
+import { type AccrualPosition, getChainAddresses } from "@morpho-org/blue-sdk";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { Button } from "components/base/button";
 import { RenderCryptoValue } from "components/base/cryptoValue";
@@ -18,20 +18,25 @@ import { TokenInput } from "components/tokenInput";
 import { Balance } from "components/tokenInput/balance";
 import type { InputError } from "components/tokenInput/utils";
 import { TokenSelectorReadOnly } from "components/tokenSelectorReadOnly";
+import { useBorrowMoreAssets } from "hooks/borrow/useBorrowMoreAssets";
 import type { MarketData } from "hooks/borrow/useMarketData";
 import { useMorphoMarket } from "hooks/borrow/useMorphoMarket";
 import { useSupplyAndBorrow } from "hooks/borrow/useSupplyAndBorrow";
 import { useTotalSupplyAndBorrowFees } from "hooks/borrow/useSupplyAndBorrowFees";
+import { useSupplyAndBorrowReview } from "hooks/borrow/useSupplyAndBorrowReview";
 import { useActivityTracking } from "hooks/useActivityTracking";
 import { useMainnet } from "hooks/useMainnet";
 import {
   type FormEvent,
   type SetStateAction,
   useCallback,
+  useRef,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
 import { getMaxBorrowable } from "utils/borrowLimit";
+import { getBorrowRetryState } from "utils/borrowRetry";
+import { formatLtvAsPercentage } from "utils/borrowReview";
 import { formatNumber } from "utils/format";
 import { isGeoRestricted } from "utils/geoRestriction";
 import { type Address, formatUnits, parseUnits } from "viem";
@@ -39,6 +44,7 @@ import { useAccount } from "wagmi";
 
 import { BorrowDrawer, type BorrowFlowStatus } from "./borrowDrawer";
 import { BorrowingReview } from "./borrowingReview";
+import { PositionReview } from "./positionReview";
 
 type SubmitButtonProps = {
   address: Address | undefined;
@@ -131,6 +137,8 @@ type Props = {
   onBorrowChange: (value: string) => void;
   onCollateralChange: (value: string) => void;
   onDrawerOpenChange: (value: SetStateAction<boolean>) => void;
+  onSuccess?: VoidFunction;
+  position?: AccrualPosition;
 };
 
 export function BorrowForm({
@@ -141,6 +149,8 @@ export function BorrowForm({
   onBorrowChange,
   onCollateralChange,
   onDrawerOpenChange,
+  onSuccess,
+  position,
 }: Props) {
   const { t } = useTranslation();
   const ethereumChain = useMainnet();
@@ -149,9 +159,15 @@ export function BorrowForm({
   const [flowStatus, setFlowStatus] = useState<BorrowFlowStatus>("idle");
   const [showToast, setShowToast] = useState(false);
   const [startedWithApproval, setStartedWithApproval] = useState(false);
+  const supplyCollateralSucceeded = useRef(false);
   const handleDrawerClose = useCallback(
-    () => onDrawerOpenChange(false),
-    [onDrawerOpenChange],
+    function () {
+      onDrawerOpenChange(false);
+      if (flowStatus === "borrowed") {
+        onSuccess?.();
+      }
+    },
+    [flowStatus, onDrawerOpenChange, onSuccess],
   );
 
   const { collateralToken, loanToken, marketId } = market;
@@ -187,7 +203,8 @@ export function BorrowForm({
 
   const maxBorrowable = morphoMarket
     ? getMaxBorrowable({
-        collateral: collateralAmountBigInt,
+        borrowShares: position?.borrowShares,
+        collateral: (position?.collateral ?? 0n) + collateralAmountBigInt,
         market: morphoMarket,
       })
     : undefined;
@@ -249,7 +266,7 @@ export function BorrowForm({
         setFlowStatus("supplying-collateral"),
       );
       emitter.on("supply-collateral-transaction-succeeded", function () {
-        supplyCollateralSucceeded = true;
+        supplyCollateralSucceeded.current = true;
         setFlowStatus("supplied-collateral");
       });
       emitter.on("supply-collateral-transaction-reverted", () =>
@@ -290,6 +307,40 @@ export function BorrowForm({
     },
   });
 
+  const handleBorrowMoreSuccess = function () {
+    onCompleted();
+    setFlowStatus("borrowed");
+    setShowToast(true);
+    watchToken();
+  };
+
+  const handleBorrowMoreFailure = function () {
+    onFailed();
+    setFlowStatus("borrow-error");
+  };
+
+  const borrowMoreMutation = useBorrowMoreAssets({
+    borrowAmount: borrowAmountBigInt,
+    marketId,
+    onEmitter(emitter) {
+      emitter.on("pre-borrow-assets", () => setFlowStatus("borrowing"));
+      emitter.on("user-signed-borrow-assets", function (hash) {
+        onTransactionHash(hash);
+        onPending();
+        setFlowStatus("borrowing");
+      });
+      emitter.on(
+        "borrow-assets-transaction-succeeded",
+        handleBorrowMoreSuccess,
+      );
+      emitter.on("borrow-assets-transaction-reverted", handleBorrowMoreFailure);
+      emitter.on("borrow-assets-failed", handleBorrowMoreFailure);
+      emitter.on("borrow-assets-failed-validation", handleBorrowMoreFailure);
+      emitter.on("user-signing-borrow-assets-error", handleBorrowMoreFailure);
+      emitter.on("unexpected-error", handleBorrowMoreFailure);
+    },
+  });
+
   const nativeBalance = nativeBalanceData?.value;
 
   const inputError = getInputError({
@@ -304,16 +355,34 @@ export function BorrowForm({
   const balancesLoaded =
     nativeBalance !== undefined && collateralBalance !== undefined;
 
+  const { current, updated } = useSupplyAndBorrowReview({
+    borrowApy: market.borrowApy,
+    borrowInput,
+    collateralInput,
+    collateralToken,
+    frozen: isDrawerOpen,
+    loanToken,
+    position,
+  });
+
   const handleRetry = function () {
-    setFlowStatus(
-      startedWithApproval ? "approving" : "supply-collateral-ready",
-    );
+    const { action, flowStatus: retryFlowStatus } = getBorrowRetryState({
+      startedWithApproval,
+      supplyCollateralSucceeded: supplyCollateralSucceeded.current,
+    });
+
+    setFlowStatus(retryFlowStatus);
+    if (action === "borrow-more") {
+      borrowMoreMutation.mutate();
+      return;
+    }
     borrowMutation.mutate();
   };
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (!inputError) {
+      supplyCollateralSucceeded.current = false;
       setStartedWithApproval(!!needsApproval);
       setFlowStatus(needsApproval ? "approving" : "supply-collateral-ready");
       borrowMutation.mutate();
@@ -407,14 +476,25 @@ export function BorrowForm({
           </FormSectionItem>
           <FormSectionItem>
             <div className="py-1">
-              <BorrowingReview
-                borrowApy={market.borrowApy}
-                borrowInput={borrowInput}
-                collateralInput={collateralInput}
-                collateralToken={collateralToken}
-                loanToken={loanToken}
-                morphoMarket={morphoMarket}
-              />
+              {position ? (
+                <PositionReview
+                  borrowApy={market.borrowApy}
+                  collateralToken={collateralToken}
+                  current={current}
+                  lltv={formatLtvAsPercentage(market.lltv)}
+                  loanToken={loanToken}
+                  updated={inputError ? null : updated}
+                />
+              ) : (
+                <BorrowingReview
+                  borrowApy={market.borrowApy}
+                  borrowInput={borrowInput}
+                  collateralInput={collateralInput}
+                  collateralToken={collateralToken}
+                  loanToken={loanToken}
+                  morphoMarket={morphoMarket}
+                />
+              )}
             </div>
           </FormSectionItem>
         </FormSection>

--- a/web/src/components/borrow/manageButton.tsx
+++ b/web/src/components/borrow/manageButton.tsx
@@ -81,6 +81,11 @@ export function ManageButton({ marketId, onAction }: Props) {
       label: t("pages.borrow.borrow-more"),
     },
     {
+      icon: <PlusCircleIcon />,
+      key: "supply-collateral-and-borrow" as BorrowAction,
+      label: t("pages.borrow.supply-collateral-and-borrow"),
+    },
+    {
       icon: <RepayIcon />,
       key: "repay-loan" as BorrowAction,
       label: t("pages.borrow.repay-loan"),

--- a/web/src/components/borrow/positionsTable.tsx
+++ b/web/src/components/borrow/positionsTable.tsx
@@ -44,6 +44,12 @@ const SupplyCollateralDrawerForm = lazy(() =>
   })),
 );
 
+const SupplyCollateralAndBorrowDrawerForm = lazy(() =>
+  import("./supplyCollateralAndBorrowDrawerForm").then((m) => ({
+    default: m.SupplyCollateralAndBorrowDrawerForm,
+  })),
+);
+
 const RepayLoanDrawerForm = lazy(() =>
   import("./repayLoanDrawerForm").then((m) => ({
     default: m.RepayLoanDrawerForm,
@@ -269,6 +275,14 @@ export function PositionsTable({ marketIds }: Props) {
           {borrowAction === "supply-collateral" && (
             <Suspense>
               <SupplyCollateralDrawerForm
+                market={activeMarket}
+                onClose={clearBorrowAction}
+              />
+            </Suspense>
+          )}
+          {borrowAction === "supply-collateral-and-borrow" && (
+            <Suspense>
+              <SupplyCollateralAndBorrowDrawerForm
                 market={activeMarket}
                 onClose={clearBorrowAction}
               />

--- a/web/src/components/borrow/supplyCollateralAndBorrowDrawerForm.tsx
+++ b/web/src/components/borrow/supplyCollateralAndBorrowDrawerForm.tsx
@@ -1,0 +1,59 @@
+import { Drawer } from "components/base/drawer";
+import { DrawerLoader } from "components/base/drawer/drawerLoader";
+import { DrawerTitle } from "components/base/drawer/drawerTitle";
+import type { MarketData } from "hooks/borrow/useMarketData";
+import { usePositionInfo } from "hooks/borrow/usePositionInfo";
+import { useAmount } from "hooks/useAmount";
+import { Suspense, lazy, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+const BorrowForm = lazy(() =>
+  import("./borrowForm").then((m) => ({
+    default: m.BorrowForm,
+  })),
+);
+
+type Props = {
+  market: MarketData;
+  onClose: VoidFunction;
+};
+
+export function SupplyCollateralAndBorrowDrawerForm({
+  market,
+  onClose,
+}: Props) {
+  const { t } = useTranslation();
+  const [borrowInput, onBorrowChange] = useAmount();
+  const [collateralInput, onCollateralChange] = useAmount();
+  const [isProgressDrawerOpen, setIsProgressDrawerOpen] = useState(false);
+  const { data: position } = usePositionInfo(market.marketId);
+
+  return (
+    <Drawer onClose={onClose}>
+      <div className="flex h-full flex-col">
+        <DrawerTitle>
+          {t("pages.borrow.supply-collateral-and-borrow")}
+        </DrawerTitle>
+        {position ? (
+          <div className="flex-1 overflow-y-auto">
+            <Suspense fallback={<DrawerLoader />}>
+              <BorrowForm
+                borrowInput={borrowInput}
+                collateralInput={collateralInput}
+                isDrawerOpen={isProgressDrawerOpen}
+                market={market}
+                onBorrowChange={onBorrowChange}
+                onCollateralChange={onCollateralChange}
+                onDrawerOpenChange={setIsProgressDrawerOpen}
+                onSuccess={onClose}
+                position={position}
+              />
+            </Suspense>
+          </div>
+        ) : (
+          <DrawerLoader />
+        )}
+      </div>
+    </Drawer>
+  );
+}

--- a/web/src/components/borrow/supplyCollateralAndBorrowDrawerForm.tsx
+++ b/web/src/components/borrow/supplyCollateralAndBorrowDrawerForm.tsx
@@ -1,6 +1,9 @@
+import { Button } from "components/base/button";
 import { Drawer } from "components/base/drawer";
 import { DrawerLoader } from "components/base/drawer/drawerLoader";
 import { DrawerTitle } from "components/base/drawer/drawerTitle";
+import { StatusMessage } from "components/base/statusMessage";
+import { WarningCircleIcon } from "components/icons/warningCircleIcon";
 import type { MarketData } from "hooks/borrow/useMarketData";
 import { usePositionInfo } from "hooks/borrow/usePositionInfo";
 import { useAmount } from "hooks/useAmount";
@@ -26,7 +29,57 @@ export function SupplyCollateralAndBorrowDrawerForm({
   const [borrowInput, onBorrowChange] = useAmount();
   const [collateralInput, onCollateralChange] = useAmount();
   const [isProgressDrawerOpen, setIsProgressDrawerOpen] = useState(false);
-  const { data: position } = usePositionInfo(market.marketId);
+  const {
+    data: position,
+    isError: isPositionError,
+    isPending: isPositionPending,
+    refetch: refetchPosition,
+  } = usePositionInfo(market.marketId);
+
+  const renderContent = function () {
+    if (isPositionPending) {
+      return <DrawerLoader />;
+    }
+
+    if (isPositionError) {
+      return (
+        <div className="flex flex-1 items-center justify-center">
+          <StatusMessage
+            action={
+              <Button onClick={() => refetchPosition()} size="xSmall">
+                {t("pages.borrow.progress.retry")}
+              </Button>
+            }
+            description={t("pages.server-error.description")}
+            icon={<WarningCircleIcon />}
+            title={t("pages.server-error.title")}
+          />
+        </div>
+      );
+    }
+
+    if (!position) {
+      return <DrawerLoader />;
+    }
+
+    return (
+      <div className="flex-1 overflow-y-auto">
+        <Suspense fallback={<DrawerLoader />}>
+          <BorrowForm
+            borrowInput={borrowInput}
+            collateralInput={collateralInput}
+            isDrawerOpen={isProgressDrawerOpen}
+            market={market}
+            onBorrowChange={onBorrowChange}
+            onCollateralChange={onCollateralChange}
+            onDrawerOpenChange={setIsProgressDrawerOpen}
+            onSuccess={onClose}
+            position={position}
+          />
+        </Suspense>
+      </div>
+    );
+  };
 
   return (
     <Drawer onClose={onClose}>
@@ -34,25 +87,7 @@ export function SupplyCollateralAndBorrowDrawerForm({
         <DrawerTitle>
           {t("pages.borrow.supply-collateral-and-borrow")}
         </DrawerTitle>
-        {position ? (
-          <div className="flex-1 overflow-y-auto">
-            <Suspense fallback={<DrawerLoader />}>
-              <BorrowForm
-                borrowInput={borrowInput}
-                collateralInput={collateralInput}
-                isDrawerOpen={isProgressDrawerOpen}
-                market={market}
-                onBorrowChange={onBorrowChange}
-                onCollateralChange={onCollateralChange}
-                onDrawerOpenChange={setIsProgressDrawerOpen}
-                onSuccess={onClose}
-                position={position}
-              />
-            </Suspense>
-          </div>
-        ) : (
-          <DrawerLoader />
-        )}
+        {renderContent()}
       </div>
     </Drawer>
   );

--- a/web/src/hooks/borrow/useBorrowAction.ts
+++ b/web/src/hooks/borrow/useBorrowAction.ts
@@ -4,6 +4,7 @@ const borrowActions = [
   "borrow-more",
   "repay-loan",
   "supply-collateral",
+  "supply-collateral-and-borrow",
   "withdraw-collateral",
 ] as const;
 

--- a/web/src/hooks/borrow/useSupplyAndBorrowReview.ts
+++ b/web/src/hooks/borrow/useSupplyAndBorrowReview.ts
@@ -1,0 +1,41 @@
+import type { AccrualPosition } from "@morpho-org/blue-sdk";
+import type { Token } from "@vetro-protocol/core";
+import { parseTokenUnits } from "utils/token";
+
+import { usePositionReview } from "./usePositionReview";
+
+type Params = {
+  borrowApy: number;
+  borrowInput: string;
+  collateralInput: string;
+  collateralToken: Token;
+  frozen?: boolean;
+  loanToken: Token;
+  position: AccrualPosition | undefined;
+};
+
+export const useSupplyAndBorrowReview = ({
+  borrowApy,
+  borrowInput,
+  collateralInput,
+  collateralToken,
+  frozen,
+  loanToken,
+  position,
+}: Params) =>
+  usePositionReview({
+    borrowApy,
+    collateralToken,
+    frozen,
+    getUpdatedPosition: (pos, borrowAmount) => ({
+      borrowShares: pos.market.toBorrowShares(
+        pos.market.toBorrowAssets(pos.borrowShares) + borrowAmount,
+      ),
+      collateral:
+        pos.collateral + parseTokenUnits(collateralInput, collateralToken),
+    }),
+    input: borrowInput,
+    inputToken: loanToken,
+    loanToken,
+    position,
+  });

--- a/web/src/utils/borrowRetry.ts
+++ b/web/src/utils/borrowRetry.ts
@@ -1,0 +1,24 @@
+export type BorrowRetryState = {
+  action: "borrow-more" | "supply-and-borrow";
+  flowStatus: "approving" | "borrowing" | "supply-collateral-ready";
+};
+
+export const getBorrowRetryState = function ({
+  startedWithApproval,
+  supplyCollateralSucceeded,
+}: {
+  startedWithApproval: boolean;
+  supplyCollateralSucceeded: boolean;
+}): BorrowRetryState {
+  if (supplyCollateralSucceeded) {
+    return {
+      action: "borrow-more",
+      flowStatus: "borrowing",
+    };
+  }
+
+  return {
+    action: "supply-and-borrow",
+    flowStatus: startedWithApproval ? "approving" : "supply-collateral-ready",
+  };
+};

--- a/web/test/locale.test.ts
+++ b/web/test/locale.test.ts
@@ -55,6 +55,8 @@ const dynamicallyReferencedKeys = [
   "common.insufficient-gas",
   "common.insufficient-liquidity",
   "common.insufficient-treasury",
+  "pages.borrow.activity.open-position-text",
+  "pages.borrow.activity.open-position-title",
 ];
 
 const escapeRegExp = (value: string) =>

--- a/web/test/utils/borrowRetry.test.ts
+++ b/web/test/utils/borrowRetry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { getBorrowRetryState } from "../../src/utils/borrowRetry";
+
+describe("getBorrowRetryState", function () {
+  it("retries the combined flow from the supply step when approval was not needed", function () {
+    expect(
+      getBorrowRetryState({
+        startedWithApproval: false,
+        supplyCollateralSucceeded: false,
+      }),
+    ).toEqual({
+      action: "supply-and-borrow",
+      flowStatus: "supply-collateral-ready",
+    });
+  });
+
+  it("retries approval before restarting the combined flow when approval was needed", function () {
+    expect(
+      getBorrowRetryState({
+        startedWithApproval: true,
+        supplyCollateralSucceeded: false,
+      }),
+    ).toEqual({
+      action: "supply-and-borrow",
+      flowStatus: "approving",
+    });
+  });
+
+  it("retries borrowing only after collateral supply succeeds", function () {
+    expect(
+      getBorrowRetryState({
+        startedWithApproval: true,
+        supplyCollateralSucceeded: true,
+      }),
+    ).toEqual({
+      action: "borrow-more",
+      flowStatus: "borrowing",
+    });
+  });
+});


### PR DESCRIPTION
### Description

Adds a “Supply collateral and borrow” action for existing borrow positions.

The flow reuses the borrow form, includes existing position data in the review and borrow limit, and retries only the borrow step if collateral was already supplied. This prevents collateral from being supplied twice.

### Screenshots
<img width="2051" height="1207" alt="image" src="https://github.com/user-attachments/assets/7982bc15-2873-400c-b5fd-c95f823cfd03" />

<img width="1754" height="566" alt="image" src="https://github.com/user-attachments/assets/26cb18bb-b3bc-40cd-889c-d93b93fe44d1" />


### Related issue(s)

Closes #501

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added.
- [ ] Documentation updated, or N/A.
- [ ] Environment variables set in CI, or N/A.