### PR TITLE
Add max repayment to borrow flow

### DIFF
--- a/packages/morpho-blue-market/README.md
+++ b/packages/morpho-blue-market/README.md
@@ -13,6 +13,7 @@ pnpm add @vetro-protocol/morpho-blue-market viem
 - Every action takes the Morpho Blue contract `address` plus the `marketId`; the market's `MarketParams` struct is read on-chain from `idToMarketParams` and passed to the contract call.
 - Writes emit their progress through an `EventEmitter` and return `{ emitter, promise }`.
 - `supplyCollateral` and `repayAssets` handle the ERC-20 approval themselves: they read the current allowance — of the collateral token and the loan token respectively — and approve only when it falls short. `approveAmount` defaults to `amount`; pass a larger value to approve once for several operations.
+- `repayAssets` accepts an optional `shares` value for full-position repayment. When provided, it sends `assets = 0` and the given borrow-share balance, while `amount` remains the asset estimate used for validation.
 - `supplyCollateralAndBorrow` runs both steps against one emitter and skips the borrow if the supply doesn't succeed. Its event map is the union of both, with a single `supply-collateral-and-borrow-settled` at the end.
 - The `encode*` helpers return the calldata for their contract call without sending anything — useful for gas estimation or for batching into a multicall. They take `marketParams` directly, since there is no client to read them with.
 

--- a/packages/morpho-blue-market/src/actions/wallet/repayAssets.ts
+++ b/packages/morpho-blue-market/src/actions/wallet/repayAssets.ts
@@ -22,6 +22,7 @@ export type RepayAssetsParams = {
   approveAmount?: bigint;
   marketId: Hash;
   onBehalf: Address;
+  shares?: bigint;
 };
 
 const canRepayAssets = function ({
@@ -31,6 +32,7 @@ const canRepayAssets = function ({
   client,
   marketId,
   onBehalf,
+  shares,
 }: {
   address: Address;
   amount: bigint;
@@ -38,6 +40,7 @@ const canRepayAssets = function ({
   client: WalletClient;
   marketId: Hash;
   onBehalf: Address;
+  shares?: bigint;
 }): {
   canRepayAssets: boolean;
   reason?: string;
@@ -102,6 +105,18 @@ const canRepayAssets = function ({
       reason: "Approve amount must be greater than or equal to amount",
     };
   }
+  if (shares !== undefined && typeof shares !== "bigint") {
+    return {
+      canRepayAssets: false,
+      reason: "Shares must be a bigint",
+    };
+  }
+  if (shares !== undefined && shares <= 0n) {
+    return {
+      canRepayAssets: false,
+      reason: "Shares must be greater than 0",
+    };
+  }
 
   return { canRepayAssets: true };
 };
@@ -114,6 +129,7 @@ const runRepayAssets = (
     approveAmount = amount,
     marketId,
     onBehalf,
+    shares,
   }: RepayAssetsParams,
 ) =>
   async function (emitter: EventEmitter<RepayAssetsEvents>) {
@@ -125,6 +141,7 @@ const runRepayAssets = (
         client: walletClient,
         marketId,
         onBehalf,
+        shares,
       });
 
       if (!canRepayAssetsFlag) {
@@ -144,7 +161,9 @@ const runRepayAssets = (
         spender: address,
       });
 
-      if (currentAllowance < amount) {
+      const requiredAllowance = shares === undefined ? amount : approveAmount;
+
+      if (currentAllowance < requiredAllowance) {
         emitter.emit("pre-approve");
 
         const approvalHash = await approve(walletClient, {
@@ -185,7 +204,13 @@ const runRepayAssets = (
         abi: morphoBlueAbi,
         account: walletClient.account!,
         address,
-        args: [marketParams, amount, 0n, onBehalf, "0x"],
+        args: [
+          marketParams,
+          shares === undefined ? amount : 0n,
+          shares ?? 0n,
+          onBehalf,
+          "0x",
+        ],
         chain: walletClient.chain,
         functionName: "repay",
       }).catch(function (error: Error) {
@@ -231,13 +256,21 @@ export const encodeRepayAssets = ({
   amount,
   marketParams,
   onBehalf,
+  shares,
 }: {
   amount: bigint;
   marketParams: MarketParams;
   onBehalf: Address;
+  shares?: bigint;
 }) =>
   encodeFunctionData({
     abi: morphoBlueAbi,
-    args: [marketParams, amount, 0n, onBehalf, "0x"],
+    args: [
+      marketParams,
+      shares === undefined ? amount : 0n,
+      shares ?? 0n,
+      onBehalf,
+      "0x",
+    ],
     functionName: "repay",
   });

--- a/packages/morpho-blue-market/test/wallet/repayAssets.test.ts
+++ b/packages/morpho-blue-market/test/wallet/repayAssets.test.ts
@@ -365,6 +365,55 @@ describe("repayAssets", function () {
     expect(onSettled).toHaveBeenCalledOnce();
   });
 
+  it("should repay by shares when shares are provided", async function () {
+    const receipt = {
+      status: "success",
+    } as TransactionReceipt;
+    const shares = 500n;
+    const approveAmount = 1200n;
+
+    vi.mocked(readContract).mockResolvedValue(mockMarketParams);
+    vi.mocked(allowance).mockResolvedValue(validParameters.amount);
+    vi.mocked(approve).mockResolvedValue(zeroHash);
+    vi.mocked(writeContract).mockResolvedValue(zeroHash);
+    vi.mocked(waitForTransactionReceipt)
+      .mockResolvedValueOnce(receipt)
+      .mockResolvedValueOnce(receipt);
+
+    const { promise } = repayAssets(mockWalletClient, {
+      ...validParameters,
+      approveAmount,
+      shares,
+    });
+
+    await promise;
+
+    expect(approve).toHaveBeenCalledWith(
+      mockWalletClient,
+      expect.objectContaining({
+        amount: approveAmount,
+      }),
+    );
+    expect(writeContract).toHaveBeenCalledWith(
+      mockWalletClient,
+      expect.objectContaining({
+        args: [
+          expect.objectContaining({
+            collateralToken: mockMarketParams[1],
+            irm: mockMarketParams[3],
+            lltv: mockMarketParams[4],
+            loanToken: mockMarketParams[0],
+            oracle: mockMarketParams[2],
+          }),
+          0n,
+          shares,
+          validParameters.onBehalf,
+          "0x",
+        ],
+      }),
+    );
+  });
+
   it("should approve first if allowance is insufficient, then repay", async function () {
     const successReceipt = {
       status: "success",

--- a/web/src/components/borrow/repayLoanForm.tsx
+++ b/web/src/components/borrow/repayLoanForm.tsx
@@ -5,6 +5,7 @@ import { getChainAddresses } from "@morpho-org/blue-sdk";
 import { Button } from "components/base/button";
 import { RenderCryptoValue } from "components/base/cryptoValue";
 import { RenderFiatValue } from "components/base/fiatValue";
+import { MaxButton } from "components/base/maxButton";
 import { Toast } from "components/base/toast";
 import {
   type Step,
@@ -37,7 +38,14 @@ import { useTranslation } from "react-i18next";
 import { formatLtvAsPercentage } from "utils/borrowReview";
 import { formatNumber } from "utils/format";
 import { isGeoRestricted } from "utils/geoRestriction";
+import {
+  getCurrentBorrowAssets,
+  getMaxRepayable,
+  getRepayApprovalAmount,
+  getRepayShares,
+} from "utils/repay";
 import { parseTokenUnits } from "utils/token";
+import { formatUnits } from "viem";
 import { useAccount } from "wagmi";
 
 import { PositionReview } from "./positionReview";
@@ -252,25 +260,45 @@ export function RepayLoanForm({ market, onClose }: Props) {
 
   const { data: nativeBalanceData } = useNativeBalance(ethereumChain.id);
 
-  const { data: needsApproval } = useNeedsApproval({
-    amount: repayAmountBigInt,
-    spender: getChainAddresses(ethereumChain.id).morpho,
-    token: loanToken,
-  });
-
   const { data: positionInfo } = usePositionInfo(marketId);
 
   const { data: morphoMarket } = useMorphoMarket(marketId);
 
-  const currentBorrowAssets =
-    positionInfo && morphoMarket
-      ? morphoMarket.toBorrowAssets(positionInfo.borrowShares)
-      : undefined;
+  const currentBorrowAssets = getCurrentBorrowAssets({
+    borrowShares: positionInfo?.borrowShares,
+    market: morphoMarket,
+  });
+
+  const maxRepayable = getMaxRepayable({
+    borrowShares: positionInfo?.borrowShares,
+    loanTokenBalance: loanBalance,
+    market: morphoMarket,
+  });
+
+  const repayShares = getRepayShares({
+    amount: repayAmountBigInt,
+    borrowAssets: currentBorrowAssets,
+    borrowShares: positionInfo?.borrowShares,
+    loanTokenBalance: loanBalance,
+  });
+
+  const repayApprovalAmount = getRepayApprovalAmount({
+    amount: repayAmountBigInt,
+    loanTokenBalance: loanBalance,
+    shares: repayShares,
+  });
+
+  const { data: needsApproval } = useNeedsApproval({
+    amount: repayApprovalAmount,
+    spender: getChainAddresses(ethereumChain.id).morpho,
+    token: loanToken,
+  });
 
   const networkFee = useTotalRepayFees({
     amount: repayAmountBigInt,
-    approveAmount: undefined,
+    approveAmount: repayShares !== undefined ? repayApprovalAmount : undefined,
     marketId,
+    shares: repayShares,
     token: loanToken,
   });
 
@@ -285,6 +313,7 @@ export function RepayLoanForm({ market, onClose }: Props) {
     });
 
   const repayMutation = useRepayAssets({
+    approveAmount: repayShares !== undefined ? repayApprovalAmount : undefined,
     marketId,
     onEmitter(emitter) {
       emitter.on("user-signed-approval", () => setFlowStatus("approving"));
@@ -330,6 +359,7 @@ export function RepayLoanForm({ market, onClose }: Props) {
       });
     },
     repayAmount: repayAmountBigInt,
+    repayShares,
   });
 
   const nativeBalance = nativeBalanceData?.value;
@@ -402,6 +432,14 @@ export function RepayLoanForm({ market, onClose }: Props) {
               <RenderFiatValue token={loanToken} value={repayAmountBigInt} />
             }
             label={t("pages.borrow.repay-loan-progress.you-will-repay")}
+            maxButton={
+              <MaxButton
+                disabled={maxRepayable === undefined}
+                onClick={() =>
+                  onRepayChange(formatUnits(maxRepayable!, loanToken.decimals))
+                }
+              />
+            }
             onChange={onRepayChange}
             tokenSelector={<TokenSelectorReadOnly {...loanToken} />}
             value={repayInput}

--- a/web/src/fetchers/fetchRepayGasUnits.ts
+++ b/web/src/fetchers/fetchRepayGasUnits.ts
@@ -14,7 +14,8 @@ import { estimateApprovalGasUnits } from "./estimateApprovalGasUnits";
 /**
  * Estimates gas units for a repay operation. Returns the total gas units
  * for the whole flow (approval + repay).
- * Throws if the amount exceeds the user's current debt or loan token balance.
+ * Throws if the amount exceeds the user's current debt or the required
+ * approval amount exceeds the user's loan token balance.
  */
 export const fetchRepayGasUnits = async function ({
   amount,
@@ -23,6 +24,7 @@ export const fetchRepayGasUnits = async function ({
   marketId,
   owner,
   queryClient,
+  shares,
   token,
 }: {
   amount: bigint;
@@ -31,6 +33,7 @@ export const fetchRepayGasUnits = async function ({
   marketId: Hash;
   owner: Address;
   queryClient: QueryClient;
+  shares?: bigint;
   token: Token;
 }) {
   const chainId = client.chain!.id;
@@ -60,13 +63,16 @@ export const fetchRepayGasUnits = async function ({
     throw new Error("Amount exceeds current debt");
   }
 
-  if (amount > loanBalance) {
+  const amountForApproval =
+    shares === undefined ? amount : (approveAmount ?? amount);
+
+  if (amountForApproval > loanBalance) {
     throw new Error("Insufficient loan token balance");
   }
 
   const [approvalGas, repayGas] = await Promise.all([
     estimateApprovalGasUnits({
-      amount,
+      amount: amountForApproval,
       approveAmount,
       client,
       owner,
@@ -77,9 +83,10 @@ export const fetchRepayGasUnits = async function ({
     estimateGas(client, {
       account: owner,
       data: encodeRepayAssets({
-        amount,
+        amount: shares === undefined ? amount : 0n,
         marketParams: morphoMarket.params,
         onBehalf: owner,
+        shares,
       }),
       stateOverride: createErc20AllowanceStateOverride({
         owner,

--- a/web/src/fetchers/fetchTotalRepayFees.ts
+++ b/web/src/fetchers/fetchTotalRepayFees.ts
@@ -16,6 +16,7 @@ export const fetchTotalRepayFees = async function ({
   marketId,
   owner,
   queryClient,
+  shares,
   token,
 }: {
   amount: bigint;
@@ -25,6 +26,7 @@ export const fetchTotalRepayFees = async function ({
   marketId: Hash;
   owner: Address;
   queryClient: QueryClient;
+  shares?: bigint;
   token: Token;
 }) {
   const gasUnits = await queryClient.ensureQueryData(
@@ -36,6 +38,7 @@ export const fetchTotalRepayFees = async function ({
       marketId,
       owner,
       queryClient,
+      shares,
       token,
     }),
   );

--- a/web/src/hooks/borrow/useRepayAssets.ts
+++ b/web/src/hooks/borrow/useRepayAssets.ts
@@ -4,10 +4,13 @@ import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
 import { type AccrualPosition, getChainAddresses } from "@morpho-org/blue-sdk";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type { RepayAssetsEvents } from "@vetro-protocol/morpho-blue-market";
+import {
+  morphoBlueAbi,
+  type RepayAssetsEvents,
+} from "@vetro-protocol/morpho-blue-market";
 import { repayAssets } from "@vetro-protocol/morpho-blue-market/actions";
 import type { EventEmitter } from "events";
-import type { Hash } from "viem";
+import { parseEventLogs, type Hash } from "viem";
 import { useAccount } from "wagmi";
 
 import { useEthereumWalletClient } from "../useEthereumWalletClient";
@@ -19,13 +22,17 @@ import { morphoMarketOptions, morphoMarketQueryKey } from "./useMorphoMarket";
 import { positionInfoQueryKey } from "./usePositionInfo";
 
 export const useRepayAssets = function ({
+  approveAmount,
   marketId,
   onEmitter,
   repayAmount,
+  repayShares,
 }: {
+  approveAmount?: bigint;
   marketId: Hash;
   onEmitter?: (emitter: EventEmitter<RepayAssetsEvents>) => void;
   repayAmount: bigint;
+  repayShares?: bigint;
 }) {
   const { address: account } = useAccount();
   const { data: walletClient } = useEthereumWalletClient();
@@ -77,8 +84,10 @@ export const useRepayAssets = function ({
       const { emitter, promise } = repayAssets(walletClient!, {
         address: morphoAddress,
         amount: repayAmount,
+        approveAmount,
         marketId,
         onBehalf: account,
+        shares: repayShares,
       });
 
       onEmitter?.(emitter);
@@ -95,15 +104,26 @@ export const useRepayAssets = function ({
       });
       emitter.on("repay-assets-transaction-succeeded", function (receipt) {
         updateNativeBalanceAfterReceipt(receipt);
+
+        const events = parseEventLogs({
+          abi: morphoBlueAbi,
+          eventName: "Repay",
+          logs: receipt.logs,
+        });
+        const repayment = events[0]?.args ?? {
+          assets: repayAmount,
+          shares: repayShares ?? 0n,
+        };
+
         // Decrease loan token balance
         queryClient.setQueryData(loanBalanceKey, (old?: bigint) =>
-          old !== undefined ? old - repayAmount : old,
+          old !== undefined ? old - repayment.assets : old,
         );
         // Update position's borrow
         queryClient.setQueryData(
           positionInfoKey,
           (old: AccrualPosition | undefined) =>
-            old?.repay(repayAmount, 0n).position,
+            old?.repay(repayment.assets, repayment.shares).position,
         );
         // Update market's liquidity and total borrow
         queryClient.setQueryData(
@@ -115,8 +135,8 @@ export const useRepayAssets = function ({
             old
               ? {
                   ...old,
-                  liquidity: old.liquidity + repayAmount,
-                  totalBorrowAssets: old.totalBorrowAssets - repayAmount,
+                  liquidity: old.liquidity + repayment.assets,
+                  totalBorrowAssets: old.totalBorrowAssets - repayment.assets,
                 }
               : old,
         );

--- a/web/src/hooks/borrow/useRepayAssets.ts
+++ b/web/src/hooks/borrow/useRepayAssets.ts
@@ -10,6 +10,7 @@ import {
 } from "@vetro-protocol/morpho-blue-market";
 import { repayAssets } from "@vetro-protocol/morpho-blue-market/actions";
 import type { EventEmitter } from "events";
+import { getRepayPositionArgs } from "utils/repay";
 import { parseEventLogs, type Hash } from "viem";
 import { useAccount } from "wagmi";
 
@@ -114,6 +115,11 @@ export const useRepayAssets = function ({
           assets: repayAmount,
           shares: repayShares ?? 0n,
         };
+        const positionRepay = getRepayPositionArgs({
+          assets: repayment.assets,
+          repayShares,
+          shares: repayment.shares,
+        });
 
         // Decrease loan token balance
         queryClient.setQueryData(loanBalanceKey, (old?: bigint) =>
@@ -123,7 +129,7 @@ export const useRepayAssets = function ({
         queryClient.setQueryData(
           positionInfoKey,
           (old: AccrualPosition | undefined) =>
-            old?.repay(repayment.assets, repayment.shares).position,
+            old?.repay(positionRepay.assets, positionRepay.shares).position,
         );
         // Update market's liquidity and total borrow
         queryClient.setQueryData(

--- a/web/src/hooks/borrow/useRepayFees.ts
+++ b/web/src/hooks/borrow/useRepayFees.ts
@@ -14,15 +14,19 @@ import { useAccount } from "wagmi";
 
 const repayGasUnitsQueryKey = ({
   amount,
+  approveAmount,
   chainId,
   marketId,
   owner,
+  shares,
   token,
 }: {
   amount: bigint;
+  approveAmount: bigint | undefined;
   chainId: Chain["id"];
   marketId: Hash;
   owner: Address | undefined;
+  shares: bigint | undefined;
   token: Token | undefined;
 }) => [
   "borrow-repay-gas-units",
@@ -31,6 +35,8 @@ const repayGasUnitsQueryKey = ({
   token?.address,
   owner,
   amount.toString(),
+  approveAmount?.toString(),
+  shares?.toString(),
 ];
 
 export const repayGasUnitsOptions = ({
@@ -41,6 +47,7 @@ export const repayGasUnitsOptions = ({
   marketId,
   owner,
   queryClient,
+  shares,
   token,
 }: {
   amount: bigint;
@@ -50,6 +57,7 @@ export const repayGasUnitsOptions = ({
   marketId: Hash;
   owner: Address | undefined;
   queryClient: QueryClient;
+  shares: bigint | undefined;
   token: Token | undefined;
 }) =>
   queryOptions({
@@ -62,28 +70,35 @@ export const repayGasUnitsOptions = ({
         marketId,
         owner: owner!,
         queryClient,
+        shares,
         token: token!,
       }),
     queryKey: repayGasUnitsQueryKey({
       amount,
+      approveAmount,
       chainId,
       marketId,
       owner,
+      shares,
       token,
     }),
   });
 
 const totalRepayFeesQueryKey = ({
   amount,
+  approveAmount,
   chainId,
   marketId,
   owner,
+  shares,
   token,
 }: {
   amount: bigint;
+  approveAmount: bigint | undefined;
   chainId: Chain["id"];
   marketId: Hash;
   owner: Address | undefined;
+  shares: bigint | undefined;
   token: Token | undefined;
 }) => [
   "total-repay-fees",
@@ -92,6 +107,8 @@ const totalRepayFeesQueryKey = ({
   token?.address,
   owner,
   amount.toString(),
+  approveAmount?.toString(),
+  shares?.toString(),
 ];
 
 const totalRepayFeesOptions = ({
@@ -102,6 +119,7 @@ const totalRepayFeesOptions = ({
   marketId,
   owner,
   queryClient,
+  shares,
   token,
 }: {
   amount: bigint;
@@ -111,6 +129,7 @@ const totalRepayFeesOptions = ({
   marketId: Hash;
   owner: Address | undefined;
   queryClient: QueryClient;
+  shares: bigint | undefined;
   token: Token | undefined;
 }) =>
   queryOptions({
@@ -124,13 +143,16 @@ const totalRepayFeesOptions = ({
         marketId,
         owner: owner!,
         queryClient,
+        shares,
         token: token!,
       }),
     queryKey: totalRepayFeesQueryKey({
       amount,
+      approveAmount,
       chainId: chain.id,
       marketId,
       owner,
+      shares,
       token,
     }),
   });
@@ -139,11 +161,13 @@ export const useTotalRepayFees = function ({
   amount,
   approveAmount,
   marketId,
+  shares,
   token,
 }: {
   amount: bigint;
   approveAmount: bigint | undefined;
   marketId: Hash;
+  shares?: bigint;
   token: Token | undefined;
 }) {
   const { address: owner } = useAccount();
@@ -160,6 +184,7 @@ export const useTotalRepayFees = function ({
       marketId,
       owner,
       queryClient,
+      shares,
       token,
     }),
   );

--- a/web/src/utils/repay.ts
+++ b/web/src/utils/repay.ts
@@ -72,3 +72,14 @@ export const getRepayApprovalAmount = ({
   loanTokenBalance: bigint | undefined;
   shares: bigint | undefined;
 }) => (shares === undefined ? amount : (loanTokenBalance ?? amount));
+
+export const getRepayPositionArgs = ({
+  assets,
+  repayShares,
+  shares,
+}: {
+  assets: bigint;
+  repayShares: bigint | undefined;
+  shares: bigint;
+}) =>
+  repayShares === undefined ? { assets, shares: 0n } : { assets: 0n, shares };

--- a/web/src/utils/repay.ts
+++ b/web/src/utils/repay.ts
@@ -1,0 +1,74 @@
+import type { Market } from "@morpho-org/blue-sdk";
+
+import { BPS_DENOMINATOR } from "./bigint";
+
+// Treat repayments of at least 99% of the debt as an intent to close it fully.
+const FULL_REPAYMENT_THRESHOLD_BPS = 9900n;
+
+export const getCurrentBorrowAssets = function ({
+  borrowShares,
+  market,
+}: {
+  borrowShares: bigint | undefined;
+  market: Market | undefined;
+}) {
+  if (market === undefined || borrowShares === undefined) {
+    return undefined;
+  }
+
+  return market.toBorrowAssets(borrowShares);
+};
+
+export const getRepayShares = function ({
+  amount,
+  borrowAssets,
+  borrowShares,
+  loanTokenBalance,
+}: {
+  amount: bigint;
+  borrowAssets: bigint | undefined;
+  borrowShares: bigint | undefined;
+  loanTokenBalance: bigint | undefined;
+}) {
+  const isNearFullRepayment =
+    amount > 0n &&
+    borrowAssets !== undefined &&
+    borrowAssets > 0n &&
+    borrowShares !== undefined &&
+    borrowShares > 0n &&
+    loanTokenBalance !== undefined &&
+    loanTokenBalance >= borrowAssets &&
+    amount * BPS_DENOMINATOR >= borrowAssets * FULL_REPAYMENT_THRESHOLD_BPS;
+
+  return isNearFullRepayment ? borrowShares : undefined;
+};
+
+export const getMaxRepayable = function ({
+  borrowShares,
+  loanTokenBalance,
+  market,
+}: {
+  borrowShares: bigint | undefined;
+  loanTokenBalance: bigint | undefined;
+  market: Market | undefined;
+}) {
+  if (
+    market === undefined ||
+    borrowShares === undefined ||
+    loanTokenBalance === undefined
+  ) {
+    return undefined;
+  }
+
+  return market.getRepayCapacityLimit(borrowShares, loanTokenBalance).value;
+};
+
+export const getRepayApprovalAmount = ({
+  amount,
+  loanTokenBalance,
+  shares,
+}: {
+  amount: bigint;
+  loanTokenBalance: bigint | undefined;
+  shares: bigint | undefined;
+}) => (shares === undefined ? amount : (loanTokenBalance ?? amount));

--- a/web/test/fetchers/fetchRepayGasUnits.test.ts
+++ b/web/test/fetchers/fetchRepayGasUnits.test.ts
@@ -1,5 +1,6 @@
 import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import type { Token } from "@vetro-protocol/core";
+import { encodeRepayAssets } from "@vetro-protocol/morpho-blue-market/actions";
 import { type Client, zeroAddress, zeroHash } from "viem";
 import { estimateGas } from "viem/actions";
 import { describe, expect, it, vi } from "vitest";
@@ -109,6 +110,39 @@ describe("fetchRepayGasUnits", function () {
     });
 
     expect(result).toBe(repayGas);
+  });
+
+  it("estimates a share-based full repayment", async function () {
+    const approvalGas = 46000n;
+    const repayGas = 120000n;
+    const queryClient = createPrepopulatedQueryClient();
+
+    vi.mocked(estimateApprovalGasUnits).mockResolvedValue(approvalGas);
+    vi.mocked(estimateGas).mockResolvedValue(repayGas);
+
+    const result = await fetchRepayGasUnits({
+      amount: 990n,
+      approveAmount: 1000n,
+      client: mockClient,
+      marketId: zeroHash,
+      owner: mockOwner,
+      queryClient,
+      shares: 500n,
+      token: mockToken,
+    });
+
+    expect(result).toBe(approvalGas + repayGas);
+    expect(vi.mocked(estimateApprovalGasUnits)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 1000n,
+      }),
+    );
+    expect(vi.mocked(encodeRepayAssets)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 0n,
+        shares: 500n,
+      }),
+    );
   });
 
   it("throws when amount exceeds current debt", async function () {

--- a/web/test/utils/repay.test.ts
+++ b/web/test/utils/repay.test.ts
@@ -1,0 +1,91 @@
+import type { Market } from "@morpho-org/blue-sdk";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  getMaxRepayable,
+  getRepayApprovalAmount,
+  getRepayShares,
+} from "../../src/utils/repay";
+
+describe("getRepayShares", function () {
+  const repayment = {
+    borrowAssets: 1000n,
+    borrowShares: 500n,
+    loanTokenBalance: 1000n,
+  };
+
+  it("returns the borrow shares for a near-full repayment", function () {
+    expect(
+      getRepayShares({
+        ...repayment,
+        amount: 990n,
+      }),
+    ).toBe(repayment.borrowShares);
+  });
+
+  it("keeps an ordinary partial repayment asset-based", function () {
+    expect(
+      getRepayShares({
+        ...repayment,
+        amount: 989n,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not use shares when the wallet cannot cover the debt", function () {
+    expect(
+      getRepayShares({
+        ...repayment,
+        amount: 990n,
+        loanTokenBalance: 999n,
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("getRepayApprovalAmount", function () {
+  it("uses the input amount for an asset-based repayment", function () {
+    expect(
+      getRepayApprovalAmount({
+        amount: 100n,
+        loanTokenBalance: 1000n,
+        shares: undefined,
+      }),
+    ).toBe(100n);
+  });
+
+  it("uses the wallet balance for a share-based repayment", function () {
+    expect(
+      getRepayApprovalAmount({
+        amount: 990n,
+        loanTokenBalance: 1000n,
+        shares: 500n,
+      }),
+    ).toBe(1000n);
+  });
+});
+
+describe("getMaxRepayable", function () {
+  it("uses the market repayment capacity", function () {
+    const getRepayCapacityLimit = vi.fn().mockReturnValue({ value: 900n });
+
+    expect(
+      getMaxRepayable({
+        borrowShares: 500n,
+        loanTokenBalance: 1000n,
+        market: { getRepayCapacityLimit } as unknown as Market,
+      }),
+    ).toBe(900n);
+    expect(getRepayCapacityLimit).toHaveBeenCalledWith(500n, 1000n);
+  });
+
+  it("waits for the repayment data before enabling MAX", function () {
+    expect(
+      getMaxRepayable({
+        borrowShares: undefined,
+        loanTokenBalance: 1000n,
+        market: undefined,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/web/test/utils/repay.test.ts
+++ b/web/test/utils/repay.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   getMaxRepayable,
   getRepayApprovalAmount,
+  getRepayPositionArgs,
   getRepayShares,
 } from "../../src/utils/repay";
 
@@ -87,5 +88,27 @@ describe("getMaxRepayable", function () {
         market: undefined,
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("getRepayPositionArgs", function () {
+  it("uses assets only for an asset-based repayment", function () {
+    expect(
+      getRepayPositionArgs({
+        assets: 100n,
+        repayShares: undefined,
+        shares: 50n,
+      }),
+    ).toEqual({ assets: 100n, shares: 0n });
+  });
+
+  it("uses shares only for a share-based repayment", function () {
+    expect(
+      getRepayPositionArgs({
+        assets: 100n,
+        repayShares: 50n,
+        shares: 50n,
+      }),
+    ).toEqual({ assets: 0n, shares: 50n });
   });
 });


### PR DESCRIPTION
### Description

Adds a MAX button to the repay loan form. MAX fills the lower of the current debt and the wallet’s loan-token balance.

Near-full repayments use Morpho’s share-based repayment path to avoid leaving debt dust as interest accrues. The successful repayment cache update also uses mutually exclusive asset/share arguments.

### Screenshots

<img width="967" height="1376" alt="image" src="https://github.com/user-attachments/assets/df96fa5d-51f5-43a5-8d51-0c5caee19373" />


### Related issue(s)

Closes #800

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.