### PR TITLE
Reconcile pending activity on reload

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -29,6 +29,8 @@ import {
 import { featureFlags } from "utils/featureFlags";
 import { isGeoRestricted } from "utils/geoRestriction";
 
+import { usePendingActivityReconciliation } from "./hooks/usePendingActivityReconciliation";
+
 const SentryRoutes = Sentry.withSentryReactRouterV7Routing(Routes);
 
 const analyticsEnabled =
@@ -141,22 +143,26 @@ function LanguageRoutes() {
   );
 }
 
-export const App = () => (
-  <BrowserRouter>
-    <NuqsAdapter>
-      {analyticsEnabled && <AnalyticsTracker />}
-      <AppViewport>
-        <SentryRoutes>
-          {/* Redirect root to English */}
-          <Route element={<Navigate replace to="/en" />} path="/" />
+export function App() {
+  usePendingActivityReconciliation();
 
-          {/* Language-prefixed routes */}
-          <Route element={<LanguageRoutes />} path="/:lang/*" />
+  return (
+    <BrowserRouter>
+      <NuqsAdapter>
+        {analyticsEnabled && <AnalyticsTracker />}
+        <AppViewport>
+          <SentryRoutes>
+            {/* Redirect root to English */}
+            <Route element={<Navigate replace to="/en" />} path="/" />
 
-          {/* Catch-all: redirect unknown paths to English */}
-          <Route element={<Navigate replace to="/en" />} path="*" />
-        </SentryRoutes>
-      </AppViewport>
-    </NuqsAdapter>
-  </BrowserRouter>
-);
+            {/* Language-prefixed routes */}
+            <Route element={<LanguageRoutes />} path="/:lang/*" />
+
+            {/* Catch-all: redirect unknown paths to English */}
+            <Route element={<Navigate replace to="/en" />} path="*" />
+          </SentryRoutes>
+        </AppViewport>
+      </NuqsAdapter>
+    </BrowserRouter>
+  );
+}

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -29,8 +29,6 @@ import {
 import { featureFlags } from "utils/featureFlags";
 import { isGeoRestricted } from "utils/geoRestriction";
 
-import { usePendingActivityReconciliation } from "./hooks/usePendingActivityReconciliation";
-
 const SentryRoutes = Sentry.withSentryReactRouterV7Routing(Routes);
 
 const analyticsEnabled =
@@ -143,26 +141,22 @@ function LanguageRoutes() {
   );
 }
 
-export function App() {
-  usePendingActivityReconciliation();
+export const App = () => (
+  <BrowserRouter>
+    <NuqsAdapter>
+      {analyticsEnabled && <AnalyticsTracker />}
+      <AppViewport>
+        <SentryRoutes>
+          {/* Redirect root to English */}
+          <Route element={<Navigate replace to="/en" />} path="/" />
 
-  return (
-    <BrowserRouter>
-      <NuqsAdapter>
-        {analyticsEnabled && <AnalyticsTracker />}
-        <AppViewport>
-          <SentryRoutes>
-            {/* Redirect root to English */}
-            <Route element={<Navigate replace to="/en" />} path="/" />
+          {/* Language-prefixed routes */}
+          <Route element={<LanguageRoutes />} path="/:lang/*" />
 
-            {/* Language-prefixed routes */}
-            <Route element={<LanguageRoutes />} path="/:lang/*" />
-
-            {/* Catch-all: redirect unknown paths to English */}
-            <Route element={<Navigate replace to="/en" />} path="*" />
-          </SentryRoutes>
-        </AppViewport>
-      </NuqsAdapter>
-    </BrowserRouter>
-  );
-}
+          {/* Catch-all: redirect unknown paths to English */}
+          <Route element={<Navigate replace to="/en" />} path="*" />
+        </SentryRoutes>
+      </AppViewport>
+    </NuqsAdapter>
+  </BrowserRouter>
+);

--- a/web/src/components/pendingActivityReconciliation.tsx
+++ b/web/src/components/pendingActivityReconciliation.tsx
@@ -1,0 +1,6 @@
+import { usePendingActivityReconciliation } from "../hooks/usePendingActivityReconciliation";
+
+export function PendingActivityReconciliation() {
+  usePendingActivityReconciliation();
+  return null;
+}

--- a/web/src/hooks/usePendingActivityReconciliation.ts
+++ b/web/src/hooks/usePendingActivityReconciliation.ts
@@ -1,12 +1,15 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { getTransactionReceipt } from "viem/actions";
 import { useAccount } from "wagmi";
 
 import { updateActivity, useActivities } from "../stores/activityStore";
+import { SECONDS_PER_DAY, unixNowTimestamp } from "../utils/date";
 import { getPendingActivityStatus } from "../utils/reconcilePendingActivity";
 
 import { useEthereumClient } from "./useEthereumClient";
 
 const pendingActivityPollInterval = 10_000;
+const pendingActivityMaxAge = SECONDS_PER_DAY;
 
 export function usePendingActivityReconciliation() {
   const { address } = useAccount();
@@ -17,12 +20,22 @@ export function usePendingActivityReconciliation() {
   // does not mean that the bridged funds have arrived. They need separate
   // delivery tracking.
   const pendingActivities = useMemo(
-    () =>
-      activities.filter(
+    function getPendingActivities() {
+      const now = unixNowTimestamp();
+      return activities.filter(
         (activity) =>
-          activity.status === "pending" && activity.page !== "bridge",
-      ),
+          activity.status === "pending" &&
+          activity.page !== "bridge" &&
+          now - activity.date < pendingActivityMaxAge,
+      );
+    },
     [activities],
+  );
+  const pendingActivitiesRef = useRef(pendingActivities);
+  pendingActivitiesRef.current = pendingActivities;
+  const pendingActivityHashes = useMemo(
+    () => pendingActivities.map(({ txHash }) => txHash).join(","),
+    [pendingActivities],
   );
 
   useEffect(
@@ -43,19 +56,30 @@ export function usePendingActivityReconciliation() {
 
         isChecking = true;
         try {
-          await Promise.all(
-            pendingActivities.map(async function reconcileActivity(activity) {
-              const status = await getPendingActivityStatus({
-                activity,
-                getReceipt: (hash) =>
-                  publicClient.getTransactionReceipt({ hash }),
-              });
+          const reconciledActivities = await Promise.all(
+            pendingActivitiesRef.current.map(
+              async function reconcileActivity(activity) {
+                const status = await getPendingActivityStatus({
+                  activity,
+                  getReceipt: (hash) =>
+                    getTransactionReceipt(publicClient, { hash }),
+                });
 
-              if (isActive && status) {
+                return { activity, status };
+              },
+            ),
+          );
+
+          if (isActive) {
+            reconciledActivities.forEach(function updateReconciledActivity({
+              activity,
+              status,
+            }) {
+              if (status) {
                 updateActivity(account, activity.txHash, { status });
               }
-            }),
-          );
+            });
+          }
         } finally {
           isChecking = false;
         }
@@ -72,6 +96,6 @@ export function usePendingActivityReconciliation() {
         clearInterval(interval);
       };
     },
-    [address, client, pendingActivities],
+    [address, client, pendingActivityHashes],
   );
 }

--- a/web/src/hooks/usePendingActivityReconciliation.ts
+++ b/web/src/hooks/usePendingActivityReconciliation.ts
@@ -1,0 +1,77 @@
+import { useEffect, useMemo } from "react";
+import { useAccount } from "wagmi";
+
+import { updateActivity, useActivities } from "../stores/activityStore";
+import { getPendingActivityStatus } from "../utils/reconcilePendingActivity";
+
+import { useEthereumClient } from "./useEthereumClient";
+
+const pendingActivityPollInterval = 10_000;
+
+export function usePendingActivityReconciliation() {
+  const { address } = useAccount();
+  const activities = useActivities(address);
+  const client = useEthereumClient();
+
+  // Bridge transactions can start on several chains, and source confirmation
+  // does not mean that the bridged funds have arrived. They need separate
+  // delivery tracking.
+  const pendingActivities = useMemo(
+    () =>
+      activities.filter(
+        (activity) =>
+          activity.status === "pending" && activity.page !== "bridge",
+      ),
+    [activities],
+  );
+
+  useEffect(
+    function reconcilePendingActivities() {
+      if (!address || !client || pendingActivities.length === 0) {
+        return undefined;
+      }
+
+      const account = address;
+      const publicClient = client;
+      let isActive = true;
+      let isChecking = false;
+
+      async function reconcile() {
+        if (!isActive || isChecking) {
+          return;
+        }
+
+        isChecking = true;
+        try {
+          await Promise.all(
+            pendingActivities.map(async function reconcileActivity(activity) {
+              const status = await getPendingActivityStatus({
+                activity,
+                getReceipt: (hash) =>
+                  publicClient.getTransactionReceipt({ hash }),
+              });
+
+              if (isActive && status) {
+                updateActivity(account, activity.txHash, { status });
+              }
+            }),
+          );
+        } finally {
+          isChecking = false;
+        }
+      }
+
+      void reconcile();
+      const interval = setInterval(
+        () => void reconcile(),
+        pendingActivityPollInterval,
+      );
+
+      return function cleanup() {
+        isActive = false;
+        clearInterval(interval);
+      };
+    },
+    [address, client, pendingActivities],
+  );
+}

--- a/web/src/hooks/usePendingActivityReconciliation.ts
+++ b/web/src/hooks/usePendingActivityReconciliation.ts
@@ -4,7 +4,10 @@ import { useAccount } from "wagmi";
 
 import { updateActivity, useActivities } from "../stores/activityStore";
 import { SECONDS_PER_DAY, unixNowTimestamp } from "../utils/date";
-import { getPendingActivityStatus } from "../utils/reconcilePendingActivity";
+import {
+  getPendingActivitiesToReconcile,
+  getPendingActivityStatus,
+} from "../utils/reconcilePendingActivity";
 
 import { useEthereumClient } from "./useEthereumClient";
 
@@ -15,20 +18,19 @@ export function usePendingActivityReconciliation() {
   const { address } = useAccount();
   const activities = useActivities(address);
   const client = useEthereumClient();
+  const checkedHashesRef = useRef(new Set<string>());
 
   // Bridge transactions can start on several chains, and source confirmation
   // does not mean that the bridged funds have arrived. They need separate
   // delivery tracking.
   const pendingActivities = useMemo(
-    function getPendingActivities() {
-      const now = unixNowTimestamp();
-      return activities.filter(
-        (activity) =>
-          activity.status === "pending" &&
-          activity.page !== "bridge" &&
-          now - activity.date < pendingActivityMaxAge,
-      );
-    },
+    () =>
+      getPendingActivitiesToReconcile({
+        activities,
+        checkedHashes: checkedHashesRef.current,
+        maxAge: pendingActivityMaxAge,
+        now: unixNowTimestamp(),
+      }),
     [activities],
   );
   const pendingActivitiesRef = useRef(pendingActivities);
@@ -48,6 +50,9 @@ export function usePendingActivityReconciliation() {
       const publicClient = client;
       let isActive = true;
       let isChecking = false;
+      const intervalRef = {
+        current: undefined as ReturnType<typeof setInterval> | undefined,
+      };
 
       async function reconcile() {
         if (!isActive || isChecking) {
@@ -56,8 +61,25 @@ export function usePendingActivityReconciliation() {
 
         isChecking = true;
         try {
+          const now = unixNowTimestamp();
+          const activitiesToReconcile = getPendingActivitiesToReconcile({
+            activities: pendingActivitiesRef.current,
+            checkedHashes: checkedHashesRef.current,
+            maxAge: pendingActivityMaxAge,
+            now,
+          });
+
+          pendingActivitiesRef.current = activitiesToReconcile;
+
+          if (activitiesToReconcile.length === 0) {
+            if (intervalRef.current) {
+              clearInterval(intervalRef.current);
+            }
+            return;
+          }
+
           const reconciledActivities = await Promise.all(
-            pendingActivitiesRef.current.map(
+            activitiesToReconcile.map(
               async function reconcileActivity(activity) {
                 const status = await getPendingActivityStatus({
                   activity,
@@ -75,25 +97,42 @@ export function usePendingActivityReconciliation() {
               activity,
               status,
             }) {
+              checkedHashesRef.current.add(activity.txHash);
               if (status) {
                 updateActivity(account, activity.txHash, { status });
               }
             });
+
+            pendingActivitiesRef.current = getPendingActivitiesToReconcile({
+              activities: pendingActivitiesRef.current,
+              checkedHashes: checkedHashesRef.current,
+              maxAge: pendingActivityMaxAge,
+              now: unixNowTimestamp(),
+            });
+
+            if (
+              pendingActivitiesRef.current.length === 0 &&
+              intervalRef.current
+            ) {
+              clearInterval(intervalRef.current);
+            }
           }
         } finally {
           isChecking = false;
         }
       }
 
-      void reconcile();
-      const interval = setInterval(
+      intervalRef.current = setInterval(
         () => void reconcile(),
         pendingActivityPollInterval,
       );
+      void reconcile();
 
       return function cleanup() {
         isActive = false;
-        clearInterval(interval);
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+        }
       };
     },
     [address, client, pendingActivityHashes],

--- a/web/src/hooks/usePendingActivityReconciliation.ts
+++ b/web/src/hooks/usePendingActivityReconciliation.ts
@@ -97,7 +97,9 @@ export function usePendingActivityReconciliation() {
               activity,
               status,
             }) {
-              checkedHashesRef.current.add(activity.txHash);
+              if (status !== undefined) {
+                checkedHashesRef.current.add(activity.txHash);
+              }
               if (status) {
                 updateActivity(account, activity.txHash, { status });
               }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -9,6 +9,7 @@ import ReactDOM from "react-dom/client";
 
 import { App } from "./app";
 import { AddressRestriction } from "./components/addressRestriction";
+import { PendingActivityReconciliation } from "./components/pendingActivityReconciliation";
 import { Web3Provider } from "./providers/web3Provider";
 
 initializeI18n();
@@ -35,6 +36,7 @@ ReactDOM.createRoot(document.getElementById("root")!, {
   <React.StrictMode>
     <Web3Provider>
       <AddressRestriction />
+      <PendingActivityReconciliation />
       <App />
     </Web3Provider>
   </React.StrictMode>,

--- a/web/src/utils/reconcilePendingActivity.ts
+++ b/web/src/utils/reconcilePendingActivity.ts
@@ -1,0 +1,28 @@
+import type { Hash, TransactionReceipt } from "viem";
+
+import type { Activity } from "../components/base/activityList/types";
+
+type ReceiptReader = (
+  hash: Hash,
+) => Promise<Pick<TransactionReceipt, "status">>;
+
+export async function getPendingActivityStatus({
+  activity,
+  getReceipt,
+}: {
+  activity: Activity;
+  getReceipt: ReceiptReader;
+}): Promise<"completed" | "failed" | undefined> {
+  if (activity.status !== "pending" || activity.page === "bridge") {
+    return undefined;
+  }
+
+  try {
+    const receipt = await getReceipt(activity.txHash as Hash);
+    return receipt.status === "success" ? "completed" : "failed";
+  } catch {
+    // A missing receipt means the transaction is still pending, or the RPC is
+    // temporarily unavailable. Keep the activity pending in both cases.
+    return undefined;
+  }
+}

--- a/web/src/utils/reconcilePendingActivity.ts
+++ b/web/src/utils/reconcilePendingActivity.ts
@@ -1,4 +1,8 @@
-import type { Hash, TransactionReceipt } from "viem";
+import {
+  type Hash,
+  TransactionReceiptNotFoundError,
+  type TransactionReceipt,
+} from "viem";
 
 import type { Activity } from "../components/base/activityList/types";
 
@@ -32,7 +36,7 @@ export async function getPendingActivityStatus({
 }: {
   activity: Activity;
   getReceipt: ReceiptReader;
-}): Promise<"completed" | "failed" | undefined> {
+}): Promise<"completed" | "failed" | null | undefined> {
   if (activity.status !== "pending" || activity.page === "bridge") {
     return undefined;
   }
@@ -40,9 +44,15 @@ export async function getPendingActivityStatus({
   try {
     const receipt = await getReceipt(activity.txHash as Hash);
     return receipt.status === "success" ? "completed" : "failed";
-  } catch {
-    // A missing receipt means the transaction is still pending, or the RPC is
-    // temporarily unavailable. Keep the activity pending in both cases.
+  } catch (error) {
+    if (error instanceof TransactionReceiptNotFoundError) {
+      // A missing receipt means the transaction is still pending. The lookup
+      // completed, so stale activities do not need to be checked again.
+      return null;
+    }
+
+    // Keep the activity eligible for another attempt when the RPC is
+    // temporarily unavailable.
     return undefined;
   }
 }

--- a/web/src/utils/reconcilePendingActivity.ts
+++ b/web/src/utils/reconcilePendingActivity.ts
@@ -2,6 +2,26 @@ import type { Hash, TransactionReceipt } from "viem";
 
 import type { Activity } from "../components/base/activityList/types";
 
+export const getPendingActivitiesToReconcile = ({
+  activities,
+  checkedHashes,
+  maxAge,
+  now,
+}: {
+  activities: Activity[];
+  checkedHashes: ReadonlySet<string>;
+  maxAge: number;
+  now: number;
+}) =>
+  // Give persisted activities one receipt lookup after a new session starts,
+  // even when they are already older than the polling cutoff.
+  activities.filter(
+    (activity) =>
+      activity.status === "pending" &&
+      activity.page !== "bridge" &&
+      (now - activity.date < maxAge || !checkedHashes.has(activity.txHash)),
+  );
+
 type ReceiptReader = (
   hash: Hash,
 ) => Promise<Pick<TransactionReceipt, "status">>;

--- a/web/test/utils/reconcilePendingActivity.test.ts
+++ b/web/test/utils/reconcilePendingActivity.test.ts
@@ -1,0 +1,80 @@
+import type { Hash } from "viem";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Activity } from "../../src/components/base/activityList/types";
+import { getPendingActivityStatus } from "../../src/utils/reconcilePendingActivity";
+
+const transactionHash =
+  "0x0000000000000000000000000000000000000000000000000000000000000001" as Hash;
+
+const createActivity = (overrides: Partial<Activity> = {}): Activity => ({
+  date: 0,
+  page: "borrow",
+  status: "pending",
+  text: "Borrow more VUSD",
+  title: "Borrow",
+  txHash: transactionHash,
+  ...overrides,
+});
+
+describe("getPendingActivityStatus", function () {
+  it("maps a successful receipt to a completed activity", async function () {
+    const getReceipt = vi.fn(async () => ({ status: "success" as const }));
+
+    await expect(
+      getPendingActivityStatus({
+        activity: createActivity(),
+        getReceipt,
+      }),
+    ).resolves.toBe("completed");
+    expect(getReceipt).toHaveBeenCalledExactlyOnceWith(transactionHash);
+  });
+
+  it("maps a reverted receipt to a failed activity", async function () {
+    const getReceipt = vi.fn(async () => ({ status: "reverted" as const }));
+
+    await expect(
+      getPendingActivityStatus({
+        activity: createActivity(),
+        getReceipt,
+      }),
+    ).resolves.toBe("failed");
+  });
+
+  it("keeps an activity pending when no receipt is available", async function () {
+    const getReceipt = vi
+      .fn()
+      .mockRejectedValue(new Error("Transaction receipt not found"));
+
+    await expect(
+      getPendingActivityStatus({
+        activity: createActivity(),
+        getReceipt,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not reconcile bridge activities", async function () {
+    const getReceipt = vi.fn(async () => ({ status: "success" as const }));
+
+    await expect(
+      getPendingActivityStatus({
+        activity: createActivity({ page: "bridge" }),
+        getReceipt,
+      }),
+    ).resolves.toBeUndefined();
+    expect(getReceipt).not.toHaveBeenCalled();
+  });
+
+  it("does not reconcile activities that are no longer pending", async function () {
+    const getReceipt = vi.fn(async () => ({ status: "success" as const }));
+
+    await expect(
+      getPendingActivityStatus({
+        activity: createActivity({ status: "completed" }),
+        getReceipt,
+      }),
+    ).resolves.toBeUndefined();
+    expect(getReceipt).not.toHaveBeenCalled();
+  });
+});

--- a/web/test/utils/reconcilePendingActivity.test.ts
+++ b/web/test/utils/reconcilePendingActivity.test.ts
@@ -2,7 +2,10 @@ import type { Hash } from "viem";
 import { describe, expect, it, vi } from "vitest";
 
 import type { Activity } from "../../src/components/base/activityList/types";
-import { getPendingActivityStatus } from "../../src/utils/reconcilePendingActivity";
+import {
+  getPendingActivitiesToReconcile,
+  getPendingActivityStatus,
+} from "../../src/utils/reconcilePendingActivity";
 
 const transactionHash =
   "0x0000000000000000000000000000000000000000000000000000000000000001" as Hash;
@@ -15,6 +18,86 @@ const createActivity = (overrides: Partial<Activity> = {}): Activity => ({
   title: "Borrow",
   txHash: transactionHash,
   ...overrides,
+});
+
+describe("getPendingActivitiesToReconcile", function () {
+  const now = 1_000;
+  const maxAge = 100;
+
+  it("includes fresh pending activities", function () {
+    const activity = createActivity({ date: now - maxAge });
+
+    expect(
+      getPendingActivitiesToReconcile({
+        activities: [activity],
+        checkedHashes: new Set(),
+        maxAge,
+        now,
+      }),
+    ).toEqual([activity]);
+  });
+
+  it("includes a stale activity until it has been checked", function () {
+    const activity = createActivity({ date: now - maxAge - 1 });
+
+    expect(
+      getPendingActivitiesToReconcile({
+        activities: [activity],
+        checkedHashes: new Set(),
+        maxAge,
+        now,
+      }),
+    ).toEqual([activity]);
+  });
+
+  it("excludes a stale activity after it has been checked", function () {
+    const activity = createActivity({ date: now - maxAge - 1 });
+
+    expect(
+      getPendingActivitiesToReconcile({
+        activities: [activity],
+        checkedHashes: new Set([activity.txHash]),
+        maxAge,
+        now,
+      }),
+    ).toEqual([]);
+  });
+
+  it("applies the cutoff using the current time", function () {
+    const activity = createActivity({ date: now - maxAge + 1 });
+    const checkedHashes = new Set([activity.txHash]);
+
+    expect(
+      getPendingActivitiesToReconcile({
+        activities: [activity],
+        checkedHashes,
+        maxAge,
+        now,
+      }),
+    ).toEqual([activity]);
+    expect(
+      getPendingActivitiesToReconcile({
+        activities: [activity],
+        checkedHashes,
+        maxAge,
+        now: now + 2,
+      }),
+    ).toEqual([]);
+  });
+
+  it("excludes completed and bridge activities", function () {
+    const completedActivity = createActivity({ status: "completed" });
+    const bridgeActivity = createActivity({ page: "bridge" });
+
+    expect(
+      getPendingActivitiesToReconcile({
+        activities: [completedActivity, bridgeActivity],
+        checkedHashes: new Set(),
+        maxAge,
+        now,
+      }),
+    ).toEqual([]);
+  });
 });
 
 describe("getPendingActivityStatus", function () {

--- a/web/test/utils/reconcilePendingActivity.test.ts
+++ b/web/test/utils/reconcilePendingActivity.test.ts
@@ -1,4 +1,4 @@
-import type { Hash } from "viem";
+import { TransactionReceiptNotFoundError, type Hash } from "viem";
 import { describe, expect, it, vi } from "vitest";
 
 import type { Activity } from "../../src/components/base/activityList/types";
@@ -25,12 +25,12 @@ describe("getPendingActivitiesToReconcile", function () {
   const maxAge = 100;
 
   it("includes fresh pending activities", function () {
-    const activity = createActivity({ date: now - maxAge });
+    const activity = createActivity({ date: now - maxAge + 1 });
 
     expect(
       getPendingActivitiesToReconcile({
         activities: [activity],
-        checkedHashes: new Set(),
+        checkedHashes: new Set([activity.txHash]),
         maxAge,
         now,
       }),
@@ -127,7 +127,20 @@ describe("getPendingActivityStatus", function () {
   it("keeps an activity pending when no receipt is available", async function () {
     const getReceipt = vi
       .fn()
-      .mockRejectedValue(new Error("Transaction receipt not found"));
+      .mockRejectedValue(
+        new TransactionReceiptNotFoundError({ hash: transactionHash }),
+      );
+
+    await expect(
+      getPendingActivityStatus({
+        activity: createActivity(),
+        getReceipt,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("does not mark an activity as checked when the receipt lookup fails", async function () {
+    const getReceipt = vi.fn().mockRejectedValue(new Error("RPC unavailable"));
 
     await expect(
       getPendingActivityStatus({


### PR DESCRIPTION
### Description

Pending transaction activities are saved in local storage, but their status was only updated by callbacks kept in memory. After a page reload, a mined or reverted non-bridge transaction could remain pending indefinitely.

### Screenshots

N/A — no visual layout changes.

### Related issue(s)

Closes #804 

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.