### PR TITLE
Refactor shared vault stake queries

### DIFF
--- a/web/src/fetchers/fetchEarnedAmountUsd.ts
+++ b/web/src/fetchers/fetchEarnedAmountUsd.ts
@@ -1,9 +1,7 @@
 import { tokenBalanceQueryOptions } from "@hemilabs/react-hooks/useTokenBalance";
 import type { QueryClient } from "@tanstack/react-query";
+import { fetchVaultStakePosition } from "fetchers/fetchVaultStakePosition";
 import { costBasisQueryOptions } from "hooks/useCostBasis";
-import { pricesOptions } from "hooks/usePrices";
-import { stakedBalanceQueryOptions } from "hooks/useStakedBalance";
-import { vaultPeggedTokenQueryOptions } from "hooks/useVaultPeggedToken";
 import { tokenAmountToUsd } from "utils/currency";
 import type { Address, Client } from "viem";
 
@@ -23,31 +21,20 @@ export const fetchEarnedAmountUsd = async function ({
     throw new Error("Client is missing a chain");
   }
 
-  const [costBases, peggedToken, prices, userShares, userStakedAssets] =
+  const [{ peggedToken, prices, stakedAssets }, costBases, userShares] =
     await Promise.all([
+      fetchVaultStakePosition({
+        account,
+        client,
+        queryClient,
+        stakingVaultAddress,
+      }),
       queryClient.ensureQueryData(costBasisQueryOptions({ address: account })),
-      queryClient.ensureQueryData(
-        vaultPeggedTokenQueryOptions({
-          client,
-          queryClient,
-          stakingVaultAddress,
-        }),
-      ),
-      queryClient.ensureQueryData(pricesOptions({ client, queryClient })),
       queryClient.ensureQueryData(
         tokenBalanceQueryOptions({
           account,
           client,
           token: { address: stakingVaultAddress, chainId },
-        }),
-      ),
-      queryClient.ensureQueryData(
-        stakedBalanceQueryOptions({
-          account,
-          chainId,
-          client,
-          queryClient,
-          stakingVaultAddress,
         }),
       ),
     ]);
@@ -62,7 +49,7 @@ export const fetchEarnedAmountUsd = async function ({
   }
 
   return tokenAmountToUsd({
-    amount: userStakedAssets - costBasis,
+    amount: stakedAssets - costBasis,
     prices,
     token: peggedToken,
   });

--- a/web/src/fetchers/fetchStakedUsd.ts
+++ b/web/src/fetchers/fetchStakedUsd.ts
@@ -1,7 +1,5 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { pricesOptions } from "hooks/usePrices";
-import { stakedBalanceQueryOptions } from "hooks/useStakedBalance";
-import { vaultPeggedTokenQueryOptions } from "hooks/useVaultPeggedToken";
+import { fetchVaultStakePosition } from "fetchers/fetchVaultStakePosition";
 import { tokenAmountToUsd } from "utils/currency";
 import type { Address, Client } from "viem";
 
@@ -16,30 +14,12 @@ export const fetchStakedUsd = async function ({
   queryClient: QueryClient;
   stakingVaultAddress: Address;
 }): Promise<number> {
-  const chainId = client.chain?.id;
-  if (chainId === undefined) {
-    throw new Error("Client is missing a chain");
-  }
-
-  const [peggedToken, prices, stakedAssets] = await Promise.all([
-    queryClient.ensureQueryData(
-      vaultPeggedTokenQueryOptions({
-        client,
-        queryClient,
-        stakingVaultAddress,
-      }),
-    ),
-    queryClient.ensureQueryData(pricesOptions({ client, queryClient })),
-    queryClient.ensureQueryData(
-      stakedBalanceQueryOptions({
-        account,
-        chainId,
-        client,
-        queryClient,
-        stakingVaultAddress,
-      }),
-    ),
-  ]);
+  const { peggedToken, prices, stakedAssets } = await fetchVaultStakePosition({
+    account,
+    client,
+    queryClient,
+    stakingVaultAddress,
+  });
 
   return tokenAmountToUsd({ amount: stakedAssets, prices, token: peggedToken });
 };

--- a/web/src/fetchers/fetchVaultStakePosition.ts
+++ b/web/src/fetchers/fetchVaultStakePosition.ts
@@ -1,0 +1,44 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { pricesOptions } from "hooks/usePrices";
+import { stakedBalanceQueryOptions } from "hooks/useStakedBalance";
+import { vaultPeggedTokenQueryOptions } from "hooks/useVaultPeggedToken";
+import type { Address, Client } from "viem";
+
+export const fetchVaultStakePosition = async function ({
+  account,
+  client,
+  queryClient,
+  stakingVaultAddress,
+}: {
+  account: Address;
+  client: Client;
+  queryClient: QueryClient;
+  stakingVaultAddress: Address;
+}) {
+  const chainId = client.chain?.id;
+  if (chainId === undefined) {
+    throw new Error("Client is missing a chain");
+  }
+
+  const [peggedToken, prices, stakedAssets] = await Promise.all([
+    queryClient.ensureQueryData(
+      vaultPeggedTokenQueryOptions({
+        client,
+        queryClient,
+        stakingVaultAddress,
+      }),
+    ),
+    queryClient.ensureQueryData(pricesOptions({ client, queryClient })),
+    queryClient.ensureQueryData(
+      stakedBalanceQueryOptions({
+        account,
+        chainId,
+        client,
+        queryClient,
+        stakingVaultAddress,
+      }),
+    ),
+  ]);
+
+  return { peggedToken, prices, stakedAssets };
+};


### PR DESCRIPTION
### Description

Extract the shared vault stake-position queries used by `fetchStakedUsd` and `fetchEarnedAmountUsd` into `fetchVaultStakePosition`. This removes duplicated query setup while preserving the existing calculations.

### Screenshots

N/A

### Related issue(s)

Closes #776


### Checklist

- [ ] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.