### PR TITLE
Migrate @tanstack/react-table to v9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,8 +497,8 @@ importers:
         specifier: 5.90.19
         version: 5.90.19(react@19.2.8)
       '@tanstack/react-table':
-        specifier: 8.21.3
-        version: 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 9.1.2
+        version: 9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vetro-protocol/bridge':
         specifier: workspace:*
         version: link:../packages/bridge
@@ -3484,16 +3484,24 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-table@8.21.3':
-    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==, tarball: https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz}
-    engines: {node: '>=12'}
+  '@tanstack/react-store@0.11.1':
+    resolution: {integrity: sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ==, tarball: https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.11.1.tgz}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/table-core@8.21.3':
-    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==, tarball: https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz}
-    engines: {node: '>=12'}
+  '@tanstack/react-table@9.1.2':
+    resolution: {integrity: sha512-YQPZFJ1nIi/bjjwsPZVouABgahDcl7Gdm33CdTStUJBn0DjEVJ2uhSTVmIoWt9MVKdQziXGAsXipSzy949Hygg==, tarball: https://registry.npmjs.org/@tanstack/react-table/-/react-table-9.1.2.tgz}
+    engines: {node: '>=20'}
+    peerDependencies:
+      react: '>=18'
+
+  '@tanstack/store@0.11.1':
+    resolution: {integrity: sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA==, tarball: https://registry.npmjs.org/@tanstack/store/-/store-0.11.1.tgz}
+
+  '@tanstack/table-core@9.1.2':
+    resolution: {integrity: sha512-ONpWQeass1sfg80CWF1NSwQ8r3GiqxA2lT/EdqIcrDEPZ0Z+0mM94eQoFYLPN0Kztzj8TQVb2+PrSZSItqA61g==, tarball: https://registry.npmjs.org/@tanstack/table-core/-/table-core-9.1.2.tgz}
+    engines: {node: '>=20'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==, tarball: https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz}
@@ -12289,13 +12297,26 @@ snapshots:
       '@tanstack/query-core': 5.90.19
       react: 19.2.8
 
-  '@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-store@0.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tanstack/table-core': 8.21.3
+      '@tanstack/store': 0.11.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
 
-  '@tanstack/table-core@8.21.3': {}
+  '@tanstack/react-table@9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/react-store': 0.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/table-core': 9.1.2
+      react: 19.2.8
+    transitivePeerDependencies:
+      - react-dom
+
+  '@tanstack/store@0.11.1': {}
+
+  '@tanstack/table-core@9.1.2':
+    dependencies:
+      '@tanstack/store': 0.11.1
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -12688,7 +12709,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.1.0)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.1.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.9)(vite@8.0.13(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.4))
 
   '@vitest/eslint-plugin@1.6.6(eslint@8.57.0)(typescript@6.0.2)(vitest@4.1.9)':
     dependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,7 @@
     "@rainbow-me/rainbowkit": "2.2.10",
     "@sentry/react": "10.50.0",
     "@tanstack/react-query": "5.90.19",
-    "@tanstack/react-table": "8.21.3",
+    "@tanstack/react-table": "9.1.2",
     "@vetro-protocol/bridge": "workspace:*",
     "@vetro-protocol/core": "workspace:*",
     "@vetro-protocol/earn": "workspace:*",

--- a/web/src/components/base/table/index.tsx
+++ b/web/src/components/base/table/index.tsx
@@ -1,10 +1,11 @@
 import { useWindowSize } from "@hemilabs/react-hooks/useWindowSize";
 import {
   type ColumnDef,
-  type Table as TanStackTable,
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
+  type ReactTable,
+  type RowData,
+  columnOrderingFeature,
+  tableFeatures,
+  useTable,
 } from "@tanstack/react-table";
 import { type MouseEvent, Fragment, type ReactNode, useMemo } from "react";
 import Skeleton from "react-loading-skeleton";
@@ -13,12 +14,31 @@ import { screenBreakpoints } from "styles/breakpoints";
 import { Column } from "./column";
 import { ColumnHeader } from "./columnHeader";
 
-const getColumnOrder = function <T>({
+type ColumnMeta = {
+  className?: string;
+  width?: string;
+};
+
+const features = tableFeatures({
+  columnMeta: {} as ColumnMeta,
+  columnOrderingFeature,
+});
+
+type TableFeatureSet = typeof features;
+
+type TableInstance<TData extends RowData> = ReactTable<TableFeatureSet, TData>;
+
+export type TableColumnDef<TData extends RowData> = ColumnDef<
+  TableFeatureSet,
+  TData
+>;
+
+const getColumnOrder = function <T extends RowData>({
   columns,
   priorityColumnIds = [],
   width,
 }: {
-  columns: ColumnDef<T>[];
+  columns: TableColumnDef<T>[];
   priorityColumnIds?: string[];
   width: number;
 }) {
@@ -34,8 +54,8 @@ const getColumnOrder = function <T>({
   ];
 };
 
-type Props<TData> = {
-  columns: ColumnDef<TData>[];
+type Props<TData extends RowData> = {
+  columns: TableColumnDef<TData>[];
   data: TData[];
   getRowId?: (row: TData) => string;
   loading?: boolean;
@@ -47,12 +67,12 @@ type Props<TData> = {
   skeletonRowCount?: number;
 };
 
-type TableHeaderProps<TData> = {
+type TableHeaderProps<TData extends RowData> = {
   getColumnClassName: (columnId: string, meta?: string) => string;
-  table: TanStackTable<TData>;
+  table: TableInstance<TData>;
 };
 
-const TableHeader = <TData,>({
+const TableHeader = <TData extends RowData>({
   getColumnClassName,
   table,
 }: TableHeaderProps<TData>) => (
@@ -70,10 +90,7 @@ const TableHeader = <TData,>({
                 key={header.id}
                 style={{ width: header.column.columnDef.meta?.width }}
               >
-                {flexRender(
-                  header.column.columnDef.header,
-                  header.getContext(),
-                )}
+                <table.FlexRender header={header} />
               </ColumnHeader>
             ))}
           </tr>
@@ -83,15 +100,15 @@ const TableHeader = <TData,>({
   </div>
 );
 
-type TableBodyProps<TData> = {
+type TableBodyProps<TData extends RowData> = {
   getColumnClassName: (columnId: string, meta?: string) => string;
   maxBodyHeight?: string;
   onRowClick?: (row: TData) => void;
   renderAfterRow?: (row: TData) => ReactNode;
-  table: TanStackTable<TData>;
+  table: TableInstance<TData>;
 };
 
-const TableBody = <TData,>({
+const TableBody = <TData extends RowData>({
   getColumnClassName,
   maxBodyHeight,
   onRowClick,
@@ -130,7 +147,7 @@ const TableBody = <TData,>({
               }
               role={onRowClick ? "link" : undefined}
             >
-              {row.getVisibleCells().map((cell) => (
+              {row.getAllCells().map((cell) => (
                 <Column
                   className={getColumnClassName(
                     cell.column.id,
@@ -139,7 +156,7 @@ const TableBody = <TData,>({
                   key={cell.id}
                   style={{ width: cell.column.columnDef.meta?.width }}
                 >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  <table.FlexRender cell={cell} />
                 </Column>
               ))}
             </tr>
@@ -151,7 +168,7 @@ const TableBody = <TData,>({
   </div>
 );
 
-export function Table<TData>({
+export function Table<TData extends RowData>({
   columns,
   data,
   getRowId,
@@ -195,10 +212,10 @@ export function Table<TData>({
     width,
   });
 
-  const table = useReactTable({
+  const table = useTable({
     columns: columnsWithSkeleton,
     data: data.length > 0 ? data : showSkeleton ? skeletonData : [],
-    getCoreRowModel: getCoreRowModel(),
+    features,
     getRowId: showSkeleton ? undefined : getRowId,
     state: { columnOrder },
   });

--- a/web/src/components/base/table/react-table.d.ts
+++ b/web/src/components/base/table/react-table.d.ts
@@ -1,9 +1,0 @@
-import "@tanstack/react-table";
-
-declare module "@tanstack/react-table" {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface ColumnMeta<TData, TValue> {
-    className?: string;
-    width?: string;
-  }
-}

--- a/web/src/components/borrow/marketsTable.tsx
+++ b/web/src/components/borrow/marketsTable.tsx
@@ -1,7 +1,6 @@
-import { type ColumnDef } from "@tanstack/react-table";
 import { I18nLink } from "components/base/i18nLink";
 import { SectionHeader } from "components/base/sectionHeader";
-import { Table } from "components/base/table";
+import { Table, type TableColumnDef } from "components/base/table";
 import { Header } from "components/base/table/header";
 import { CollateralCell } from "components/borrow/collateralCell";
 import { TokenValueCell } from "components/borrow/tokenValueCell";
@@ -25,7 +24,7 @@ export function MarketsTable({ marketIds }: Props) {
     navigate(`/borrow/${row.marketId}`);
 
   const columns = useMemo(
-    (): ColumnDef<MarketData>[] => [
+    (): TableColumnDef<MarketData>[] => [
       {
         cell: ({ row }) => (
           <div className="flex items-center gap-2">

--- a/web/src/components/borrow/positionsTable.tsx
+++ b/web/src/components/borrow/positionsTable.tsx
@@ -1,6 +1,5 @@
-import { type ColumnDef } from "@tanstack/react-table";
 import { SectionHeader } from "components/base/sectionHeader";
-import { Table } from "components/base/table";
+import { Table, type TableColumnDef } from "components/base/table";
 import { Header } from "components/base/table/header";
 import { useBorrowAction } from "hooks/borrow/useBorrowAction";
 import { type MarketData, useMarketsData } from "hooks/borrow/useMarketsData";
@@ -98,7 +97,7 @@ export function PositionsTable({ marketIds }: Props) {
   );
 
   const columns = useMemo(
-    (): ColumnDef<PositionRow>[] => [
+    (): TableColumnDef<PositionRow>[] => [
       {
         cell: ({ row }) => (
           <TokenValueCell

--- a/web/src/components/swapForm/redeemQueueTable.tsx
+++ b/web/src/components/swapForm/redeemQueueTable.tsx
@@ -1,10 +1,9 @@
-import { type ColumnDef } from "@tanstack/react-table";
 import { Badge } from "components/base/badge";
 import { Button, ButtonIcon } from "components/base/button";
 import { DisplayAmount } from "components/base/displayAmount";
 import { Spinner } from "components/base/spinner";
 import { StatusBadge } from "components/base/statusBadge";
-import { Table } from "components/base/table";
+import { Table, type TableColumnDef } from "components/base/table";
 import { Header } from "components/base/table/header";
 import { TokenLogo } from "components/tokenLogo";
 import { Tooltip } from "components/tooltip";
@@ -136,7 +135,7 @@ export function RedeemQueueTable({
   const { t } = useTranslation();
 
   const columns = useMemo(
-    (): ColumnDef<RedeemRequest>[] => [
+    (): TableColumnDef<RedeemRequest>[] => [
       {
         cell: ({ row }) => (
           <div className="text-b-medium flex items-center gap-2 text-gray-900">

--- a/web/src/pages/earn/components/exitTickets/index.tsx
+++ b/web/src/pages/earn/components/exitTickets/index.tsx
@@ -1,12 +1,11 @@
 import { useConnectModal } from "@rainbow-me/rainbowkit";
-import { type ColumnDef } from "@tanstack/react-table";
 import { stakingVaultAddresses } from "@vetro-protocol/earn";
 import { Badge } from "components/base/badge";
 import { Button } from "components/base/button";
 import { FilterMenu } from "components/base/filterMenu";
 import { SectionHeader } from "components/base/sectionHeader";
 import { StatusBadge } from "components/base/statusBadge";
-import { Table } from "components/base/table";
+import { Table, type TableColumnDef } from "components/base/table";
 import { Header } from "components/base/table/header";
 import { Toast } from "components/base/toast";
 import { Tooltip } from "components/tooltip";
@@ -45,7 +44,7 @@ export const getColumns = ({
   onDeleteSuccess: VoidFunction;
   onWithdrawingChange: (isWithdrawing: boolean) => void;
   t: ReturnType<typeof useTranslation>["t"];
-}): ColumnDef<ExitTicket>[] => [
+}): TableColumnDef<ExitTicket>[] => [
   {
     cell: ({ row }) => <DateCreatedCell ticket={row.original} />,
     header: () => (

--- a/web/stories/table.stories.tsx
+++ b/web/stories/table.stories.tsx
@@ -1,10 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { type ColumnDef } from "@tanstack/react-table";
 
 import { Badge } from "../src/components/base/badge";
 import { Button } from "../src/components/base/button";
 import { StatusBadge } from "../src/components/base/statusBadge";
-import { Table } from "../src/components/base/table";
+import { Table, type TableColumnDef } from "../src/components/base/table";
 import { Header } from "../src/components/base/table/header";
 
 type ExampleRow = {
@@ -22,7 +21,7 @@ const statusLabels = {
   withdrawn: "Withdrawn",
 } as const;
 
-const columns: ColumnDef<ExampleRow>[] = [
+const columns: TableColumnDef<ExampleRow>[] = [
   {
     cell: ({ row }) => (
       <span className="text-xsm font-normal text-gray-500">


### PR DESCRIPTION
### Description

Migrate `@tanstack/react-table` from 8.21.3 to 9.1.2. 8.21.3 is the last v8 release, so v9 is the only upgrade path.

### Screenshots

N/A — no visual changes.

### Related issue(s)

N/A

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.
