### PR TITLE
Add retry to stake flows

### DIFF
--- a/web/src/hooks/useStakeDeposit.ts
+++ b/web/src/hooks/useStakeDeposit.ts
@@ -5,6 +5,7 @@ import { tokenBalanceQueryKey } from "@hemilabs/react-hooks/useTokenBalance";
 import { useUpdateNativeBalanceAfterReceipt } from "@hemilabs/react-hooks/useUpdateNativeBalanceAfterReceipt";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deposit } from "@vetro-protocol/earn/actions";
+import { useRef } from "react";
 import type { TokenWithGateway } from "types";
 import { type CostBases, bumpCostBasis } from "utils/costBasis";
 import type { Address, TransactionReceipt } from "viem";
@@ -29,6 +30,7 @@ type DepositStatus =
 type Params = {
   approveAmount?: bigint;
   assets: bigint;
+  needsApproval: boolean;
   onStatusChange?: (status: DepositStatus) => void;
   onSuccess?: VoidFunction;
   onTransactionHash?: (hash: string) => void;
@@ -39,6 +41,7 @@ type Params = {
 export const useStakeDeposit = function ({
   approveAmount,
   assets,
+  needsApproval,
   onStatusChange,
   onSuccess,
   onTransactionHash,
@@ -50,6 +53,7 @@ export const useStakeDeposit = function ({
   const { data: walletClient } = useEthereumWalletClient();
   const ensureConnectedTo = useEnsureConnectedTo();
   const queryClient = useQueryClient();
+  const currentStep = useRef<"approve" | "deposit">("deposit");
   const { queryKey: nativeBalanceKey } = useNativeBalance(chain.id);
   const updateNativeBalanceAfterReceipt = useUpdateNativeBalanceAfterReceipt(
     chain.id,
@@ -85,6 +89,7 @@ export const useStakeDeposit = function ({
         throw new Error("No account connected");
       }
 
+      currentStep.current = needsApproval ? "approve" : "deposit";
       await ensureConnectedTo(chain.id);
 
       const { emitter, promise } = deposit(walletClient!, {
@@ -96,7 +101,12 @@ export const useStakeDeposit = function ({
       });
 
       emitter.on("user-signed-approval", function () {
+        currentStep.current = "approve";
         onStatusChange?.("approving");
+      });
+
+      emitter.on("pre-approve", function () {
+        currentStep.current = "approve";
       });
 
       emitter.on("approve-transaction-succeeded", function () {
@@ -104,8 +114,13 @@ export const useStakeDeposit = function ({
       });
 
       emitter.on("user-signed-deposit", function (hash) {
+        currentStep.current = "deposit";
         onTransactionHash?.(hash);
         onStatusChange?.("depositing");
+      });
+
+      emitter.on("pre-deposit", function () {
+        currentStep.current = "deposit";
       });
 
       emitter.on("user-signing-approval-error", function () {
@@ -129,6 +144,26 @@ export const useStakeDeposit = function ({
           });
         },
       );
+
+      emitter.on("deposit-failed", function () {
+        onStatusChange?.(
+          currentStep.current === "approve"
+            ? "approve-failed"
+            : "deposit-failed",
+        );
+      });
+
+      emitter.on("deposit-failed-validation", function () {
+        onStatusChange?.("deposit-failed");
+      });
+
+      emitter.on("unexpected-error", function () {
+        onStatusChange?.(
+          currentStep.current === "approve"
+            ? "approve-failed"
+            : "deposit-failed",
+        );
+      });
 
       emitter.on("user-signing-deposit-error", function () {
         onStatusChange?.("deposit-failed");
@@ -173,6 +208,11 @@ export const useStakeDeposit = function ({
       );
 
       return promise;
+    },
+    onError() {
+      onStatusChange?.(
+        currentStep.current === "approve" ? "approve-failed" : "deposit-failed",
+      );
     },
     async onSettled() {
       queryClient.invalidateQueries({

--- a/web/src/hooks/useStakeWithdraw.ts
+++ b/web/src/hooks/useStakeWithdraw.ts
@@ -89,6 +89,18 @@ export const useStakeWithdraw = function ({
         onStatusChange?.("request-failed");
       });
 
+      emitter.on("request-withdraw-failed", function () {
+        onStatusChange?.("request-failed");
+      });
+
+      emitter.on("request-withdraw-failed-validation", function () {
+        onStatusChange?.("request-failed");
+      });
+
+      emitter.on("unexpected-error", function () {
+        onStatusChange?.("request-failed");
+      });
+
       emitter.on(
         "request-withdraw-transaction-reverted",
         function (receipt: TransactionReceipt) {
@@ -155,6 +167,9 @@ export const useStakeWithdraw = function ({
       );
 
       return promise;
+    },
+    onError() {
+      onStatusChange?.("request-failed");
     },
     async onSettled() {
       queryClient.invalidateQueries({

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -379,6 +379,7 @@
         "ready-to-withdraw-in_other": "Ready to withdraw in {{count}} days",
         "request-withdrawal": "Request withdrawal",
         "requesting": "Requesting...",
+        "retry": "Retry",
         "withdraw": "Withdraw",
         "withdraw-in-progress": "Withdrawal in progress",
         "withdraw-progress": "Withdraw progress",

--- a/web/src/i18n/locales/es/translation.json
+++ b/web/src/i18n/locales/es/translation.json
@@ -382,6 +382,7 @@
         "ready-to-withdraw-in_other": "Listo para retirar en {{count}} días",
         "request-withdrawal": "Solicitar retiro",
         "requesting": "Solicitando...",
+        "retry": "Reintentar",
         "withdraw": "Retirar",
         "withdraw-in-progress": "Retiro en progreso",
         "withdraw-progress": "Progreso del retiro",

--- a/web/src/pages/earn/components/stakeForm/stakeDepositForm.tsx
+++ b/web/src/pages/earn/components/stakeForm/stakeDepositForm.tsx
@@ -161,6 +161,7 @@ export function StakeDepositForm({
     function handleDepositStepChange(step: DepositStep) {
       onDepositStepChange(step);
       const handlers: Partial<Record<DepositStep, () => void>> = {
+        "approve-failed": onFailed,
         completed: onCompleted,
         "deposit-failed": onFailed,
         depositing: onPending,
@@ -184,6 +185,7 @@ export function StakeDepositForm({
   const depositMutation = useStakeDeposit({
     approveAmount,
     assets: amountBigInt,
+    needsApproval,
     onStatusChange: handleDepositStepChange,
     onSuccess: handleDepositSuccess,
     onTransactionHash,

--- a/web/src/pages/earn/components/stakeForm/stakeDepositForm.tsx
+++ b/web/src/pages/earn/components/stakeForm/stakeDepositForm.tsx
@@ -193,6 +193,13 @@ export function StakeDepositForm({
     stakingVaultAddress,
   });
 
+  function handleRetry() {
+    onDepositStepChange(
+      depositStep === "approve-failed" ? "approving" : "depositing",
+    );
+    depositMutation.mutate();
+  }
+
   const depositFeesQuery = useTotalDepositFees({
     amount: amountBigInt,
     approveAmount,
@@ -311,6 +318,12 @@ export function StakeDepositForm({
               depositStep={depositStep}
               needsApproval={needsApproval}
               networkFee={depositFeesQuery}
+              onRetry={
+                depositStep === "approve-failed" ||
+                depositStep === "deposit-failed"
+                  ? handleRetry
+                  : undefined
+              }
               peggedToken={peggedToken}
               shareToken={shareToken}
               stakingVaultAddress={stakingVaultAddress}

--- a/web/src/pages/earn/components/stakeForm/stakeDepositProgressDrawer.tsx
+++ b/web/src/pages/earn/components/stakeForm/stakeDepositProgressDrawer.tsx
@@ -1,4 +1,5 @@
 import type { Token } from "@vetro-protocol/core";
+import { Button } from "components/base/button";
 import { RenderCryptoValue } from "components/base/cryptoValue";
 import { DollarSign } from "components/base/dollarSign";
 import { DrawerTitle } from "components/base/drawer/drawerTitle";
@@ -10,6 +11,7 @@ import {
 import { VerticalStepper, stepStatus } from "components/base/verticalStepper";
 import { DrawerFeesContainer } from "components/feesContainer";
 import { NetworkFees } from "components/networkFees";
+import { useAnimatedVisibility } from "hooks/useAnimatedVisibility";
 import { useVaultPreviewDeposit } from "hooks/useVaultPreviewDeposit";
 import type { ComponentProps } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,6 +27,7 @@ type Props = {
   depositStep: DepositStep;
   needsApproval: boolean;
   networkFee: ComponentProps<typeof NetworkFees>["networkFee"];
+  onRetry?: VoidFunction;
   peggedToken: TokenWithGateway;
   shareToken: Token;
   stakingVaultAddress: Address;
@@ -109,6 +112,7 @@ export function StakeDepositProgressDrawer({
   depositStep,
   needsApproval,
   networkFee,
+  onRetry,
   peggedToken,
   shareToken,
   stakingVaultAddress,
@@ -122,6 +126,8 @@ export function StakeDepositProgressDrawer({
     depositStep,
     needsApproval,
   });
+  const { render: renderRetry, show: showRetry } =
+    useAnimatedVisibility(!!onRetry);
 
   const fiatDetail = (
     <>
@@ -169,6 +175,22 @@ export function StakeDepositProgressDrawer({
           <VerticalStepper steps={steps} />
         </div>
       </div>
+
+      {renderRetry && (
+        <div
+          className={`grid transition-[grid-template-rows] duration-300 ease-out ${
+            showRetry ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+          }`}
+        >
+          <div className="overflow-hidden">
+            <div className="border-t border-gray-200 bg-gray-50 px-6 py-3 *:w-full">
+              <Button onClick={onRetry} size="small" variant="primary">
+                {t("pages.earn.stake.retry")}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/pages/earn/components/stakeForm/stakeWithdrawForm.tsx
+++ b/web/src/pages/earn/components/stakeForm/stakeWithdrawForm.tsx
@@ -35,6 +35,14 @@ const StakeWithdrawProgressDrawer = lazy(() =>
   })),
 );
 
+const retryWithdrawSteps = {
+  failed: "withdrawing",
+  "request-failed": "requesting",
+} as const;
+
+const getRetryHandler = (step: WithdrawStep, onRetry: VoidFunction) =>
+  step === "failed" || step === "request-failed" ? onRetry : undefined;
+
 type Props = {
   inputValue: string;
   isDrawerOpen: boolean;
@@ -192,6 +200,13 @@ export function StakeWithdrawForm({
     ? instantWithdrawMutation
     : requestWithdrawMutation;
 
+  function handleRetry() {
+    onWithdrawStepChange(
+      retryWithdrawSteps[withdrawStep as keyof typeof retryWithdrawSteps],
+    );
+    withdrawMutation.mutate();
+  }
+
   const withdrawFeesQuery = useTotalWithdrawFees({
     amount: amountBigInt,
     stakingVaultAddress,
@@ -305,6 +320,7 @@ export function StakeWithdrawForm({
               canInstantWithdraw={canInstantWithdraw}
               cooldownDays={cooldownDays}
               networkFee={withdrawFeesQuery}
+              onRetry={getRetryHandler(withdrawStep, handleRetry)}
               peggedToken={peggedToken}
               shareToken={shareToken}
               stakingVaultAddress={stakingVaultAddress}

--- a/web/src/pages/earn/components/stakeForm/stakeWithdrawProgressDrawer.tsx
+++ b/web/src/pages/earn/components/stakeForm/stakeWithdrawProgressDrawer.tsx
@@ -1,4 +1,5 @@
 import type { Token } from "@vetro-protocol/core";
+import { Button } from "components/base/button";
 import { RenderCryptoValue } from "components/base/cryptoValue";
 import { DollarSign } from "components/base/dollarSign";
 import { DrawerTitle } from "components/base/drawer/drawerTitle";
@@ -10,6 +11,7 @@ import {
 import { VerticalStepper, stepStatus } from "components/base/verticalStepper";
 import { DrawerFeesContainer } from "components/feesContainer";
 import { NetworkFees } from "components/networkFees";
+import { useAnimatedVisibility } from "hooks/useAnimatedVisibility";
 import { useVaultPreviewWithdraw } from "hooks/useVaultPreviewWithdraw";
 import type { ComponentProps } from "react";
 import { useTranslation } from "react-i18next";
@@ -29,6 +31,7 @@ type Props = SummaryProps & {
   canInstantWithdraw: boolean;
   cooldownDays: number | undefined;
   networkFee: ComponentProps<typeof NetworkFees>["networkFee"];
+  onRetry?: VoidFunction;
   shareToken: Token;
   stakingVaultAddress: Address;
   withdrawStep: WithdrawStep;
@@ -177,6 +180,7 @@ export function StakeWithdrawProgressDrawer({
   canInstantWithdraw,
   cooldownDays,
   networkFee,
+  onRetry,
   peggedToken,
   shareToken,
   stakingVaultAddress,
@@ -189,6 +193,8 @@ export function StakeWithdrawProgressDrawer({
     cooldownDays,
     withdrawStep,
   });
+  const { render: renderRetry, show: showRetry } =
+    useAnimatedVisibility(!!onRetry);
 
   return (
     <div className="flex h-full flex-col">
@@ -227,6 +233,22 @@ export function StakeWithdrawProgressDrawer({
           <VerticalStepper steps={steps} />
         </div>
       </div>
+
+      {renderRetry && (
+        <div
+          className={`grid transition-[grid-template-rows] duration-300 ease-out ${
+            showRetry ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+          }`}
+        >
+          <div className="overflow-hidden">
+            <div className="border-t border-gray-200 bg-gray-50 px-6 py-3 *:w-full">
+              <Button onClick={onRetry} size="small" variant="primary">
+                {t("pages.earn.stake.retry")}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Description

Adds retry handling to Earn staking deposit and withdrawal flows.

Failed approval, deposit, instant withdrawal, and queued withdrawal steps now show a retry action. Retrying resumes from the failed step without repeating successful steps.

### Screenshots

<img width="1024" height="1520" alt="image" src="https://github.com/user-attachments/assets/ad2be72c-0d8a-48b4-b4bc-74c4b2f8843e" />


### Related issue(s)

Closes #768

### Checklist

- [x] Manual testing passed.
- [x] Automated tests added, or N/A.
- [x] Documentation updated, or N/A.
- [x] Environment variables set in CI, or N/A.